### PR TITLE
Update IntelliJ IDEA Ultimate dependency to 2025.1.4.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ idea {
 
 dependencies {
     intellijPlatform {
-        intellijIdeaUltimate("2025.1.3")
+        intellijIdeaUltimate("2025.1.4.1")
         bundledPlugin("org.jetbrains.plugins.gradle")
 
         testFramework(TestFrameworkType.JUnit5)


### PR DESCRIPTION
The dependency for IntelliJ IDEA Ultimate has been updated to version 2025.1.4.1 to ensure compatibility with the latest features and fixes. 