### PR TITLE
Grant `actions: write` permission in Copilot setup workflow

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -4,8 +4,7 @@ name: Copilot Setup Steps
 on:
   workflow_dispatch:
   push:
-    paths:
-      - .github/workflows/copilot-setup-steps.yml
+    branches: [ main ]
   pull_request:
     paths:
       - .github/workflows/copilot-setup-steps.yml

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -17,6 +17,7 @@ jobs:
 
     permissions:
       contents: read
+      actions: write
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
this buildscript donwload intellij idea from cdn but the firewall via cloudfront cannot allow using whitelist not resolved on copilot agent. we should write cache on default branch and same workflow file.