### PR TITLE
chore(wizard): bump Armeria BOM to 1.39.0

### DIFF
--- a/plugin/src/main/resources/starters/armeria.pom
+++ b/plugin/src/main/resources/starters/armeria.pom
@@ -9,21 +9,21 @@
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-bom</artifactId>
-                <version>2.1.21</version>
+                <version>2.3.21</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>com.linecorp.armeria</groupId>
                 <artifactId>armeria-bom</artifactId>
-                <version>1.38.0</version>
+                <version>1.39.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.5.18</version>
+                <version>1.5.33</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
## Summary

- Update \plugin/src/main/resources/starters/armeria.pom\ pins used by the New Project wizard
- **armeria-bom**: 1.38.0 → 1.39.0
- **kotlin-bom**: 2.1.21 → 2.3.21 (matches \gradle/libs.versions.toml\)
- **logback-classic**: 1.5.18 → 1.5.33

Generated Gradle/Maven projects resolve versions via \context.getVersion(...)\ from this POM; no template changes required.

## Test plan

- [ ] New Project → Armeria → Gradle (Kotlin DSL): confirm \rmeria-bom\ is 1.39.0 in \uild.gradle.kts\
- [ ] New Project → Armeria → Maven: confirm BOM version in \pom.xml\
- [ ] Optional: \./gradlew :plugin:test\ (if JUnit runtime classpath is configured locally)


Made with [Cursor](https://cursor.com)