### PR TITLE
chore: update IntelliJ Platform Gradle Plugin and IDEA platform versions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,4 +7,4 @@
 - Route user-visible strings through `message(...)` and add the corresponding keys to `plugin/src/main/resources/messages/ArmeriaBundle.properties` instead of hard-coding UI text.
 - Reuse existing IntelliJ PSI and platform APIs already used in the plugin instead of introducing parallel abstractions.
 - Validate changes with `./gradlew --no-daemon :plugin:compileKotlin :plugin:test`.
-- The build targets IntelliJ IDEA Ultimate `2026.1.2` and uses the Java 21 JetBrains toolchain, so keep new code compatible with that environment.
+- The build targets IntelliJ IDEA Ultimate `2026.1.3` and uses the Java 21 JetBrains toolchain, so keep new code compatible with that environment.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 jdk = "21"
 kotlin = "2.4.0"
-intellij-platform-plugin = "2.16.0"
-idea-platform = "2026.1.2"
+intellij-platform-plugin = "2.17.0"
+idea-platform = "2026.1.3"
 changelog = "2.5.0"
 junit4 = "4.13.2"
 velocity = "2.4.1"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.jetbrains.intellij.platform.settings") version "2.16.0"
+    id("org.jetbrains.intellij.platform.settings") version "2.17.0"
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates outdated library versions in the Gradle version catalog and settings plugin, and aligns Copilot guidance with the new target IDE version.

## Changes

| Dependency | Before | After |
| --- | --- | --- |
| IntelliJ Platform Gradle Plugin | 2.16.0 | 2.17.0 |
| IntelliJ IDEA platform (target IDE) | 2026.1.2 | 2026.1.3 |

Also updates `.github/copilot-instructions.md` to reference IDEA `2026.1.3`.

## Already up to date

The following dependencies were checked and are already on the latest stable release:

- Kotlin 2.4.0
- Gradle 9.6.1 (wrapper)
- JetBrains Changelog plugin 2.5.0
- JUnit 4.13.2
- Apache Velocity Engine Core 2.4.1
- Foojay resolver convention plugin 1.0.0
- GitHub Actions (checkout v7.0.0, setup-java v5.4.0, setup-gradle v6)

## Verification

- `./gradlew build` passes locally
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2012-1bef-770e-b203-dd8e9ae2e404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2012-1bef-770e-b203-dd8e9ae2e404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

