### PR TITLE
feat: Kotlin Route Explorer support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,8 @@ gradle-app.setting
 # Avoid ignore Gradle wrappper properties
 !gradle-wrapper.properties
 
+# Cache of project
+.gradletasknamecache
 .kotlin/
 
 # Eclipse Gradle plugin generated files

--- a/.gitignore
+++ b/.gitignore
@@ -93,8 +93,7 @@ gradle-app.setting
 # Avoid ignore Gradle wrappper properties
 !gradle-wrapper.properties
 
-# Cache of project
-.gradletasknamecache
+.kotlin/
 
 # Eclipse Gradle plugin generated files
 # Eclipse Core

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -3,9 +3,6 @@
 ## [Unreleased]
 ### Added
 - Added Kotlin source support to Route Explorer for annotated services and Server.builder registrations.
-### Fixed
-- Fixed duplicate Kotlin annotated routes and false-positive service registrations in Route Explorer.
-- Aligned Kotlin service registration discovery with the Java collector via shared PSI delegation.
 - Added Velocity-based regression tests for New Project Wizard file templates.
 - Added `plugin/src/test/resources/wizard-verification-matrix.md` documenting representative wizard scenarios.
 - Added an Armeria Route Explorer tool window for discovering annotated services and registered routes.
@@ -19,6 +16,8 @@
 ### Removed
 
 ### Fixed
+- Fixed duplicate Kotlin annotated routes and false-positive service registrations in Route Explorer.
+- Aligned Kotlin service registration discovery with the Java collector via shared PSI delegation.
 - New Project Wizard: emit `armeria-tomcat8` in Gradle and Maven templates when selected.
 - New Project Wizard: align Scala optional dependencies and Scala build setup in Gradle (Groovy) and Maven templates with Gradle (Kotlin DSL).
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -20,6 +20,8 @@
 - Fixed false-positive route detection for unqualified `service` calls inside `also`/`let` blocks on `Server.builder()`.
 - Fixed FQCN `com.linecorp.armeria.server.Server.builder()` detection in Kotlin fallback scanning.
 - Fixed potential NPE when building Kotlin service registration keys for non-physical PSI files.
+- Fixed unresolved-target detection for Kotlin `build()`/`builder()` wrapper expressions.
+- Fixed Kotlin `ServerBuilder?` and generic type spellings not recognized as server-builder receivers.
 - Aligned Kotlin service registration discovery with the Java collector via shared PSI delegation.
 - New Project Wizard: emit `armeria-tomcat8` in Gradle and Maven templates when selected.
 - New Project Wizard: align Scala optional dependencies and Scala build setup in Gradle (Groovy) and Maven templates with Gradle (Kotlin DSL).

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -22,6 +22,8 @@
 - Fixed potential NPE when building Kotlin service registration keys for non-physical PSI files.
 - Fixed unresolved-target detection for Kotlin `build()`/`builder()` wrapper expressions.
 - Fixed Kotlin `ServerBuilder?` and generic type spellings not recognized as server-builder receivers.
+- Fixed Kotlin path extraction for Java `static final` constants and `ServerBuilder` extension functions.
+- Fixed Kotlin `ServerBuilder` typealias variables not recognized as server-builder receivers.
 - Aligned Kotlin service registration discovery with the Java collector via shared PSI delegation.
 - New Project Wizard: emit `armeria-tomcat8` in Gradle and Maven templates when selected.
 - New Project Wizard: align Scala optional dependencies and Scala build setup in Gradle (Groovy) and Maven templates with Gradle (Kotlin DSL).

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -18,6 +18,8 @@
 ### Fixed
 - Fixed duplicate Kotlin annotated routes and false-positive service registrations in Route Explorer.
 - Fixed false-positive route detection for unqualified `service` calls inside `also`/`let` blocks on `Server.builder()`.
+- Fixed FQCN `com.linecorp.armeria.server.Server.builder()` detection in Kotlin fallback scanning.
+- Fixed potential NPE when building Kotlin service registration keys for non-physical PSI files.
 - Aligned Kotlin service registration discovery with the Java collector via shared PSI delegation.
 - New Project Wizard: emit `armeria-tomcat8` in Gradle and Maven templates when selected.
 - New Project Wizard: align Scala optional dependencies and Scala build setup in Gradle (Groovy) and Maven templates with Gradle (Kotlin DSL).

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- Added Kotlin source support to Route Explorer for annotated services and Server.builder registrations.
 - Added Velocity-based regression tests for New Project Wizard file templates.
 - Added `plugin/src/test/resources/wizard-verification-matrix.md` documenting representative wizard scenarios.
 - Added an Armeria Route Explorer tool window for discovering annotated services and registered routes.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Fixed
 - Fixed duplicate Kotlin annotated routes and false-positive service registrations in Route Explorer.
+- Fixed false-positive route detection for unqualified `service` calls inside `also`/`let` blocks on `Server.builder()`.
 - Aligned Kotlin service registration discovery with the Java collector via shared PSI delegation.
 - New Project Wizard: emit `armeria-tomcat8` in Gradle and Maven templates when selected.
 - New Project Wizard: align Scala optional dependencies and Scala build setup in Gradle (Groovy) and Maven templates with Gradle (Kotlin DSL).

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 ### Added
 - Added Kotlin source support to Route Explorer for annotated services and Server.builder registrations.
+### Fixed
+- Fixed duplicate Kotlin annotated routes and false-positive service registrations in Route Explorer.
+- Aligned Kotlin service registration discovery with the Java collector via shared PSI delegation.
 - Added Velocity-based regression tests for New Project Wizard file templates.
 - Added `plugin/src/test/resources/wizard-verification-matrix.md` documenting representative wizard scenarios.
 - Added an Armeria Route Explorer tool window for discovering annotated services and registered routes.

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
         intellijIdeaUltimate(libs.versions.idea.platform.get())
         bundledPlugin("com.intellij.java")
         bundledPlugin("org.jetbrains.plugins.gradle")
+        bundledPlugin("org.jetbrains.kotlin")
         testFramework(TestFrameworkType.Plugin.Java)
     }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
@@ -21,10 +21,6 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 
 internal object ArmeriaKotlinRouteCollector {
-    private const val ARMERIA_SERVER_PACKAGE_PREFIX = "com.linecorp.armeria.server"
-    private const val SERVER_BUILDER_FQN = "com.linecorp.armeria.server.ServerBuilder"
-    private const val SERVER_BUILDER_SIMPLE = "ServerBuilder"
-    private val REGISTRATION_METHOD_NAMES = setOf("service", "serviceUnder", "annotatedService")
     private val BUILDER_SCOPE_METHOD_NAMES = setOf("apply", "run", "also", "let")
 
     fun collectServiceRegistrationsFallback(
@@ -57,7 +53,7 @@ internal object ArmeriaKotlinRouteCollector {
         for (call in file.collectDescendantsOfType<KtCallExpression>()) {
             ArmeriaRouteCollectionMetrics.current()?.methodCallsVisited?.incrementAndGet()
             val methodName = resolveCallName(call) ?: continue
-            if (methodName !in REGISTRATION_METHOD_NAMES) {
+            if (methodName !in ServiceRegistrationMethod.METHOD_NAMES) {
                 continue
             }
             if (!looksLikeArmeriaBuilderCall(call)) {
@@ -95,7 +91,7 @@ internal object ArmeriaKotlinRouteCollector {
         for (reference in dotQualified.references) {
             val resolved = reference.resolve()
             if (resolved is PsiMethod &&
-                resolved.containingClass?.qualifiedName?.startsWith(ARMERIA_SERVER_PACKAGE_PREFIX) == true
+                resolved.containingClass?.qualifiedName?.startsWith(ArmeriaRouteSupport.ARMERIA_SERVER_PACKAGE_PREFIX) == true
             ) {
                 return true
             }
@@ -111,25 +107,19 @@ internal object ArmeriaKotlinRouteCollector {
         if (receiver is KtNameReferenceExpression) {
             when (val resolved = receiver.references.firstOrNull()?.resolve()) {
                 is com.intellij.psi.PsiVariable -> {
-                    if (isServerBuilderType(resolved.type.canonicalText)) {
+                    if (ArmeriaRouteSupport.isServerBuilderType(resolved.type.canonicalText)) {
                         return true
                     }
                 }
                 is KtProperty -> {
                     val typeText = resolved.typeReference?.text
-                    if (typeText != null && isServerBuilderType(typeText)) {
+                    if (typeText != null && ArmeriaRouteSupport.isServerBuilderType(typeText)) {
                         return true
                     }
                 }
             }
         }
         return false
-    }
-
-    private fun isServerBuilderType(typeText: String): Boolean {
-        return typeText == SERVER_BUILDER_SIMPLE ||
-            typeText == SERVER_BUILDER_FQN ||
-            typeText.endsWith(".$SERVER_BUILDER_SIMPLE")
     }
 
     private fun hasServerBuilderImplicitReceiver(call: KtCallExpression): Boolean {
@@ -196,11 +186,13 @@ internal object ArmeriaKotlinRouteCollector {
     }
 
     private fun resolveServiceExpression(methodName: String, arguments: List<KtValueArgument>): KtExpression? {
-        return when (methodName) {
-            "annotatedService" ->
+        return when (ServiceRegistrationMethod.fromMethodName(methodName)) {
+            ServiceRegistrationMethod.ANNOTATED_SERVICE ->
                 findArgumentExpression(arguments, "service", 1)
                     ?: findArgumentExpression(arguments, "service", 0)
-            else -> findArgumentExpression(arguments, "service", 1)
+            ServiceRegistrationMethod.SERVICE, ServiceRegistrationMethod.SERVICE_UNDER ->
+                findArgumentExpression(arguments, "service", 1)
+            null -> null
         }
     }
 
@@ -216,17 +208,19 @@ internal object ArmeriaKotlinRouteCollector {
     }
 
     private fun extractRegistrationPath(methodName: String, arguments: List<KtValueArgument>): String? {
-        return when (methodName) {
-            "service" -> extractKotlinString(findArgumentExpression(arguments, "path", 0))
-            "serviceUnder" -> extractKotlinString(findArgumentExpression(arguments, "prefix", 0))
-            "annotatedService" -> {
+        return when (ServiceRegistrationMethod.fromMethodName(methodName)) {
+            ServiceRegistrationMethod.SERVICE ->
+                extractKotlinString(findArgumentExpression(arguments, "path", 0))
+            ServiceRegistrationMethod.SERVICE_UNDER ->
+                extractKotlinString(findArgumentExpression(arguments, "prefix", 0))
+            ServiceRegistrationMethod.ANNOTATED_SERVICE -> {
                 if (arguments.size > 1) {
                     extractKotlinString(findArgumentExpression(arguments, "prefix", 0))
                 } else {
                     "/"
                 }
             }
-            else -> null
+            null -> null
         }
     }
 

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
@@ -2,7 +2,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiManager
 import com.intellij.psi.search.FileTypeIndex
 import com.intellij.psi.search.GlobalSearchScope
@@ -11,14 +11,21 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.KtParenthesizedExpression
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 
 internal object ArmeriaKotlinRouteCollector {
-    private const val SERVER_BUILDER_SUFFIX = "ServerBuilder"
+    private const val ARMERIA_SERVER_PACKAGE_PREFIX = "com.linecorp.armeria.server"
+    private const val SERVER_BUILDER_FQN = "com.linecorp.armeria.server.ServerBuilder"
+    private const val SERVER_BUILDER_SIMPLE = "ServerBuilder"
     private val REGISTRATION_METHOD_NAMES = setOf("service", "serviceUnder", "annotatedService")
+    private val BUILDER_SCOPE_METHOD_NAMES = setOf("apply", "run", "also", "let")
 
     fun collectServiceRegistrationsFallback(
         project: Project,
@@ -48,6 +55,7 @@ internal object ArmeriaKotlinRouteCollector {
         seenServiceRegistrations: MutableSet<String>,
     ) {
         for (call in file.collectDescendantsOfType<KtCallExpression>()) {
+            ArmeriaRouteCollectionMetrics.current()?.methodCallsVisited?.incrementAndGet()
             val methodName = resolveCallName(call) ?: continue
             if (methodName !in REGISTRATION_METHOD_NAMES) {
                 continue
@@ -68,30 +76,93 @@ internal object ArmeriaKotlinRouteCollector {
     }
 
     private fun looksLikeArmeriaBuilderCall(call: KtCallExpression): Boolean {
+        if (resolvesToArmeriaServerBuilder(call)) {
+            return true
+        }
         val dotQualified = when (val callee = call.calleeExpression) {
             is KtDotQualifiedExpression -> callee
             else -> call.parent as? KtDotQualifiedExpression
-        } ?: return false
-        val receiver = dotQualified.receiverExpression
+        }
+        if (dotQualified != null && isServerBuilderReceiver(dotQualified.receiverExpression)) {
+            return true
+        }
+        return hasServerBuilderImplicitReceiver(call)
+    }
+
+    private fun resolvesToArmeriaServerBuilder(call: KtCallExpression): Boolean {
+        ArmeriaRouteCollectionMetrics.current()?.resolveCount?.incrementAndGet()
+        val dotQualified = call.parent as? KtDotQualifiedExpression ?: return false
+        for (reference in dotQualified.references) {
+            val resolved = reference.resolve()
+            if (resolved is PsiMethod &&
+                resolved.containingClass?.qualifiedName?.startsWith(ARMERIA_SERVER_PACKAGE_PREFIX) == true
+            ) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private fun isServerBuilderReceiver(receiver: KtExpression): Boolean {
         val receiverText = receiver.text
-        if (receiverText.contains("Server.builder()") ||
-            receiverText.contains("serverBuilder") ||
-            receiverText.contains(SERVER_BUILDER_SUFFIX)
-        ) {
+        if (receiverText.contains("Server.builder()") || receiverText.contains("serverBuilder")) {
             return true
         }
         if (receiver is KtNameReferenceExpression) {
             when (val resolved = receiver.references.firstOrNull()?.resolve()) {
                 is com.intellij.psi.PsiVariable -> {
-                    if (resolved.type.canonicalText.contains(SERVER_BUILDER_SUFFIX)) {
+                    if (isServerBuilderType(resolved.type.canonicalText)) {
                         return true
                     }
                 }
                 is KtProperty -> {
-                    if (resolved.typeReference?.text?.contains(SERVER_BUILDER_SUFFIX) == true) {
+                    val typeText = resolved.typeReference?.text
+                    if (typeText != null && isServerBuilderType(typeText)) {
                         return true
                     }
                 }
+            }
+        }
+        return false
+    }
+
+    private fun isServerBuilderType(typeText: String): Boolean {
+        return typeText == SERVER_BUILDER_SIMPLE ||
+            typeText == SERVER_BUILDER_FQN ||
+            typeText.endsWith(".$SERVER_BUILDER_SIMPLE")
+    }
+
+    private fun hasServerBuilderImplicitReceiver(call: KtCallExpression): Boolean {
+        val lambda = call.getParentOfType<KtLambdaExpression>(strict = true) ?: return false
+        val lambdaArgument = lambda.parent as? KtValueArgument ?: return false
+        val scopeCall = lambdaArgument.parent as? KtCallExpression ?: return false
+        val scopeMethod = resolveCallName(scopeCall) ?: return false
+        if (scopeMethod !in BUILDER_SCOPE_METHOD_NAMES) {
+            return false
+        }
+        val scopeReceiver = when (val callee = scopeCall.calleeExpression) {
+            is KtDotQualifiedExpression -> callee.receiverExpression
+            else -> (scopeCall.parent as? KtDotQualifiedExpression)?.receiverExpression
+        } ?: return false
+        return isServerBuilderReceiver(scopeReceiver) ||
+            receiverChainContainsServerBuilder(scopeReceiver)
+    }
+
+    private fun receiverChainContainsServerBuilder(receiver: KtExpression): Boolean {
+        var current: KtExpression? = receiver
+        while (current != null) {
+            if (isServerBuilderReceiver(current)) {
+                return true
+            }
+            current = when (current) {
+                is KtDotQualifiedExpression -> current.receiverExpression
+                is KtCallExpression -> {
+                    when (val callee = current.calleeExpression) {
+                        is KtDotQualifiedExpression -> callee.receiverExpression
+                        else -> (current.parent as? KtDotQualifiedExpression)?.receiverExpression
+                    }
+                }
+                else -> null
             }
         }
         return false
@@ -104,20 +175,19 @@ internal object ArmeriaKotlinRouteCollector {
         seenServiceRegistrations: MutableSet<String>,
     ) {
         val registrationKey = "${call.containingKtFile.virtualFile.path}:${call.textRange.startOffset}"
-        val arguments = call.valueArguments.map { it.getArgumentExpression() }
+        val arguments = call.valueArguments
         val path = extractRegistrationPath(methodName, arguments) ?: return
-        val implementationExpression = when (methodName) {
-            "annotatedService" -> arguments.getOrNull(1) ?: arguments.getOrNull(0)
-            else -> arguments.getOrNull(1)
-        } ?: return
-        val targetInfo = extractKotlinTarget(implementationExpression)
+        val implementationExpression = resolveServiceExpression(methodName, arguments) ?: return
+        val unwrappedImplementation = unwrapKotlinExpression(implementationExpression) ?: return
+        val target = extractKotlinTarget(unwrappedImplementation)
+        val targetUnresolved = isUnresolvedKotlinTarget(implementationExpression, target)
         ArmeriaRouteCollector.addServiceRegistrationRoute(
             element = call,
             registrationKey = registrationKey,
             methodName = methodName,
             path = path,
-            target = targetInfo.first,
-            targetUnresolved = targetInfo.second,
+            target = target,
+            targetUnresolved = targetUnresolved,
             implementationText = implementationExpression.text,
             argumentCount = arguments.size,
             routes = routes,
@@ -125,28 +195,73 @@ internal object ArmeriaKotlinRouteCollector {
         )
     }
 
-    private fun extractRegistrationPath(methodName: String, arguments: List<KtExpression?>): String? {
+    private fun resolveServiceExpression(methodName: String, arguments: List<KtValueArgument>): KtExpression? {
         return when (methodName) {
-            "service", "serviceUnder" -> extractKotlinString(arguments.getOrNull(0))
-            "annotatedService" -> if (arguments.size > 1) extractKotlinString(arguments.getOrNull(0)) else "/"
+            "annotatedService" ->
+                findArgumentExpression(arguments, "service", 1)
+                    ?: findArgumentExpression(arguments, "service", 0)
+            else -> findArgumentExpression(arguments, "service", 1)
+        }
+    }
+
+    private fun findArgumentExpression(
+        arguments: List<KtValueArgument>,
+        parameterName: String,
+        positionalIndex: Int,
+    ): KtExpression? {
+        arguments.firstOrNull { argument ->
+            argument.getArgumentName()?.asName?.identifier == parameterName
+        }?.getArgumentExpression()?.let { return it }
+        return arguments.getOrNull(positionalIndex)?.getArgumentExpression()
+    }
+
+    private fun extractRegistrationPath(methodName: String, arguments: List<KtValueArgument>): String? {
+        return when (methodName) {
+            "service" -> extractKotlinString(findArgumentExpression(arguments, "path", 0))
+            "serviceUnder" -> extractKotlinString(findArgumentExpression(arguments, "prefix", 0))
+            "annotatedService" -> {
+                if (arguments.size > 1) {
+                    extractKotlinString(findArgumentExpression(arguments, "prefix", 0))
+                } else {
+                    "/"
+                }
+            }
             else -> null
         }
     }
 
     private fun extractKotlinString(expression: KtExpression?): String? {
-        return when (expression) {
+        val unwrapped = unwrapKotlinExpression(expression) ?: return null
+        return when (unwrapped) {
             is KtStringTemplateExpression -> {
-                if (expression.entries.size == 1) {
-                    expression.entries[0].text.trim('"')
+                if (unwrapped.entries.size == 1) {
+                    unwrapped.entries[0].text.trim('"')
                 } else {
-                    expression.text.trim('"')
+                    unwrapped.text.trim('"')
                 }
             }
-            else -> expression?.text?.trim('"')
+            is KtNameReferenceExpression -> {
+                val resolved = unwrapped.references.firstOrNull()?.resolve()
+                if (resolved is KtProperty) {
+                    extractKotlinString(resolved.initializer)?.let { return it }
+                }
+                unwrapped.text.trim('"').takeIf { it.isNotEmpty() }
+            }
+            else -> unwrapped.text.trim('"').takeIf { it.isNotEmpty() }
         }
     }
 
-    private fun extractKotlinTarget(expression: KtExpression): Pair<String, Boolean> {
+    private fun unwrapKotlinExpression(expression: KtExpression?): KtExpression? {
+        var current = expression ?: return null
+        while (true) {
+            current = when (current) {
+                is KtParenthesizedExpression -> current.expression ?: return null
+                else -> return current
+            }
+        }
+    }
+
+    private fun extractKotlinTarget(expression: KtExpression): String {
         if (expression is KtDotQualifiedExpression) {
             val selector = expression.selectorExpression
             if (selector is KtCallExpression) {
@@ -160,7 +275,7 @@ internal object ArmeriaKotlinRouteCollector {
                 else -> callee?.text
             }
             if (methodName == "build") {
-                val receiver = dotQualifiedReceiver(callee, expression) ?: return expression.text to true
+                val receiver = dotQualifiedReceiver(callee, expression) ?: return expression.text
                 return extractKotlinTarget(receiver)
             }
             if (methodName == "builder") {
@@ -171,7 +286,7 @@ internal object ArmeriaKotlinRouteCollector {
                 if (receiver is KtNameReferenceExpression) {
                     val resolved = receiver.references.firstOrNull()?.resolve()
                     if (resolved is com.intellij.psi.PsiClass) {
-                        return (resolved.qualifiedName ?: receiver.text) to false
+                        return resolved.qualifiedName ?: receiver.text
                     }
                 }
             }
@@ -181,26 +296,60 @@ internal object ArmeriaKotlinRouteCollector {
             val resolved = reference?.references?.firstOrNull()?.resolve()
             val qualifiedName = when (resolved) {
                 is com.intellij.psi.PsiClass -> resolved.qualifiedName
-                is com.intellij.psi.PsiMethod -> resolved.containingClass?.qualifiedName
+                is PsiMethod -> resolved.containingClass?.qualifiedName
                 else -> null
             }
             if (qualifiedName != null) {
-                return qualifiedName to false
+                return qualifiedName
             }
-            val simpleName = reference?.getReferencedName() ?: expression.text
-            return simpleName to true
+            return reference?.getReferencedName() ?: expression.text
         }
         if (expression is KtNameReferenceExpression) {
             val resolved = expression.references.firstOrNull()?.resolve()
             when (resolved) {
-                is com.intellij.psi.PsiClass -> return (resolved.qualifiedName ?: expression.text) to false
+                is com.intellij.psi.PsiClass -> return resolved.qualifiedName ?: expression.text
             }
-            return expression.text to true
+            return expression.text
         }
-        return expression.text to expression.text.contains("()")
+        return expression.text
     }
 
-    private fun dotQualifiedReceiver(callee: KtExpression?, expression: KtCallExpression): KtExpression? {
+    private fun isUnresolvedKotlinTarget(expression: KtExpression, extractedTarget: String): Boolean {
+        val unwrapped = unwrapKotlinExpression(expression) ?: return true
+        val rawTarget = expression.text.trim()
+        return when (unwrapped) {
+            is KtCallExpression -> {
+                ArmeriaRouteCollectionMetrics.current()?.resolveCount?.incrementAndGet()
+                val callee = unwrapped.calleeExpression
+                val methodName = when (callee) {
+                    is KtDotQualifiedExpression -> callee.selectorExpression?.text
+                    else -> callee?.text
+                }
+                if (methodName == "build" || methodName == "builder") {
+                    false
+                } else if (methodName != null && extractedTarget == methodName) {
+                    true
+                } else {
+                    val reference = callee as? KtNameReferenceExpression ?: callee?.let {
+                        if (it is KtDotQualifiedExpression) it.selectorExpression as? KtNameReferenceExpression else null
+                    }
+                    val resolved = reference?.references?.firstOrNull()?.resolve()
+                    when (resolved) {
+                        is com.intellij.psi.PsiClass -> false
+                        is PsiMethod -> extractedTarget == methodName || extractedTarget == resolved.containingClass?.qualifiedName
+                        else -> extractedTarget == rawTarget
+                    }
+                }
+            }
+            is KtNameReferenceExpression -> {
+                ArmeriaRouteCollectionMetrics.current()?.resolveCount?.incrementAndGet()
+                unwrapped.references.firstOrNull()?.resolve() == null
+            }
+            else -> extractedTarget == rawTarget
+        }
+    }
+
+    private fun dotQualifiedReceiver(callee: org.jetbrains.kotlin.psi.KtExpression?, expression: KtCallExpression): KtExpression? {
         return when (callee) {
             is KtDotQualifiedExpression -> callee.receiverExpression
             else -> (expression.parent as? KtDotQualifiedExpression)?.receiverExpression

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
@@ -14,10 +14,11 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtParenthesizedExpression
+import org.jetbrains.kotlin.psi.KtUnaryExpression
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import org.jetbrains.kotlin.psi.KtValueArgument
-import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 
 internal object ArmeriaKotlinRouteCollector {
@@ -62,16 +63,29 @@ internal object ArmeriaKotlinRouteCollector {
         routes: MutableList<ArmeriaRoute>,
         seenServiceRegistrations: MutableSet<String>,
     ) {
-        for (call in file.collectDescendantsOfType<KtCallExpression>()) {
+        file.forEachDescendant { element ->
+            val call = element as? KtCallExpression ?: return@forEachDescendant
             ArmeriaRouteCollectionMetrics.current()?.methodCallsVisited?.incrementAndGet()
-            val methodName = resolveCallName(call) ?: continue
+            val methodName = resolveCallName(call) ?: return@forEachDescendant
             if (methodName !in ServiceRegistrationMethod.METHOD_NAMES) {
-                continue
+                return@forEachDescendant
             }
             if (!looksLikeArmeriaBuilderCall(call)) {
-                continue
+                return@forEachDescendant
             }
             addKotlinServiceRegistration(call, methodName, routes, seenServiceRegistrations)
+        }
+    }
+
+    private inline fun PsiElement.forEachDescendant(action: (PsiElement) -> Unit) {
+        val queue = ArrayDeque<PsiElement>()
+        queue.add(this)
+        while (queue.isNotEmpty()) {
+            val element = queue.removeFirst()
+            action(element)
+            for (child in element.children) {
+                queue.add(child)
+            }
         }
     }
 
@@ -112,12 +126,13 @@ internal object ArmeriaKotlinRouteCollector {
     }
 
     private fun isServerBuilderReceiver(receiver: KtExpression): Boolean {
-        val receiverText = receiver.text
+        val receiverExpression = unwrapReceiverExpression(receiver)
+        val receiverText = receiverExpression.text
         if (ArmeriaRouteSupport.looksLikeServerBuilderReceiverText(receiverText)) {
             return true
         }
-        if (receiver is KtNameReferenceExpression) {
-            when (val resolved = receiver.references.firstOrNull()?.resolve()) {
+        if (receiverExpression is KtNameReferenceExpression) {
+            when (val resolved = receiverExpression.references.firstOrNull()?.resolve()) {
                 is com.intellij.psi.PsiVariable -> {
                     if (ArmeriaRouteSupport.isServerBuilderType(resolved.type.canonicalText)) {
                         return true
@@ -132,6 +147,13 @@ internal object ArmeriaKotlinRouteCollector {
             }
         }
         return false
+    }
+
+    private fun unwrapReceiverExpression(receiver: KtExpression): KtExpression {
+        return when (receiver) {
+            is KtUnaryExpression -> receiver.baseExpression?.let(::unwrapReceiverExpression) ?: receiver
+            else -> receiver
+        }
     }
 
     private fun hasServerBuilderImplicitReceiver(call: KtCallExpression): Boolean {
@@ -208,8 +230,9 @@ internal object ArmeriaKotlinRouteCollector {
         val path = extractRegistrationPath(methodName, arguments) ?: return
         val implementationExpression = resolveServiceExpression(methodName, arguments) ?: return
         val unwrappedImplementation = unwrapKotlinExpression(implementationExpression) ?: return
-        val target = extractKotlinTarget(unwrappedImplementation)
-        val targetUnresolved = isUnresolvedKotlinTarget(implementationExpression, target)
+        val targetExpression = extractKotlinTargetExpression(unwrappedImplementation)
+        val target = renderKotlinTarget(targetExpression)
+        val targetUnresolved = isUnresolvedKotlinTarget(targetExpression, target)
         ArmeriaRouteCollector.addServiceRegistrationRoute(
             element = call,
             registrationKey = registrationKey,
@@ -299,11 +322,11 @@ internal object ArmeriaKotlinRouteCollector {
         }
     }
 
-    private fun extractKotlinTarget(expression: KtExpression): String {
+    private fun extractKotlinTargetExpression(expression: KtExpression): KtExpression {
         if (expression is KtDotQualifiedExpression) {
             val selector = expression.selectorExpression
             if (selector is KtCallExpression) {
-                return extractKotlinTarget(selector)
+                return extractKotlinTargetExpression(selector)
             }
         }
         if (expression is KtCallExpression) {
@@ -313,21 +336,31 @@ internal object ArmeriaKotlinRouteCollector {
                 else -> callee?.text
             }
             if (methodName == "build") {
-                val receiver = dotQualifiedReceiver(callee, expression) ?: return expression.text
-                return extractKotlinTarget(receiver)
+                val receiver = dotQualifiedReceiver(callee, expression) ?: return expression
+                return extractKotlinTargetExpression(receiver)
             }
             if (methodName == "builder") {
                 expression.valueArguments.firstOrNull()?.getArgumentExpression()?.let { serviceArg ->
-                    return extractKotlinTarget(serviceArg)
+                    return extractKotlinTargetExpression(serviceArg)
                 }
                 val receiver = dotQualifiedReceiver(callee, expression)
                 if (receiver is KtNameReferenceExpression) {
                     val resolved = receiver.references.firstOrNull()?.resolve()
                     if (resolved is com.intellij.psi.PsiClass) {
-                        return resolved.qualifiedName ?: receiver.text
+                        return receiver
                     }
                 }
             }
+        }
+        return expression
+    }
+
+    private fun extractKotlinTarget(expression: KtExpression): String =
+        renderKotlinTarget(extractKotlinTargetExpression(expression))
+
+    private fun renderKotlinTarget(expression: KtExpression): String {
+        if (expression is KtCallExpression) {
+            val callee = expression.calleeExpression
             val reference = callee as? KtNameReferenceExpression ?: callee?.let {
                 if (it is KtDotQualifiedExpression) it.selectorExpression as? KtNameReferenceExpression else null
             }
@@ -363,9 +396,7 @@ internal object ArmeriaKotlinRouteCollector {
                     is KtDotQualifiedExpression -> callee.selectorExpression?.text
                     else -> callee?.text
                 }
-                if (methodName == "build" || methodName == "builder") {
-                    false
-                } else if (methodName != null && extractedTarget == methodName) {
+                if (methodName != null && extractedTarget == methodName) {
                     true
                 } else {
                     val reference = callee as? KtNameReferenceExpression ?: callee?.let {

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
@@ -2,11 +2,14 @@ package com.linecorp.intellij.plugins.armeria.explorer
 
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiManager
 import com.intellij.psi.search.FileTypeIndex
 import com.intellij.psi.search.GlobalSearchScope
 import org.jetbrains.kotlin.idea.KotlinFileType
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtConstructor
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtExpression
@@ -18,7 +21,6 @@ import org.jetbrains.kotlin.psi.KtUnaryExpression
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import org.jetbrains.kotlin.psi.KtValueArgument
-import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 
 internal object ArmeriaKotlinRouteCollector {
@@ -346,7 +348,7 @@ internal object ArmeriaKotlinRouteCollector {
                 val receiver = dotQualifiedReceiver(callee, expression)
                 if (receiver is KtNameReferenceExpression) {
                     val resolved = receiver.references.firstOrNull()?.resolve()
-                    if (resolved is com.intellij.psi.PsiClass) {
+                    if (isResolvedKotlinClass(resolved)) {
                         return receiver
                     }
                 }
@@ -362,21 +364,12 @@ internal object ArmeriaKotlinRouteCollector {
                 if (it is KtDotQualifiedExpression) it.selectorExpression as? KtNameReferenceExpression else null
             }
             val resolved = reference?.references?.firstOrNull()?.resolve()
-            val qualifiedName = when (resolved) {
-                is com.intellij.psi.PsiClass -> resolved.qualifiedName
-                is PsiMethod -> resolved.containingClass?.qualifiedName
-                else -> null
-            }
-            if (qualifiedName != null) {
-                return qualifiedName
-            }
+            resolveQualifiedClassName(resolved)?.let { return it }
             return reference?.getReferencedName() ?: expression.text
         }
         if (expression is KtNameReferenceExpression) {
             val resolved = expression.references.firstOrNull()?.resolve()
-            when (resolved) {
-                is com.intellij.psi.PsiClass -> return resolved.qualifiedName ?: expression.text
-            }
+            resolveQualifiedClassName(resolved)?.let { return it }
             return expression.text
         }
         return expression.text
@@ -400,9 +393,9 @@ internal object ArmeriaKotlinRouteCollector {
                         if (it is KtDotQualifiedExpression) it.selectorExpression as? KtNameReferenceExpression else null
                     }
                     val resolved = reference?.references?.firstOrNull()?.resolve()
-                    when (resolved) {
-                        is com.intellij.psi.PsiClass -> false
-                        is PsiMethod -> {
+                    when {
+                        isResolvedKotlinClass(resolved) -> false
+                        resolved is PsiMethod -> {
                             if (resolved.isConstructor) {
                                 false
                             } else {
@@ -410,6 +403,7 @@ internal object ArmeriaKotlinRouteCollector {
                                     extractedTarget == resolved.containingClass?.qualifiedName
                             }
                         }
+                        isResolvedKotlinConstructor(resolved) -> false
                         else -> extractedTarget == rawTarget
                     }
                 }
@@ -427,5 +421,23 @@ internal object ArmeriaKotlinRouteCollector {
             is KtDotQualifiedExpression -> callee.receiverExpression
             else -> (expression.parent as? KtDotQualifiedExpression)?.receiverExpression
         }
+    }
+
+    private fun resolveQualifiedClassName(resolved: PsiElement?): String? {
+        return when (resolved) {
+            is com.intellij.psi.PsiClass -> resolved.qualifiedName
+            is PsiMethod -> resolved.containingClass?.qualifiedName
+            is KtClassOrObject -> resolved.fqName?.asString()
+            is KtConstructor<*> -> resolved.getContainingClassOrObject().fqName?.asString()
+            else -> null
+        }
+    }
+
+    private fun isResolvedKotlinClass(resolved: PsiElement?): Boolean {
+        return resolved is com.intellij.psi.PsiClass || resolved is KtClassOrObject
+    }
+
+    private fun isResolvedKotlinConstructor(resolved: PsiElement?): Boolean {
+        return resolved is PsiMethod && resolved.isConstructor || resolved is KtConstructor<*>
     }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
@@ -165,6 +165,7 @@ internal object ArmeriaKotlinRouteCollector {
     private fun unwrapReceiverExpression(receiver: KtExpression): KtExpression {
         return when (receiver) {
             is KtUnaryExpression -> receiver.baseExpression?.let(::unwrapReceiverExpression) ?: receiver
+            is KtParenthesizedExpression -> receiver.expression?.let(::unwrapReceiverExpression) ?: receiver
             else -> receiver
         }
     }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
@@ -23,6 +23,16 @@ import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 internal object ArmeriaKotlinRouteCollector {
     private val BUILDER_SCOPE_METHOD_NAMES = setOf("apply", "run", "also", "let")
 
+    internal fun referencesArmeriaKotlinContent(file: KtFile): Boolean {
+        val hasArmeriaImports = file.importList?.imports?.any { import ->
+            import.importedFqName?.asString()?.startsWith(ArmeriaRouteSupport.ARMERIA_PACKAGE_PREFIX) == true
+        } ?: false
+        if (hasArmeriaImports) {
+            return true
+        }
+        return ArmeriaRouteSupport.referencesArmeriaInText(file.viewProvider.contents)
+    }
+
     fun collectServiceRegistrationsFallback(
         project: Project,
         scope: GlobalSearchScope,
@@ -36,7 +46,7 @@ internal object ArmeriaKotlinRouteCollector {
             }
             ArmeriaRouteCollectionMetrics.current()?.filesScanned?.incrementAndGet()
             val ktFile = PsiManager.getInstance(project).findFile(virtualFile) as? KtFile ?: continue
-            if (!ArmeriaRouteCollector.referencesArmeriaContent(ktFile)) {
+            if (!referencesArmeriaKotlinContent(ktFile)) {
                 continue
             }
             fallbackScannedFiles += virtualFile
@@ -101,7 +111,7 @@ internal object ArmeriaKotlinRouteCollector {
 
     private fun isServerBuilderReceiver(receiver: KtExpression): Boolean {
         val receiverText = receiver.text
-        if (receiverText.contains("Server.builder()") || receiverText.contains("serverBuilder")) {
+        if (ArmeriaRouteSupport.looksLikeServerBuilderReceiverText(receiverText)) {
             return true
         }
         if (receiver is KtNameReferenceExpression) {

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
@@ -1,0 +1,161 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.search.FileTypeIndex
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.util.PsiTreeUtil
+import org.jetbrains.kotlin.asJava.toLightMethods
+import org.jetbrains.kotlin.idea.KotlinFileType
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+
+internal object ArmeriaKotlinRouteCollector {
+    private const val ARMERIA_PACKAGE_PREFIX = "com.linecorp.armeria"
+    private val REGISTRATION_METHOD_NAMES = setOf("service", "serviceUnder", "annotatedService")
+
+    fun collect(
+        project: Project,
+        scope: GlobalSearchScope,
+        routes: MutableList<ArmeriaRoute>,
+        seenServiceRegistrations: MutableSet<String>,
+    ) {
+        val seenMethods = mutableSetOf<PsiMethod>()
+        for (virtualFile in FileTypeIndex.getFiles(KotlinFileType.INSTANCE, scope)) {
+            val ktFile = com.intellij.psi.PsiManager.getInstance(project).findFile(virtualFile) as? KtFile ?: continue
+            if (!referencesArmeria(ktFile)) {
+                continue
+            }
+            ArmeriaRouteCollectionMetrics.current()?.armeriaFiles?.incrementAndGet()
+            collectAnnotatedRoutes(ktFile, routes, seenMethods)
+            collectServiceRegistrations(ktFile, routes, seenServiceRegistrations)
+        }
+    }
+
+    private fun referencesArmeria(file: KtFile): Boolean {
+        val hasArmeriaImports = file.importList?.imports?.any { import ->
+            import.importedFqName?.asString()?.startsWith(ARMERIA_PACKAGE_PREFIX) == true
+        } ?: false
+        if (hasArmeriaImports) {
+            return true
+        }
+        return file.text.take(4096).contains(ARMERIA_PACKAGE_PREFIX)
+    }
+
+    private fun collectAnnotatedRoutes(
+        file: KtFile,
+        routes: MutableList<ArmeriaRoute>,
+        seenMethods: MutableSet<PsiMethod>,
+    ) {
+        for (function in file.collectDescendantsOfType<KtNamedFunction>()) {
+            for (lightMethod in function.toLightMethods()) {
+                if (!seenMethods.add(lightMethod)) {
+                    continue
+                }
+                ArmeriaRouteCollector.addAnnotatedRouteFromMethod(lightMethod, routes)
+            }
+        }
+    }
+
+    private fun collectServiceRegistrations(
+        file: KtFile,
+        routes: MutableList<ArmeriaRoute>,
+        seenServiceRegistrations: MutableSet<String>,
+    ) {
+        for (call in file.collectDescendantsOfType<KtCallExpression>()) {
+            val methodName = resolveCallName(call) ?: continue
+            if (methodName !in REGISTRATION_METHOD_NAMES) {
+                continue
+            }
+            if (!looksLikeArmeriaBuilderCall(call)) {
+                continue
+            }
+            val registrationKey = "${file.virtualFile.path}:${call.textRange.startOffset}"
+            if (!seenServiceRegistrations.add(registrationKey)) {
+                continue
+            }
+            addKotlinServiceRegistration(call, methodName, routes)
+        }
+    }
+
+    private fun resolveCallName(call: KtCallExpression): String? {
+        val callee = call.calleeExpression ?: return null
+        return when (callee) {
+            is KtDotQualifiedExpression -> callee.selectorExpression?.text
+            else -> callee.text
+        }
+    }
+
+    private fun looksLikeArmeriaBuilderCall(call: KtCallExpression): Boolean {
+        val receiverText = when (val callee = call.calleeExpression) {
+            is KtDotQualifiedExpression -> callee.receiverExpression.text
+            else -> null
+        }
+        if (receiverText != null && (receiverText.contains("Server.builder") || receiverText.contains("serverBuilder") || receiverText.contains("ServerBuilder"))) {
+            return true
+        }
+        val javaCall = PsiTreeUtil.getParentOfType(call, com.intellij.psi.PsiMethodCallExpression::class.java)
+        if (javaCall != null) {
+            return true
+        }
+        return call.containingKtFile.text.contains("Server.builder") || call.containingKtFile.text.contains("serverBuilder")
+    }
+
+    private fun addKotlinServiceRegistration(
+        call: KtCallExpression,
+        methodName: String,
+        routes: MutableList<ArmeriaRoute>,
+    ) {
+        val arguments = call.valueArguments.map { it.getArgumentExpression() }
+        val path = extractRegistrationPath(methodName, arguments) ?: return
+        val implementationExpression = when (methodName) {
+            "annotatedService" -> arguments.getOrNull(1) ?: arguments.getOrNull(0)
+            else -> arguments.getOrNull(1)
+        } ?: return
+        val expressionText = implementationExpression.text
+        val protocol = ArmeriaRouteTargetExtractor.detectProtocol(expressionText)
+        val target = expressionText
+        val routeMatch = when {
+            protocol != RouteProtocol.HTTP -> RouteMatch.NON_HTTP
+            methodName == "service" -> RouteMatch.SERVICE
+            methodName == "serviceUnder" -> RouteMatch.SERVICE_UNDER
+            else -> RouteMatch.ANNOTATED_SERVICE
+        }
+        val annotatedServiceHasPathPrefix = methodName == "annotatedService" && arguments.size > 1
+        routes += ArmeriaRoute.create(
+            element = call,
+            protocol = protocol.presentableName(),
+            httpMethod = "",
+            path = ArmeriaRouteSupport.normalizePath(path),
+            target = target,
+            routeMatch = routeMatch,
+            isDocService = protocol == RouteProtocol.DOC_SERVICE,
+            annotatedServiceHasPathPrefix = annotatedServiceHasPathPrefix,
+        )
+    }
+
+    private fun extractRegistrationPath(methodName: String, arguments: List<org.jetbrains.kotlin.psi.KtExpression?>): String? {
+        return when (methodName) {
+            "service", "serviceUnder" -> extractKotlinString(arguments.getOrNull(0))
+            "annotatedService" -> if (arguments.size > 1) extractKotlinString(arguments.getOrNull(0)) else "/"
+            else -> null
+        }
+    }
+
+    private fun extractKotlinString(expression: org.jetbrains.kotlin.psi.KtExpression?): String? {
+        return when (expression) {
+            is KtStringTemplateExpression -> {
+                if (expression.entries.size == 1) {
+                    expression.entries[0].text
+                } else {
+                    expression.text.trim('"')
+                }
+            }
+            else -> expression?.text?.trim('"')
+        }
+    }
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
@@ -217,15 +217,20 @@ internal object ArmeriaKotlinRouteCollector {
         return arguments.getOrNull(positionalIndex)?.getArgumentExpression()
     }
 
+    private fun findPathPrefixArgument(arguments: List<KtValueArgument>, positionalIndex: Int): KtExpression? {
+        return findArgumentExpression(arguments, "pathPrefix", positionalIndex)
+            ?: findArgumentExpression(arguments, "prefix", positionalIndex)
+    }
+
     private fun extractRegistrationPath(methodName: String, arguments: List<KtValueArgument>): String? {
         return when (ServiceRegistrationMethod.fromMethodName(methodName)) {
             ServiceRegistrationMethod.SERVICE ->
                 extractKotlinString(findArgumentExpression(arguments, "path", 0))
             ServiceRegistrationMethod.SERVICE_UNDER ->
-                extractKotlinString(findArgumentExpression(arguments, "prefix", 0))
+                extractKotlinString(findPathPrefixArgument(arguments, 0))
             ServiceRegistrationMethod.ANNOTATED_SERVICE -> {
                 if (arguments.size > 1) {
-                    extractKotlinString(findArgumentExpression(arguments, "prefix", 0))
+                    extractKotlinString(findPathPrefixArgument(arguments, 0))
                 } else {
                     "/"
                 }
@@ -340,7 +345,14 @@ internal object ArmeriaKotlinRouteCollector {
                     val resolved = reference?.references?.firstOrNull()?.resolve()
                     when (resolved) {
                         is com.intellij.psi.PsiClass -> false
-                        is PsiMethod -> extractedTarget == methodName || extractedTarget == resolved.containingClass?.qualifiedName
+                        is PsiMethod -> {
+                            if (resolved.isConstructor) {
+                                false
+                            } else {
+                                extractedTarget == methodName ||
+                                    extractedTarget == resolved.containingClass?.qualifiedName
+                            }
+                        }
                         else -> extractedTarget == rawTarget
                     }
                 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiManager
+import com.intellij.psi.PsiVariable
 import com.intellij.psi.search.FileTypeIndex
 import com.intellij.psi.search.GlobalSearchScope
 import org.jetbrains.kotlin.idea.KotlinFileType
@@ -115,16 +116,26 @@ internal object ArmeriaKotlinRouteCollector {
 
     private fun resolvesToArmeriaServerBuilder(call: KtCallExpression): Boolean {
         ArmeriaRouteCollectionMetrics.current()?.resolveCount?.incrementAndGet()
-        val dotQualified = call.parent as? KtDotQualifiedExpression ?: return false
-        for (reference in dotQualified.references) {
-            val resolved = reference.resolve()
-            if (resolved is PsiMethod &&
-                resolved.containingClass?.qualifiedName?.startsWith(ArmeriaRouteSupport.ARMERIA_SERVER_PACKAGE_PREFIX) == true
-            ) {
-                return true
+        val dotQualified = call.parent as? KtDotQualifiedExpression
+        if (dotQualified != null) {
+            for (reference in dotQualified.references) {
+                if (isArmeriaServerBuilderMethod(reference.resolve())) {
+                    return true
+                }
             }
         }
-        return false
+        val callee = call.calleeExpression ?: return false
+        val references = when (callee) {
+            is KtNameReferenceExpression -> callee.references.toList()
+            is KtDotQualifiedExpression -> callee.references.toList()
+            else -> emptyList()
+        }
+        return references.any { isArmeriaServerBuilderMethod(it.resolve()) }
+    }
+
+    private fun isArmeriaServerBuilderMethod(resolved: PsiElement?): Boolean {
+        return resolved is PsiMethod &&
+            resolved.containingClass?.qualifiedName?.startsWith(ArmeriaRouteSupport.ARMERIA_SERVER_PACKAGE_PREFIX) == true
     }
 
     private fun isServerBuilderReceiver(receiver: KtExpression): Boolean {
@@ -135,13 +146,13 @@ internal object ArmeriaKotlinRouteCollector {
         }
         if (receiverExpression is KtNameReferenceExpression) {
             when (val resolved = receiverExpression.references.firstOrNull()?.resolve()) {
-                is com.intellij.psi.PsiVariable -> {
+                is PsiVariable -> {
                     if (ArmeriaRouteSupport.isServerBuilderType(resolved.type.canonicalText)) {
                         return true
                     }
                 }
                 is KtProperty -> {
-                    val typeText = resolved.typeReference?.text
+                    val typeText = ArmeriaRouteSupport.resolveKotlinTypeReferenceText(resolved.typeReference)
                     if (typeText != null && ArmeriaRouteSupport.isServerBuilderType(typeText)) {
                         return true
                     }
@@ -303,15 +314,29 @@ internal object ArmeriaKotlinRouteCollector {
                     unwrapped.text.trim('"')
                 }
             }
-            is KtNameReferenceExpression -> {
-                val resolved = unwrapped.references.firstOrNull()?.resolve()
-                if (resolved is KtProperty) {
-                    extractKotlinString(resolved.initializer)?.let { return it }
-                }
-                unwrapped.text.trim('"').takeIf { it.isNotEmpty() }
-            }
+            is KtDotQualifiedExpression -> extractKotlinStringFromReference(unwrapped)
+            is KtNameReferenceExpression -> extractKotlinStringFromReference(unwrapped)
             else -> unwrapped.text.trim('"').takeIf { it.isNotEmpty() }
         }
+    }
+
+    private fun extractKotlinStringFromReference(expression: KtExpression): String? {
+        val resolved = expression.references.firstOrNull()?.resolve()
+        when (resolved) {
+            is KtProperty -> extractKotlinString(resolved.initializer)?.let { return it }
+            is PsiVariable -> ArmeriaRouteSupport.evaluateJavaStringConstant(resolved)?.let { return it }
+        }
+        if (expression is KtDotQualifiedExpression) {
+            val selector = expression.selectorExpression as? KtNameReferenceExpression ?: return null
+            val receiver = expression.receiverExpression as? KtNameReferenceExpression ?: return null
+            val containingClass = receiver.references.firstOrNull()?.resolve() as? com.intellij.psi.PsiClass
+                ?: return null
+            val field = containingClass.findFieldByName(selector.getReferencedName(), true)
+            if (field != null) {
+                ArmeriaRouteSupport.evaluateJavaStringConstant(field)?.let { return it }
+            }
+        }
+        return expression.text.trim('"').takeIf { it.isNotEmpty() }
     }
 
     private fun unwrapKotlinExpression(expression: KtExpression?): KtExpression? {

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
@@ -21,7 +21,9 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 
 internal object ArmeriaKotlinRouteCollector {
-    private val BUILDER_SCOPE_METHOD_NAMES = setOf("apply", "run", "also", "let")
+    private val IMPLICIT_RECEIVER_SCOPE_METHODS = setOf("apply", "run")
+    private val EXPLICIT_PARAMETER_SCOPE_METHODS = setOf("also", "let")
+    private val BUILDER_SCOPE_METHOD_NAMES = IMPLICIT_RECEIVER_SCOPE_METHODS + EXPLICIT_PARAMETER_SCOPE_METHODS
 
     internal fun referencesArmeriaKotlinContent(file: KtFile): Boolean {
         val hasArmeriaImports = file.importList?.imports?.any { import ->
@@ -144,8 +146,34 @@ internal object ArmeriaKotlinRouteCollector {
             is KtDotQualifiedExpression -> callee.receiverExpression
             else -> (scopeCall.parent as? KtDotQualifiedExpression)?.receiverExpression
         } ?: return false
-        return isServerBuilderReceiver(scopeReceiver) ||
-            receiverChainContainsServerBuilder(scopeReceiver)
+        if (!isServerBuilderReceiver(scopeReceiver) && !receiverChainContainsServerBuilder(scopeReceiver)) {
+            return false
+        }
+        return when (scopeMethod) {
+            in IMPLICIT_RECEIVER_SCOPE_METHODS -> true
+            in EXPLICIT_PARAMETER_SCOPE_METHODS -> isRegistrationOnScopeLambdaParameter(call, lambda)
+            else -> false
+        }
+    }
+
+    private fun isRegistrationOnScopeLambdaParameter(
+        call: KtCallExpression,
+        scopeLambda: KtLambdaExpression,
+    ): Boolean {
+        val dotQualified = when (val callee = call.calleeExpression) {
+            is KtDotQualifiedExpression -> callee
+            else -> call.parent as? KtDotQualifiedExpression
+        } ?: return false
+
+        val receiver = dotQualified.receiverExpression
+        if (isServerBuilderReceiver(receiver)) {
+            return true
+        }
+        val receiverName = (receiver as? KtNameReferenceExpression)?.getReferencedName() ?: return false
+        if (scopeLambda.valueParameters.any { it.name == receiverName }) {
+            return true
+        }
+        return scopeLambda.valueParameters.isEmpty() && receiverName == "it"
     }
 
     private fun receiverChainContainsServerBuilder(receiver: KtExpression): Boolean {

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
@@ -202,7 +202,8 @@ internal object ArmeriaKotlinRouteCollector {
         routes: MutableList<ArmeriaRoute>,
         seenServiceRegistrations: MutableSet<String>,
     ) {
-        val registrationKey = "${call.containingKtFile.virtualFile.path}:${call.textRange.startOffset}"
+        val virtualFile = call.containingKtFile.virtualFile ?: return
+        val registrationKey = "${virtualFile.path}:${call.textRange.startOffset}"
         val arguments = call.valueArguments
         val path = extractRegistrationPath(methodName, arguments) ?: return
         val implementationExpression = resolveServiceExpression(methodName, arguments) ?: return

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiVariable
 import com.intellij.psi.search.FileTypeIndex
 import com.intellij.psi.search.GlobalSearchScope
 import org.jetbrains.kotlin.idea.KotlinFileType
+import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtConstructor
 import org.jetbrains.kotlin.psi.KtCallExpression
@@ -21,6 +22,9 @@ import org.jetbrains.kotlin.psi.KtParenthesizedExpression
 import org.jetbrains.kotlin.psi.KtUnaryExpression
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.psi.KtTypeAlias
+import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.KtUserType
 import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 
@@ -152,7 +156,7 @@ internal object ArmeriaKotlinRouteCollector {
                     }
                 }
                 is KtProperty -> {
-                    val typeText = ArmeriaRouteSupport.resolveKotlinTypeReferenceText(resolved.typeReference)
+                    val typeText = resolveKotlinTypeReferenceText(resolved.typeReference)
                     if (typeText != null && ArmeriaRouteSupport.isServerBuilderType(typeText)) {
                         return true
                     }
@@ -160,6 +164,19 @@ internal object ArmeriaKotlinRouteCollector {
             }
         }
         return false
+    }
+
+    private fun resolveKotlinTypeReferenceText(typeReference: KtTypeReference?): String? {
+        if (typeReference == null) {
+            return null
+        }
+        val userType = typeReference.typeElement as? KtUserType
+        val resolved = userType?.referenceExpression?.references?.firstOrNull()?.resolve()
+        return when (resolved) {
+            is KtTypeAlias -> resolved.getTypeReference()?.text ?: typeReference.text
+            is KtClass -> resolved.fqName?.asString() ?: typeReference.text
+            else -> typeReference.text
+        }
     }
 
     private fun unwrapReceiverExpression(receiver: KtExpression): KtExpression {

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
@@ -355,9 +355,6 @@ internal object ArmeriaKotlinRouteCollector {
         return expression
     }
 
-    private fun extractKotlinTarget(expression: KtExpression): String =
-        renderKotlinTarget(extractKotlinTargetExpression(expression))
-
     private fun renderKotlinTarget(expression: KtExpression): String {
         if (expression is KtCallExpression) {
             val callee = expression.calleeExpression

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
@@ -1,67 +1,48 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiMethod
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiManager
 import com.intellij.psi.search.FileTypeIndex
 import com.intellij.psi.search.GlobalSearchScope
-import com.intellij.psi.util.PsiTreeUtil
-import org.jetbrains.kotlin.asJava.toLightMethods
 import org.jetbrains.kotlin.idea.KotlinFileType
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 
 internal object ArmeriaKotlinRouteCollector {
-    private const val ARMERIA_PACKAGE_PREFIX = "com.linecorp.armeria"
+    private const val SERVER_BUILDER_SUFFIX = "ServerBuilder"
     private val REGISTRATION_METHOD_NAMES = setOf("service", "serviceUnder", "annotatedService")
 
-    fun collect(
+    fun collectServiceRegistrationsFallback(
         project: Project,
         scope: GlobalSearchScope,
         routes: MutableList<ArmeriaRoute>,
+        fallbackScannedFiles: MutableSet<VirtualFile>,
         seenServiceRegistrations: MutableSet<String>,
     ) {
-        val seenMethods = mutableSetOf<PsiMethod>()
         for (virtualFile in FileTypeIndex.getFiles(KotlinFileType.INSTANCE, scope)) {
-            val ktFile = com.intellij.psi.PsiManager.getInstance(project).findFile(virtualFile) as? KtFile ?: continue
-            if (!referencesArmeria(ktFile)) {
+            if (virtualFile in fallbackScannedFiles) {
                 continue
             }
-            ArmeriaRouteCollectionMetrics.current()?.armeriaFiles?.incrementAndGet()
-            collectAnnotatedRoutes(ktFile, routes, seenMethods)
-            collectServiceRegistrations(ktFile, routes, seenServiceRegistrations)
-        }
-    }
-
-    private fun referencesArmeria(file: KtFile): Boolean {
-        val hasArmeriaImports = file.importList?.imports?.any { import ->
-            import.importedFqName?.asString()?.startsWith(ARMERIA_PACKAGE_PREFIX) == true
-        } ?: false
-        if (hasArmeriaImports) {
-            return true
-        }
-        return file.text.take(4096).contains(ARMERIA_PACKAGE_PREFIX)
-    }
-
-    private fun collectAnnotatedRoutes(
-        file: KtFile,
-        routes: MutableList<ArmeriaRoute>,
-        seenMethods: MutableSet<PsiMethod>,
-    ) {
-        for (function in file.collectDescendantsOfType<KtNamedFunction>()) {
-            for (lightMethod in function.toLightMethods()) {
-                if (!seenMethods.add(lightMethod)) {
-                    continue
-                }
-                ArmeriaRouteCollector.addAnnotatedRouteFromMethod(lightMethod, routes)
+            ArmeriaRouteCollectionMetrics.current()?.filesScanned?.incrementAndGet()
+            val ktFile = PsiManager.getInstance(project).findFile(virtualFile) as? KtFile ?: continue
+            if (!ArmeriaRouteCollector.referencesArmeriaContent(ktFile)) {
+                continue
             }
+            fallbackScannedFiles += virtualFile
+            ArmeriaRouteCollectionMetrics.current()?.armeriaFiles?.incrementAndGet()
+            collectServiceRegistrationsFromFile(ktFile, routes, seenServiceRegistrations)
         }
     }
 
-    private fun collectServiceRegistrations(
+    private fun collectServiceRegistrationsFromFile(
         file: KtFile,
         routes: MutableList<ArmeriaRoute>,
         seenServiceRegistrations: MutableSet<String>,
@@ -74,11 +55,7 @@ internal object ArmeriaKotlinRouteCollector {
             if (!looksLikeArmeriaBuilderCall(call)) {
                 continue
             }
-            val registrationKey = "${file.virtualFile.path}:${call.textRange.startOffset}"
-            if (!seenServiceRegistrations.add(registrationKey)) {
-                continue
-            }
-            addKotlinServiceRegistration(call, methodName, routes)
+            addKotlinServiceRegistration(call, methodName, routes, seenServiceRegistrations)
         }
     }
 
@@ -91,54 +68,64 @@ internal object ArmeriaKotlinRouteCollector {
     }
 
     private fun looksLikeArmeriaBuilderCall(call: KtCallExpression): Boolean {
-        val receiverText = when (val callee = call.calleeExpression) {
-            is KtDotQualifiedExpression -> callee.receiverExpression.text
-            else -> null
-        }
-        if (receiverText != null && (receiverText.contains("Server.builder") || receiverText.contains("serverBuilder") || receiverText.contains("ServerBuilder"))) {
+        val dotQualified = when (val callee = call.calleeExpression) {
+            is KtDotQualifiedExpression -> callee
+            else -> call.parent as? KtDotQualifiedExpression
+        } ?: return false
+        val receiver = dotQualified.receiverExpression
+        val receiverText = receiver.text
+        if (receiverText.contains("Server.builder()") ||
+            receiverText.contains("serverBuilder") ||
+            receiverText.contains(SERVER_BUILDER_SUFFIX)
+        ) {
             return true
         }
-        val javaCall = PsiTreeUtil.getParentOfType(call, com.intellij.psi.PsiMethodCallExpression::class.java)
-        if (javaCall != null) {
-            return true
+        if (receiver is KtNameReferenceExpression) {
+            when (val resolved = receiver.references.firstOrNull()?.resolve()) {
+                is com.intellij.psi.PsiVariable -> {
+                    if (resolved.type.canonicalText.contains(SERVER_BUILDER_SUFFIX)) {
+                        return true
+                    }
+                }
+                is KtProperty -> {
+                    if (resolved.typeReference?.text?.contains(SERVER_BUILDER_SUFFIX) == true) {
+                        return true
+                    }
+                }
+            }
         }
-        return call.containingKtFile.text.contains("Server.builder") || call.containingKtFile.text.contains("serverBuilder")
+        return false
     }
 
     private fun addKotlinServiceRegistration(
         call: KtCallExpression,
         methodName: String,
         routes: MutableList<ArmeriaRoute>,
+        seenServiceRegistrations: MutableSet<String>,
     ) {
+        val registrationKey = "${call.containingKtFile.virtualFile.path}:${call.textRange.startOffset}"
         val arguments = call.valueArguments.map { it.getArgumentExpression() }
         val path = extractRegistrationPath(methodName, arguments) ?: return
         val implementationExpression = when (methodName) {
             "annotatedService" -> arguments.getOrNull(1) ?: arguments.getOrNull(0)
             else -> arguments.getOrNull(1)
         } ?: return
-        val expressionText = implementationExpression.text
-        val protocol = ArmeriaRouteTargetExtractor.detectProtocol(expressionText)
-        val target = expressionText
-        val routeMatch = when {
-            protocol != RouteProtocol.HTTP -> RouteMatch.NON_HTTP
-            methodName == "service" -> RouteMatch.SERVICE
-            methodName == "serviceUnder" -> RouteMatch.SERVICE_UNDER
-            else -> RouteMatch.ANNOTATED_SERVICE
-        }
-        val annotatedServiceHasPathPrefix = methodName == "annotatedService" && arguments.size > 1
-        routes += ArmeriaRoute.create(
+        val targetInfo = extractKotlinTarget(implementationExpression)
+        ArmeriaRouteCollector.addServiceRegistrationRoute(
             element = call,
-            protocol = protocol.presentableName(),
-            httpMethod = "",
-            path = ArmeriaRouteSupport.normalizePath(path),
-            target = target,
-            routeMatch = routeMatch,
-            isDocService = protocol == RouteProtocol.DOC_SERVICE,
-            annotatedServiceHasPathPrefix = annotatedServiceHasPathPrefix,
+            registrationKey = registrationKey,
+            methodName = methodName,
+            path = path,
+            target = targetInfo.first,
+            targetUnresolved = targetInfo.second,
+            implementationText = implementationExpression.text,
+            argumentCount = arguments.size,
+            routes = routes,
+            seenServiceRegistrations = seenServiceRegistrations,
         )
     }
 
-    private fun extractRegistrationPath(methodName: String, arguments: List<org.jetbrains.kotlin.psi.KtExpression?>): String? {
+    private fun extractRegistrationPath(methodName: String, arguments: List<KtExpression?>): String? {
         return when (methodName) {
             "service", "serviceUnder" -> extractKotlinString(arguments.getOrNull(0))
             "annotatedService" -> if (arguments.size > 1) extractKotlinString(arguments.getOrNull(0)) else "/"
@@ -146,16 +133,77 @@ internal object ArmeriaKotlinRouteCollector {
         }
     }
 
-    private fun extractKotlinString(expression: org.jetbrains.kotlin.psi.KtExpression?): String? {
+    private fun extractKotlinString(expression: KtExpression?): String? {
         return when (expression) {
             is KtStringTemplateExpression -> {
                 if (expression.entries.size == 1) {
-                    expression.entries[0].text
+                    expression.entries[0].text.trim('"')
                 } else {
                     expression.text.trim('"')
                 }
             }
             else -> expression?.text?.trim('"')
+        }
+    }
+
+    private fun extractKotlinTarget(expression: KtExpression): Pair<String, Boolean> {
+        if (expression is KtDotQualifiedExpression) {
+            val selector = expression.selectorExpression
+            if (selector is KtCallExpression) {
+                return extractKotlinTarget(selector)
+            }
+        }
+        if (expression is KtCallExpression) {
+            val callee = expression.calleeExpression
+            val methodName = when (callee) {
+                is KtDotQualifiedExpression -> callee.selectorExpression?.text
+                else -> callee?.text
+            }
+            if (methodName == "build") {
+                val receiver = dotQualifiedReceiver(callee, expression) ?: return expression.text to true
+                return extractKotlinTarget(receiver)
+            }
+            if (methodName == "builder") {
+                expression.valueArguments.firstOrNull()?.getArgumentExpression()?.let { serviceArg ->
+                    return extractKotlinTarget(serviceArg)
+                }
+                val receiver = dotQualifiedReceiver(callee, expression)
+                if (receiver is KtNameReferenceExpression) {
+                    val resolved = receiver.references.firstOrNull()?.resolve()
+                    if (resolved is com.intellij.psi.PsiClass) {
+                        return (resolved.qualifiedName ?: receiver.text) to false
+                    }
+                }
+            }
+            val reference = callee as? KtNameReferenceExpression ?: callee?.let {
+                if (it is KtDotQualifiedExpression) it.selectorExpression as? KtNameReferenceExpression else null
+            }
+            val resolved = reference?.references?.firstOrNull()?.resolve()
+            val qualifiedName = when (resolved) {
+                is com.intellij.psi.PsiClass -> resolved.qualifiedName
+                is com.intellij.psi.PsiMethod -> resolved.containingClass?.qualifiedName
+                else -> null
+            }
+            if (qualifiedName != null) {
+                return qualifiedName to false
+            }
+            val simpleName = reference?.getReferencedName() ?: expression.text
+            return simpleName to true
+        }
+        if (expression is KtNameReferenceExpression) {
+            val resolved = expression.references.firstOrNull()?.resolve()
+            when (resolved) {
+                is com.intellij.psi.PsiClass -> return (resolved.qualifiedName ?: expression.text) to false
+            }
+            return expression.text to true
+        }
+        return expression.text to expression.text.contains("()")
+    }
+
+    private fun dotQualifiedReceiver(callee: KtExpression?, expression: KtCallExpression): KtExpression? {
+        return when (callee) {
+            is KtDotQualifiedExpression -> callee.receiverExpression
+            else -> (expression.parent as? KtDotQualifiedExpression)?.receiverExpression
         }
     }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
@@ -1,13 +1,17 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
 import com.intellij.ide.highlighter.JavaFileType
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.JavaRecursiveElementWalkingVisitor
 import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiJavaFile
 import com.intellij.psi.PsiLiteralExpression
 import com.intellij.psi.PsiManager
@@ -22,6 +26,7 @@ import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.PsiModificationTracker
 import com.intellij.psi.util.PsiTreeUtil
 import com.linecorp.intellij.plugins.armeria.message
+import org.jetbrains.kotlin.psi.KtFile
 
 internal enum class RouteProtocol(private val messageKey: String) {
     HTTP("route.explorer.protocol.http"),
@@ -40,6 +45,7 @@ object ArmeriaRouteCollector {
     private const val SERVER_BUILDER_CLASS = "com.linecorp.armeria.server.ServerBuilder"
     private const val ARMERIA_HEADER_SCAN_LIMIT = 4096
     private val REGISTRATION_METHOD_NAMES = setOf("service", "serviceUnder", "annotatedService")
+    private val KOTLIN_PLUGIN_ID = PluginId.getId("org.jetbrains.kotlin")
     private val ARMERIA_REFERENCE_PATTERN =
         Regex("""(?<![\w"])com\.linecorp\.armeria(?:\.[A-Za-z_][A-Za-z0-9_]*)+""")
 
@@ -70,7 +76,13 @@ object ArmeriaRouteCollector {
             collectServiceRegistrationsFallback(project, scope, routes, fallbackScannedFiles, seenServiceRegistrations)
         }
         if (isKotlinPluginAvailable()) {
-            ArmeriaKotlinRouteCollector.collect(project, scope, routes, seenServiceRegistrations)
+            ArmeriaKotlinRouteCollector.collectServiceRegistrationsFallback(
+                project,
+                scope,
+                routes,
+                fallbackScannedFiles,
+                seenServiceRegistrations,
+            )
         }
 
         return CachedValueProvider.Result.create(
@@ -167,21 +179,29 @@ object ArmeriaRouteCollector {
             }
             ArmeriaRouteCollectionMetrics.current()?.filesScanned?.incrementAndGet()
             val psiFile = PsiManager.getInstance(project).findFile(virtualFile) as? PsiJavaFile ?: continue
-            if (!referencesArmeria(psiFile)) {
+            if (!referencesArmeriaContent(psiFile)) {
                 continue
             }
             fallbackScannedFiles += virtualFile
             ArmeriaRouteCollectionMetrics.current()?.armeriaFiles?.incrementAndGet()
-            collectRoutesFromFile(psiFile, routes, seenServiceRegistrations)
+            collectServiceRegistrationsFromJavaFile(psiFile, routes, seenServiceRegistrations)
         }
     }
 
-    private fun referencesArmeria(file: PsiJavaFile): Boolean {
-        val hasArmeriaImports = file.importList
-            ?.allImportStatements
-            ?.any { statement ->
-                statement.importReference?.qualifiedName?.startsWith(ARMERIA_PACKAGE_PREFIX) == true
+    internal fun referencesArmeriaContent(file: PsiFile): Boolean {
+        val hasArmeriaImports = when (file) {
+            is PsiJavaFile -> file.importList
+                ?.allImportStatements
+                ?.any { statement ->
+                    statement.importReference?.qualifiedName?.startsWith(ARMERIA_PACKAGE_PREFIX) == true
+                } ?: false
+
+            is KtFile -> file.importList?.imports?.any { import ->
+                import.importedFqName?.asString()?.startsWith(ARMERIA_PACKAGE_PREFIX) == true
             } ?: false
+
+            else -> false
+        }
         if (hasArmeriaImports) {
             return true
         }
@@ -190,27 +210,33 @@ object ArmeriaRouteCollector {
         return ARMERIA_REFERENCE_PATTERN.containsMatchIn(searchWindow)
     }
 
-    private fun collectRoutesFromFile(
+    internal fun collectServiceRegistrationsFromJavaFile(
         file: PsiJavaFile,
         routes: MutableList<ArmeriaRoute>,
         seenServiceRegistrations: MutableSet<String>,
     ) {
         file.accept(object : JavaRecursiveElementWalkingVisitor() {
             override fun visitMethodCallExpression(expression: PsiMethodCallExpression) {
-                ArmeriaRouteCollectionMetrics.current()?.methodCallsVisited?.incrementAndGet()
-                val methodName = expression.methodExpression.referenceName
-                if (methodName !in REGISTRATION_METHOD_NAMES) {
-                    super.visitMethodCallExpression(expression)
-                    return
-                }
-                if (!looksLikeArmeriaBuilderCall(expression)) {
-                    super.visitMethodCallExpression(expression)
-                    return
-                }
-                addServiceRegistrationFromCall(expression, routes, seenServiceRegistrations)
+                collectServiceRegistrationFromMethodCall(expression, routes, seenServiceRegistrations)
                 super.visitMethodCallExpression(expression)
             }
         })
+    }
+
+    private fun collectServiceRegistrationFromMethodCall(
+        expression: PsiMethodCallExpression,
+        routes: MutableList<ArmeriaRoute>,
+        seenServiceRegistrations: MutableSet<String>,
+    ) {
+        ArmeriaRouteCollectionMetrics.current()?.methodCallsVisited?.incrementAndGet()
+        val methodName = expression.methodExpression.referenceName
+        if (methodName !in REGISTRATION_METHOD_NAMES) {
+            return
+        }
+        if (!looksLikeArmeriaBuilderCall(expression)) {
+            return
+        }
+        addServiceRegistrationFromCall(expression, routes, seenServiceRegistrations)
     }
 
     internal fun addServiceRegistrationFromCall(
@@ -219,9 +245,6 @@ object ArmeriaRouteCollector {
         seenServiceRegistrations: MutableSet<String>,
     ) {
         val registrationKey = serviceRegistrationKey(expression) ?: return
-        if (!seenServiceRegistrations.add(registrationKey)) {
-            return
-        }
         val methodName = expression.methodExpression.referenceName ?: return
         val arguments = expression.argumentList.expressions
         val path = extractRegistrationPath(methodName, arguments) ?: return
@@ -229,15 +252,43 @@ object ArmeriaRouteCollector {
             "annotatedService" -> arguments.getOrNull(1) ?: arguments.getOrNull(0)
             else -> arguments.getOrNull(1)
         } ?: return
-        val protocol = ArmeriaRouteTargetExtractor.detectProtocol(implementationExpression.text)
         val target = ArmeriaRouteTargetExtractor.extractTarget(implementationExpression)
-        val targetUnresolved = ArmeriaRouteTargetExtractor.isUnresolvedTarget(implementationExpression, target)
+        addServiceRegistrationRoute(
+            element = expression,
+            registrationKey = registrationKey,
+            methodName = methodName,
+            path = path,
+            target = target,
+            targetUnresolved = ArmeriaRouteTargetExtractor.isUnresolvedTarget(implementationExpression, target),
+            implementationText = implementationExpression.text,
+            argumentCount = arguments.size,
+            routes = routes,
+            seenServiceRegistrations = seenServiceRegistrations,
+        )
+    }
+
+    internal fun addServiceRegistrationRoute(
+        element: PsiElement,
+        registrationKey: String,
+        methodName: String,
+        path: String,
+        target: String,
+        targetUnresolved: Boolean,
+        implementationText: String,
+        argumentCount: Int,
+        routes: MutableList<ArmeriaRoute>,
+        seenServiceRegistrations: MutableSet<String>,
+    ) {
+        if (!seenServiceRegistrations.add(registrationKey)) {
+            return
+        }
         val registrationMethod = RegistrationMethod.fromMethodName(methodName) ?: return
+        val protocol = ArmeriaRouteTargetExtractor.detectProtocol(implementationText)
         val routeMatch = resolveRouteMatch(registrationMethod, protocol)
         val annotatedServiceHasPathPrefix =
-            registrationMethod == RegistrationMethod.ANNOTATED_SERVICE && arguments.size > 1
+            registrationMethod == RegistrationMethod.ANNOTATED_SERVICE && argumentCount > 1
         routes += ArmeriaRoute.create(
-            element = expression,
+            element = element,
             protocol = protocol.presentableName(),
             httpMethod = "",
             path = ArmeriaRouteSupport.normalizePath(path),
@@ -322,13 +373,7 @@ object ArmeriaRouteCollector {
         }
     }
 
-    private fun isKotlinPluginAvailable(): Boolean {
-        return try {
-            Class.forName("org.jetbrains.kotlin.idea.KotlinFileType")
-            true
-        } catch (_: ClassNotFoundException) {
-            false
-        }
-    }
+    private fun isKotlinPluginAvailable(): Boolean =
+        PluginManagerCore.isPluginInstalled(KOTLIN_PLUGIN_ID)
 
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
@@ -11,7 +11,6 @@ import com.intellij.psi.JavaRecursiveElementWalkingVisitor
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiJavaFile
 import com.intellij.psi.PsiLiteralExpression
 import com.intellij.psi.PsiManager
@@ -26,7 +25,6 @@ import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.PsiModificationTracker
 import com.intellij.psi.util.PsiTreeUtil
 import com.linecorp.intellij.plugins.armeria.message
-import org.jetbrains.kotlin.psi.KtFile
 
 internal enum class RouteProtocol(private val messageKey: String) {
     HTTP("route.explorer.protocol.http"),
@@ -40,10 +38,7 @@ internal enum class RouteProtocol(private val messageKey: String) {
 
 object ArmeriaRouteCollector {
 
-    private const val ARMERIA_HEADER_SCAN_LIMIT = 4096
     private val KOTLIN_PLUGIN_ID = PluginId.getId("org.jetbrains.kotlin")
-    private val ARMERIA_REFERENCE_PATTERN =
-        Regex("""(?<![\w"])com\.linecorp\.armeria(?:\.[A-Za-z_][A-Za-z0-9_]*)+""")
 
     fun collect(project: Project): List<ArmeriaRoute> {
         val metrics = ArmeriaRouteCollectionMetrics()
@@ -175,7 +170,7 @@ object ArmeriaRouteCollector {
             }
             ArmeriaRouteCollectionMetrics.current()?.filesScanned?.incrementAndGet()
             val psiFile = PsiManager.getInstance(project).findFile(virtualFile) as? PsiJavaFile ?: continue
-            if (!referencesArmeriaContent(psiFile)) {
+            if (!referencesArmeriaJavaContent(psiFile)) {
                 continue
             }
             fallbackScannedFiles += virtualFile
@@ -184,26 +179,16 @@ object ArmeriaRouteCollector {
         }
     }
 
-    internal fun referencesArmeriaContent(file: PsiFile): Boolean {
-        val hasArmeriaImports = when (file) {
-            is PsiJavaFile -> file.importList
-                ?.allImportStatements
-                ?.any { statement ->
-                    statement.importReference?.qualifiedName?.startsWith(ArmeriaRouteSupport.ARMERIA_PACKAGE_PREFIX) == true
-                } ?: false
-
-            is KtFile -> file.importList?.imports?.any { import ->
-                import.importedFqName?.asString()?.startsWith(ArmeriaRouteSupport.ARMERIA_PACKAGE_PREFIX) == true
+    internal fun referencesArmeriaJavaContent(file: PsiJavaFile): Boolean {
+        val hasArmeriaImports = file.importList
+            ?.allImportStatements
+            ?.any { statement ->
+                statement.importReference?.qualifiedName?.startsWith(ArmeriaRouteSupport.ARMERIA_PACKAGE_PREFIX) == true
             } ?: false
-
-            else -> false
-        }
         if (hasArmeriaImports) {
             return true
         }
-        val contents = file.viewProvider.contents
-        val searchWindow = contents.subSequence(0, minOf(contents.length, ARMERIA_HEADER_SCAN_LIMIT))
-        return ARMERIA_REFERENCE_PATTERN.containsMatchIn(searchWindow)
+        return ArmeriaRouteSupport.referencesArmeriaInText(file.viewProvider.contents)
     }
 
     internal fun collectServiceRegistrationsFromJavaFile(
@@ -318,7 +303,7 @@ object ArmeriaRouteCollector {
             return true
         }
         val qualifierText = expression.methodExpression.qualifierExpression?.text ?: return false
-        return qualifierText.contains("Server.builder()") || qualifierText.contains("serverBuilder")
+        return ArmeriaRouteSupport.looksLikeServerBuilderReceiverText(qualifierText)
     }
 
     private fun resolvesToArmeriaServerBuilder(expression: PsiMethodCallExpression): Boolean {

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
@@ -40,11 +40,7 @@ internal enum class RouteProtocol(private val messageKey: String) {
 
 object ArmeriaRouteCollector {
 
-    private const val ARMERIA_PACKAGE_PREFIX = "com.linecorp.armeria"
-    private const val ARMERIA_SERVER_PACKAGE_PREFIX = "com.linecorp.armeria.server"
-    private const val SERVER_BUILDER_CLASS = "com.linecorp.armeria.server.ServerBuilder"
     private const val ARMERIA_HEADER_SCAN_LIMIT = 4096
-    private val REGISTRATION_METHOD_NAMES = setOf("service", "serviceUnder", "annotatedService")
     private val KOTLIN_PLUGIN_ID = PluginId.getId("org.jetbrains.kotlin")
     private val ARMERIA_REFERENCE_PATTERN =
         Regex("""(?<![\w"])com\.linecorp\.armeria(?:\.[A-Za-z_][A-Za-z0-9_]*)+""")
@@ -68,7 +64,7 @@ object ArmeriaRouteCollector {
         val fallbackScannedFiles = linkedSetOf<VirtualFile>()
         val seenServiceRegistrations = mutableSetOf<String>()
         val psiFacade = JavaPsiFacade.getInstance(project)
-        val serverBuilderOnClasspath = psiFacade.findClass(SERVER_BUILDER_CLASS, scope) != null
+        val serverBuilderOnClasspath = psiFacade.findClass(ArmeriaRouteSupport.SERVER_BUILDER_CLASS, scope) != null
 
         collectAnnotatedRoutesIndexed(project, scope, routes)
         collectServiceRegistrationsIndexed(project, scope, routes, seenServiceRegistrations)
@@ -151,8 +147,8 @@ object ArmeriaRouteCollector {
         seenServiceRegistrations: MutableSet<String>,
     ) {
         val psiFacade = JavaPsiFacade.getInstance(project)
-        val builderClass = psiFacade.findClass(SERVER_BUILDER_CLASS, scope) ?: return
-        for (methodName in REGISTRATION_METHOD_NAMES) {
+        val builderClass = psiFacade.findClass(ArmeriaRouteSupport.SERVER_BUILDER_CLASS, scope) ?: return
+        for (methodName in ServiceRegistrationMethod.METHOD_NAMES) {
             for (method in builderClass.findMethodsByName(methodName, false)) {
                 ReferencesSearch.search(method, scope).forEach { reference ->
                     val call = PsiTreeUtil.getParentOfType(reference.element, PsiMethodCallExpression::class.java)
@@ -193,11 +189,11 @@ object ArmeriaRouteCollector {
             is PsiJavaFile -> file.importList
                 ?.allImportStatements
                 ?.any { statement ->
-                    statement.importReference?.qualifiedName?.startsWith(ARMERIA_PACKAGE_PREFIX) == true
+                    statement.importReference?.qualifiedName?.startsWith(ArmeriaRouteSupport.ARMERIA_PACKAGE_PREFIX) == true
                 } ?: false
 
             is KtFile -> file.importList?.imports?.any { import ->
-                import.importedFqName?.asString()?.startsWith(ARMERIA_PACKAGE_PREFIX) == true
+                import.importedFqName?.asString()?.startsWith(ArmeriaRouteSupport.ARMERIA_PACKAGE_PREFIX) == true
             } ?: false
 
             else -> false
@@ -230,7 +226,7 @@ object ArmeriaRouteCollector {
     ) {
         ArmeriaRouteCollectionMetrics.current()?.methodCallsVisited?.incrementAndGet()
         val methodName = expression.methodExpression.referenceName
-        if (methodName !in REGISTRATION_METHOD_NAMES) {
+        if (methodName !in ServiceRegistrationMethod.METHOD_NAMES) {
             return
         }
         if (!looksLikeArmeriaBuilderCall(expression)) {
@@ -248,9 +244,10 @@ object ArmeriaRouteCollector {
         val methodName = expression.methodExpression.referenceName ?: return
         val arguments = expression.argumentList.expressions
         val path = extractRegistrationPath(methodName, arguments) ?: return
-        val implementationExpression = when (methodName) {
-            "annotatedService" -> arguments.getOrNull(1) ?: arguments.getOrNull(0)
-            else -> arguments.getOrNull(1)
+        val implementationExpression = when (ServiceRegistrationMethod.fromMethodName(methodName)) {
+            ServiceRegistrationMethod.ANNOTATED_SERVICE -> arguments.getOrNull(1) ?: arguments.getOrNull(0)
+            ServiceRegistrationMethod.SERVICE, ServiceRegistrationMethod.SERVICE_UNDER -> arguments.getOrNull(1)
+            null -> null
         } ?: return
         val target = ArmeriaRouteTargetExtractor.extractTarget(implementationExpression)
         addServiceRegistrationRoute(
@@ -282,11 +279,11 @@ object ArmeriaRouteCollector {
         if (!seenServiceRegistrations.add(registrationKey)) {
             return
         }
-        val registrationMethod = RegistrationMethod.fromMethodName(methodName) ?: return
+        val registrationMethod = ServiceRegistrationMethod.fromMethodName(methodName) ?: return
         val protocol = ArmeriaRouteTargetExtractor.detectProtocol(implementationText)
         val routeMatch = resolveRouteMatch(registrationMethod, protocol)
         val annotatedServiceHasPathPrefix =
-            registrationMethod == RegistrationMethod.ANNOTATED_SERVICE && argumentCount > 1
+            registrationMethod == ServiceRegistrationMethod.ANNOTATED_SERVICE && argumentCount > 1
         routes += ArmeriaRoute.create(
             element = element,
             protocol = protocol.presentableName(),
@@ -300,14 +297,14 @@ object ArmeriaRouteCollector {
         )
     }
 
-    private fun resolveRouteMatch(registrationMethod: RegistrationMethod, protocol: RouteProtocol): RouteMatch {
+    private fun resolveRouteMatch(registrationMethod: ServiceRegistrationMethod, protocol: RouteProtocol): RouteMatch {
         if (protocol != RouteProtocol.HTTP) {
             return RouteMatch.NON_HTTP
         }
         return when (registrationMethod) {
-            RegistrationMethod.SERVICE -> RouteMatch.SERVICE
-            RegistrationMethod.ANNOTATED_SERVICE -> RouteMatch.ANNOTATED_SERVICE
-            RegistrationMethod.SERVICE_UNDER -> RouteMatch.SERVICE_UNDER
+            ServiceRegistrationMethod.SERVICE -> RouteMatch.SERVICE
+            ServiceRegistrationMethod.ANNOTATED_SERVICE -> RouteMatch.ANNOTATED_SERVICE
+            ServiceRegistrationMethod.SERVICE_UNDER -> RouteMatch.SERVICE_UNDER
         }
     }
 
@@ -327,7 +324,7 @@ object ArmeriaRouteCollector {
     private fun resolvesToArmeriaServerBuilder(expression: PsiMethodCallExpression): Boolean {
         ArmeriaRouteCollectionMetrics.current()?.resolveCount?.incrementAndGet()
         val resolvedClass = expression.resolveMethod()?.containingClass?.qualifiedName
-        return resolvedClass?.startsWith(ARMERIA_SERVER_PACKAGE_PREFIX) == true
+        return resolvedClass?.startsWith(ArmeriaRouteSupport.ARMERIA_SERVER_PACKAGE_PREFIX) == true
     }
 
     private fun buildMethodTarget(psiClass: PsiClass, method: PsiMethod): String {
@@ -335,28 +332,13 @@ object ArmeriaRouteCollector {
         return "$className#${method.name}()"
     }
 
-    private enum class RegistrationMethod {
-        SERVICE,
-        SERVICE_UNDER,
-        ANNOTATED_SERVICE;
-
-        companion object {
-            fun fromMethodName(name: String): RegistrationMethod? {
-                return when (name) {
-                    "service" -> SERVICE
-                    "serviceUnder" -> SERVICE_UNDER
-                    "annotatedService" -> ANNOTATED_SERVICE
-                    else -> null
-                }
-            }
-        }
-    }
-
     private fun extractRegistrationPath(methodName: String, arguments: Array<PsiExpression>): String? {
-        val method = RegistrationMethod.fromMethodName(methodName) ?: return null
-        return when (method) {
-            RegistrationMethod.SERVICE, RegistrationMethod.SERVICE_UNDER -> extractString(arguments.getOrNull(0))
-            RegistrationMethod.ANNOTATED_SERVICE -> if (arguments.size > 1) extractString(arguments.getOrNull(0)) else "/"
+        return when (ServiceRegistrationMethod.fromMethodName(methodName)) {
+            ServiceRegistrationMethod.SERVICE, ServiceRegistrationMethod.SERVICE_UNDER ->
+                extractString(arguments.getOrNull(0))
+            ServiceRegistrationMethod.ANNOTATED_SERVICE ->
+                if (arguments.size > 1) extractString(arguments.getOrNull(0)) else "/"
+            null -> null
         }
     }
 

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
@@ -69,6 +69,9 @@ object ArmeriaRouteCollector {
         if (!serverBuilderOnClasspath) {
             collectServiceRegistrationsFallback(project, scope, routes, fallbackScannedFiles, seenServiceRegistrations)
         }
+        if (isKotlinPluginAvailable()) {
+            ArmeriaKotlinRouteCollector.collect(project, scope, routes, seenServiceRegistrations)
+        }
 
         return CachedValueProvider.Result.create(
             routes.sortedWith(
@@ -94,12 +97,12 @@ object ArmeriaRouteCollector {
                 if (!seenMethods.add(method)) {
                     return@forEach
                 }
-                addAnnotatedRoute(method, routes)
+                addAnnotatedRouteFromMethod(method, routes)
             }
         }
     }
 
-    private fun addAnnotatedRoute(method: PsiMethod, routes: MutableList<ArmeriaRoute>) {
+    internal fun addAnnotatedRouteFromMethod(method: PsiMethod, routes: MutableList<ArmeriaRoute>) {
         val annotation = ArmeriaRouteSupport.findRouteAnnotation(method) ?: return
         val containingClass = method.containingClass ?: return
         val classPrefix =
@@ -145,7 +148,7 @@ object ArmeriaRouteCollector {
                     if (call.methodExpression.referenceName != methodName) {
                         return@forEach
                     }
-                    addServiceRegistration(call, routes, seenServiceRegistrations)
+                    addServiceRegistrationFromCall(call, routes, seenServiceRegistrations)
                 }
             }
         }
@@ -204,13 +207,13 @@ object ArmeriaRouteCollector {
                     super.visitMethodCallExpression(expression)
                     return
                 }
-                addServiceRegistration(expression, routes, seenServiceRegistrations)
+                addServiceRegistrationFromCall(expression, routes, seenServiceRegistrations)
                 super.visitMethodCallExpression(expression)
             }
         })
     }
 
-    private fun addServiceRegistration(
+    internal fun addServiceRegistrationFromCall(
         expression: PsiMethodCallExpression,
         routes: MutableList<ArmeriaRoute>,
         seenServiceRegistrations: MutableSet<String>,
@@ -316,6 +319,15 @@ object ArmeriaRouteCollector {
                     .computeConstantExpression(expression) as? String
                 constantValue ?: expression.text.takeIf { StringUtil.isNotEmpty(it) }
             }
+        }
+    }
+
+    private fun isKotlinPluginAvailable(): Boolean {
+        return try {
+            Class.forName("org.jetbrains.kotlin.idea.KotlinFileType")
+            true
+        } catch (_: ClassNotFoundException) {
+            false
         }
     }
 

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
@@ -374,6 +374,6 @@ object ArmeriaRouteCollector {
     }
 
     private fun isKotlinPluginAvailable(): Boolean =
-        PluginManagerCore.isPluginInstalled(KOTLIN_PLUGIN_ID)
+        PluginManagerCore.isLoaded(KOTLIN_PLUGIN_ID)
 
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
@@ -141,9 +141,22 @@ object ArmeriaRouteSupport {
     }
 
     fun isServerBuilderType(typeText: String): Boolean {
-        return typeText == SERVER_BUILDER_SIMPLE_NAME ||
-            typeText == SERVER_BUILDER_CLASS ||
-            typeText.endsWith(".$SERVER_BUILDER_SIMPLE_NAME")
+        val normalized = normalizeServerBuilderTypeText(typeText)
+        return normalized == SERVER_BUILDER_SIMPLE_NAME ||
+            normalized == SERVER_BUILDER_CLASS ||
+            normalized.endsWith(".$SERVER_BUILDER_SIMPLE_NAME")
+    }
+
+    private fun normalizeServerBuilderTypeText(typeText: String): String {
+        var normalized = typeText.trim().replace(Regex("""/\*.*?\*/"""), "").trim()
+        if (normalized.endsWith('?')) {
+            normalized = normalized.dropLast(1).trim()
+        }
+        val genericStart = normalized.indexOf('<')
+        if (genericStart >= 0) {
+            normalized = normalized.substring(0, genericStart).trim()
+        }
+        return normalized
     }
 
     fun referencesArmeriaInText(contents: CharSequence, scanLimit: Int = ARMERIA_HEADER_SCAN_LIMIT): Boolean {

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
@@ -37,7 +37,8 @@ object ArmeriaRouteSupport {
     private val ARMERIA_REFERENCE_PATTERN =
         Regex("""(?<![\w"])com\.linecorp\.armeria(?:\.[A-Za-z_][A-Za-z0-9_]*)+""")
     private val SERVER_BUILDER_IDENTIFIER = Regex("""(?<![\w"])serverBuilder(?![\w"])""")
-    private val SERVER_BUILDER_CALL = Regex("""(?<![\w"])Server\.builder\(\)""")
+    private val SERVER_BUILDER_CALL =
+        Regex("""(?:com\.linecorp\.armeria\.server\.Server\.builder\(\)|(?<![.\w"])Server\.builder\(\))""")
 
     const val PATH_PREFIX_ANNOTATION = "com.linecorp.armeria.server.annotation.PathPrefix"
     const val DECORATOR_ANNOTATION = "com.linecorp.armeria.server.annotation.Decorator"

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
@@ -8,10 +8,6 @@ import com.intellij.psi.PsiField
 import com.intellij.psi.PsiLiteralExpression
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiVariable
-import org.jetbrains.kotlin.psi.KtClass
-import org.jetbrains.kotlin.psi.KtTypeAlias
-import org.jetbrains.kotlin.psi.KtTypeReference
-import org.jetbrains.kotlin.psi.KtUserType
 
 internal enum class ServiceRegistrationMethod(val methodName: String) {
     SERVICE("service"),
@@ -152,19 +148,6 @@ object ArmeriaRouteSupport {
         return normalized == SERVER_BUILDER_SIMPLE_NAME ||
             normalized == SERVER_BUILDER_CLASS ||
             normalized.endsWith(".$SERVER_BUILDER_SIMPLE_NAME")
-    }
-
-    fun resolveKotlinTypeReferenceText(typeReference: KtTypeReference?): String? {
-        if (typeReference == null) {
-            return null
-        }
-        val userType = typeReference.typeElement as? KtUserType
-        val resolved = userType?.referenceExpression?.references?.firstOrNull()?.resolve()
-        return when (resolved) {
-            is KtTypeAlias -> resolved.getTypeReference()?.text ?: typeReference.text
-            is KtClass -> resolved.fqName?.asString() ?: typeReference.text
-            else -> typeReference.text
-        }
     }
 
     fun evaluateJavaStringConstant(variable: PsiVariable): String? {

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
@@ -31,7 +31,7 @@ object ArmeriaRouteSupport {
     private val ARMERIA_REFERENCE_PATTERN =
         Regex("""(?<![\w"])com\.linecorp\.armeria(?:\.[A-Za-z_][A-Za-z0-9_]*)+""")
     private val SERVER_BUILDER_IDENTIFIER = Regex("""(?<![\w"])serverBuilder(?![\w"])""")
-    private val SERVER_BUILDER_CALL = Regex("""(?<![\w".])Server\.builder\(\)""")
+    private val SERVER_BUILDER_CALL = Regex("""(?<![\w"])Server\.builder\(\)""")
 
     const val PATH_PREFIX_ANNOTATION = "com.linecorp.armeria.server.annotation.PathPrefix"
     const val DECORATOR_ANNOTATION = "com.linecorp.armeria.server.annotation.Decorator"

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
@@ -26,6 +26,11 @@ object ArmeriaRouteSupport {
     const val ARMERIA_SERVER_PACKAGE_PREFIX = "com.linecorp.armeria.server"
     const val SERVER_BUILDER_CLASS = "com.linecorp.armeria.server.ServerBuilder"
     const val SERVER_BUILDER_SIMPLE_NAME = "ServerBuilder"
+    const val ARMERIA_HEADER_SCAN_LIMIT = 4096
+
+    private val ARMERIA_REFERENCE_PATTERN =
+        Regex("""(?<![\w"])com\.linecorp\.armeria(?:\.[A-Za-z_][A-Za-z0-9_]*)+""")
+    private val SERVER_BUILDER_IDENTIFIER = Regex("""(?<![\w"])serverBuilder(?![\w"])""")
 
     const val PATH_PREFIX_ANNOTATION = "com.linecorp.armeria.server.annotation.PathPrefix"
     const val DECORATOR_ANNOTATION = "com.linecorp.armeria.server.annotation.Decorator"
@@ -138,5 +143,14 @@ object ArmeriaRouteSupport {
         return typeText == SERVER_BUILDER_SIMPLE_NAME ||
             typeText == SERVER_BUILDER_CLASS ||
             typeText.endsWith(".$SERVER_BUILDER_SIMPLE_NAME")
+    }
+
+    fun referencesArmeriaInText(contents: CharSequence, scanLimit: Int = ARMERIA_HEADER_SCAN_LIMIT): Boolean {
+        val searchWindow = contents.subSequence(0, minOf(contents.length, scanLimit))
+        return ARMERIA_REFERENCE_PATTERN.containsMatchIn(searchWindow)
+    }
+
+    fun looksLikeServerBuilderReceiverText(text: String): Boolean {
+        return text.contains("Server.builder()") || SERVER_BUILDER_IDENTIFIER.containsMatchIn(text)
     }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
@@ -31,6 +31,7 @@ object ArmeriaRouteSupport {
     private val ARMERIA_REFERENCE_PATTERN =
         Regex("""(?<![\w"])com\.linecorp\.armeria(?:\.[A-Za-z_][A-Za-z0-9_]*)+""")
     private val SERVER_BUILDER_IDENTIFIER = Regex("""(?<![\w"])serverBuilder(?![\w"])""")
+    private val SERVER_BUILDER_CALL = Regex("""(?<![\w".])Server\.builder\(\)""")
 
     const val PATH_PREFIX_ANNOTATION = "com.linecorp.armeria.server.annotation.PathPrefix"
     const val DECORATOR_ANNOTATION = "com.linecorp.armeria.server.annotation.Decorator"
@@ -151,6 +152,6 @@ object ArmeriaRouteSupport {
     }
 
     fun looksLikeServerBuilderReceiverText(text: String): Boolean {
-        return text.contains("Server.builder()") || SERVER_BUILDER_IDENTIFIER.containsMatchIn(text)
+        return SERVER_BUILDER_CALL.containsMatchIn(text) || SERVER_BUILDER_IDENTIFIER.containsMatchIn(text)
     }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
@@ -7,7 +7,26 @@ import com.intellij.psi.PsiArrayInitializerMemberValue
 import com.intellij.psi.PsiLiteralExpression
 import com.intellij.psi.PsiMethod
 
+internal enum class ServiceRegistrationMethod(val methodName: String) {
+    SERVICE("service"),
+    SERVICE_UNDER("serviceUnder"),
+    ANNOTATED_SERVICE("annotatedService"),
+    ;
+
+    companion object {
+        val METHOD_NAMES: Set<String> = entries.mapTo(linkedSetOf()) { it.methodName }
+
+        fun fromMethodName(name: String): ServiceRegistrationMethod? =
+            entries.firstOrNull { it.methodName == name }
+    }
+}
+
 object ArmeriaRouteSupport {
+    const val ARMERIA_PACKAGE_PREFIX = "com.linecorp.armeria"
+    const val ARMERIA_SERVER_PACKAGE_PREFIX = "com.linecorp.armeria.server"
+    const val SERVER_BUILDER_CLASS = "com.linecorp.armeria.server.ServerBuilder"
+    const val SERVER_BUILDER_SIMPLE_NAME = "ServerBuilder"
+
     const val PATH_PREFIX_ANNOTATION = "com.linecorp.armeria.server.annotation.PathPrefix"
     const val DECORATOR_ANNOTATION = "com.linecorp.armeria.server.annotation.Decorator"
     const val EXCEPTION_HANDLER_ANNOTATION = "com.linecorp.armeria.server.annotation.ExceptionHandler"
@@ -113,5 +132,11 @@ object ArmeriaRouteSupport {
         }
         val candidate = path.trim()
         return if (candidate.startsWith("/")) candidate else "/$candidate"
+    }
+
+    fun isServerBuilderType(typeText: String): Boolean {
+        return typeText == SERVER_BUILDER_SIMPLE_NAME ||
+            typeText == SERVER_BUILDER_CLASS ||
+            typeText.endsWith(".$SERVER_BUILDER_SIMPLE_NAME")
     }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
@@ -4,8 +4,14 @@ import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiAnnotationMemberValue
 import com.intellij.psi.PsiArrayInitializerMemberValue
+import com.intellij.psi.PsiField
 import com.intellij.psi.PsiLiteralExpression
 import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiVariable
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtTypeAlias
+import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.KtUserType
 
 internal enum class ServiceRegistrationMethod(val methodName: String) {
     SERVICE("service"),
@@ -145,6 +151,28 @@ object ArmeriaRouteSupport {
         return normalized == SERVER_BUILDER_SIMPLE_NAME ||
             normalized == SERVER_BUILDER_CLASS ||
             normalized.endsWith(".$SERVER_BUILDER_SIMPLE_NAME")
+    }
+
+    fun resolveKotlinTypeReferenceText(typeReference: KtTypeReference?): String? {
+        if (typeReference == null) {
+            return null
+        }
+        val userType = typeReference.typeElement as? KtUserType
+        val resolved = userType?.referenceExpression?.references?.firstOrNull()?.resolve()
+        return when (resolved) {
+            is KtTypeAlias -> resolved.getTypeReference()?.text ?: typeReference.text
+            is KtClass -> resolved.fqName?.asString() ?: typeReference.text
+            else -> typeReference.text
+        }
+    }
+
+    fun evaluateJavaStringConstant(variable: PsiVariable): String? {
+        (variable as? PsiField)?.initializer?.let { initializer ->
+            if (initializer is PsiLiteralExpression) {
+                return initializer.value as? String
+            }
+        }
+        return variable.computeConstantValue() as? String
     }
 
     private fun normalizeServerBuilderTypeText(typeText: String): String {

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
@@ -149,6 +149,7 @@ object ArmeriaRouteSupport {
 
     private fun normalizeServerBuilderTypeText(typeText: String): String {
         var normalized = typeText.trim().replace(Regex("""/\*.*?\*/"""), "").trim()
+        normalized = stripLeadingKotlinTypeAnnotations(normalized)
         if (normalized.endsWith('?')) {
             normalized = normalized.dropLast(1).trim()
         }
@@ -157,6 +158,32 @@ object ArmeriaRouteSupport {
             normalized = normalized.substring(0, genericStart).trim()
         }
         return normalized
+    }
+
+    private fun stripLeadingKotlinTypeAnnotations(typeText: String): String {
+        var remaining = typeText.trimStart()
+        while (remaining.startsWith('@')) {
+            var index = 1
+            var depth = 0
+            while (index < remaining.length) {
+                when (val char = remaining[index]) {
+                    '(' -> depth++
+                    ')' -> {
+                        depth--
+                        if (depth == 0) {
+                            index++
+                            break
+                        }
+                    }
+                    ' ', '\t', '\n' -> if (depth == 0) {
+                        break
+                    }
+                }
+                index++
+            }
+            remaining = remaining.substring(index).trimStart()
+        }
+        return remaining
     }
 
     fun referencesArmeriaInText(contents: CharSequence, scanLimit: Int = ARMERIA_HEADER_SCAN_LIMIT): Boolean {

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaMethodEntryPoint.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaMethodEntryPoint.kt
@@ -6,6 +6,7 @@ import com.intellij.codeInspection.reference.RefElement
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiMethod
 import com.intellij.util.xmlb.XmlSerializer
+import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteSupport
 import com.linecorp.intellij.plugins.armeria.message
 import org.jdom.Element
 
@@ -17,16 +18,11 @@ class ArmeriaMethodEntryPoint(
     override fun isEntryPoint(refElement: RefElement, psiElement: PsiElement) = isEntryPoint(psiElement)
 
     override fun isEntryPoint(psiElement: PsiElement): Boolean {
-        return psiElement is PsiMethod && AnnotationUtil.isAnnotated(psiElement, listOf(
-            "com.linecorp.armeria.server.annotation.Get",
-            "com.linecorp.armeria.server.annotation.Head",
-            "com.linecorp.armeria.server.annotation.Post",
-            "com.linecorp.armeria.server.annotation.Put",
-            "com.linecorp.armeria.server.annotation.Delete",
-            "com.linecorp.armeria.server.annotation.Options",
-            "com.linecorp.armeria.server.annotation.Patch",
-            "com.linecorp.armeria.server.annotation.Trace",
-        ), AnnotationUtil.CHECK_TYPE)
+        return psiElement is PsiMethod && AnnotationUtil.isAnnotated(
+            psiElement,
+            ArmeriaRouteSupport.routeAnnotations.keys.toList(),
+            AnnotationUtil.CHECK_TYPE,
+        )
     }
 
     override fun isSelected(): Boolean = wasSelected

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaMethodEntryPoint.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaMethodEntryPoint.kt
@@ -20,7 +20,7 @@ class ArmeriaMethodEntryPoint(
     override fun isEntryPoint(psiElement: PsiElement): Boolean {
         return psiElement is PsiMethod && AnnotationUtil.isAnnotated(
             psiElement,
-            ArmeriaRouteSupport.routeAnnotations.keys.toList(),
+            ArmeriaRouteSupport.routeAnnotations.keys,
             AnnotationUtil.CHECK_TYPE,
         )
     }

--- a/plugin/src/main/resources/META-INF/kotlin-integration.xml
+++ b/plugin/src/main/resources/META-INF/kotlin-integration.xml
@@ -1,0 +1,2 @@
+<idea-plugin>
+</idea-plugin>

--- a/plugin/src/main/resources/META-INF/kotlin-integration.xml
+++ b/plugin/src/main/resources/META-INF/kotlin-integration.xml
@@ -1,2 +1,3 @@
 <idea-plugin>
+    <supportsKotlinPluginMode supportsK2="true"/>
 </idea-plugin>

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -5,6 +5,7 @@
 
     <depends>com.intellij.java</depends>
     <depends>org.jetbrains.plugins.gradle</depends>
+    <depends optional="true" config-file="kotlin-integration.xml">org.jetbrains.kotlin</depends>
     <depends optional="true" config-file="grpc-integration.xml">com.intellij.grpc</depends>
     <depends optional="true" config-file="proto-integration.xml">idea.plugin.protoeditor</depends>
 

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorTest.kt
@@ -1,0 +1,43 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+
+class ArmeriaKotlinRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
+    override fun setUp() {
+        super.setUp()
+        registerArmeriaStubs()
+    }
+
+    fun testCollectAnnotatedRouteFromKotlinLightMethod() {
+        myFixture.configureByText(
+            "HelloService.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.annotation.Get
+
+            class HelloService {
+                @Get("/hello")
+                fun hello(): String = "hello"
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+        val kotlinRoute = routes.firstOrNull { it.path == "/hello" && it.httpMethod == "GET" }
+        assertNotNull("Expected Kotlin annotated route to be discovered", kotlinRoute)
+    }
+
+    private fun registerArmeriaStubs() {
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.server.annotation;
+
+            public @interface Get {
+                String value() default "";
+                String path() default "";
+            }
+            """.trimIndent(),
+        )
+    }
+}

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorTest.kt
@@ -276,6 +276,238 @@ class ArmeriaKotlinRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
         assertNull(routes.firstOrNull { it.path == "/oops" })
     }
 
+    fun testCollectServiceRegistrationWithNamedArgumentsReversedOrder() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder()
+                    .service(service = HelloService(), path = "/api")
+                    .build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
+        assertNotNull(serviceRoute)
+        assertEquals("example.HelloService", serviceRoute!!.target)
+    }
+
+    fun testCollectServiceRegistrationInApplyBlock() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder().apply {
+                    service("/api", HelloService())
+                }.build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
+        assertNotNull(serviceRoute)
+        assertEquals("example.HelloService", serviceRoute!!.target)
+    }
+
+    fun testCollectServiceRegistrationWithConstValPath() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            private const val API_PATH = "/api"
+
+            fun main() {
+                Server.builder()
+                    .service(API_PATH, HelloService())
+                    .build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
+        assertNotNull(serviceRoute)
+    }
+
+    fun testCollectServiceUnderRegistration() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder()
+                    .serviceUnder("/v1", HelloService())
+                    .build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val serviceRoute = routes.firstOrNull { it.routeMatch == RouteMatch.SERVICE_UNDER }
+        assertNotNull(serviceRoute)
+        assertEquals("/v1", serviceRoute!!.path)
+        assertEquals("example.HelloService", serviceRoute.target)
+    }
+
+    fun testCollectAnnotatedServiceWithPathPrefix() {
+        myFixture.configureByText(
+            "HelloService.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.annotation.Get
+
+            class HelloService {
+                @Get("/hello")
+                fun hello(): String = "hello"
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder()
+                    .annotatedService("/v1", HelloService())
+                    .build()
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val registrationRoute = routes.firstOrNull { it.routeMatch == RouteMatch.ANNOTATED_SERVICE }
+        assertNotNull(registrationRoute)
+        assertEquals("/v1", registrationRoute!!.path)
+        assertTrue(registrationRoute.annotatedServiceHasPathPrefix)
+    }
+
+    fun testNoFalsePositiveForMisleadingServerBuilderTypeName() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder().build()
+                val helper = MyServerBuilderHelper()
+                helper.service("/oops", Any())
+            }
+
+            class MyServerBuilderHelper {
+                fun service(path: String, handler: Any) {}
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        assertNull(routes.firstOrNull { it.path == "/oops" })
+    }
+
+    fun testCollectUnresolvedParenthesizedNewExpressionTarget() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder()
+                    .service("/api", (MissingService()))
+                    .build()
+            }
+            """.trimIndent(),
+        )
+
+        val serviceRoute = ArmeriaRouteCollector.collect(project).firstOrNull { it.path == "/api" }
+        assertNotNull(serviceRoute)
+        assertTrue(serviceRoute!!.targetUnresolved)
+    }
+
+    fun testCollectUnresolvedFactoryMethodTarget() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder()
+                    .service("/api", createMissingService())
+                    .build()
+            }
+
+            private fun createMissingService(): Any = MissingService()
+            """.trimIndent(),
+        )
+
+        val serviceRoute = ArmeriaRouteCollector.collect(project).firstOrNull { it.path == "/api" }
+        assertNotNull(serviceRoute)
+        assertTrue(serviceRoute!!.targetUnresolved)
+    }
+
     private fun registerArmeriaStubs() {
         myFixture.addClass(
             """

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorTest.kt
@@ -338,6 +338,83 @@ class ArmeriaKotlinRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
         assertEquals("example.HelloService", serviceRoute!!.target)
     }
 
+    fun testCollectServiceRegistrationInAlsoBlockWithExplicitReceiver() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder().also {
+                    it.service("/api", HelloService())
+                }.build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
+        assertNotNull(serviceRoute)
+        assertEquals("example.HelloService", serviceRoute!!.target)
+    }
+
+    fun testNoFalsePositiveForUnqualifiedServiceCallInAlsoBlock() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder().also {
+                    service("/oops", Any())
+                }.build()
+            }
+
+            private fun service(path: String, handler: Any) {}
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        assertNull(routes.firstOrNull { it.path == "/oops" })
+    }
+
+    fun testNoFalsePositiveForUnqualifiedServiceCallInLetBlock() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder().let {
+                    service("/oops", Any())
+                }.build()
+            }
+
+            private fun service(path: String, handler: Any) {}
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        assertNull(routes.firstOrNull { it.path == "/oops" })
+    }
+
     fun testCollectServiceRegistrationWithConstValPath() {
         myFixture.configureByText(
             "Main.kt",

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorTest.kt
@@ -798,7 +798,7 @@ class ArmeriaKotlinRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
             fun main() {
                 val sb: ServerBuilder? = Server.builder()
                 sb!!.service("/api", HelloService())
-                sb.build()
+                sb!!.build()
             }
             """.trimIndent(),
         )

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorTest.kt
@@ -24,8 +24,256 @@ class ArmeriaKotlinRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
         )
 
         val routes = ArmeriaRouteCollector.collect(project)
-        val kotlinRoute = routes.firstOrNull { it.path == "/hello" && it.httpMethod == "GET" }
-        assertNotNull("Expected Kotlin annotated route to be discovered", kotlinRoute)
+
+        assertEquals(1, routes.size)
+        val route = routes.single()
+        assertEquals("/hello", route.path)
+        assertEquals("GET", route.httpMethod)
+        assertEquals(RouteMatch.ANNOTATED_HTTP, route.routeMatch)
+        assertTrue(route.target.contains("HelloService#hello"))
+    }
+
+    fun testCollectServiceRegistrationFromBuilderVariable() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+            import com.linecorp.armeria.server.ServerBuilder
+
+            fun main() {
+                val sb: ServerBuilder = Server.builder()
+                sb.service("/api", HelloService())
+                sb.build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
+        assertNotNull(serviceRoute)
+        assertEquals("example.HelloService", serviceRoute!!.target)
+    }
+
+    fun testCollectServiceRegistration() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder()
+                    .service("/api", HelloService())
+                    .build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Get;
+
+            public class HelloService {
+                @Get("/internal")
+                public String internal() {
+                    return "ok";
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
+        assertNotNull(serviceRoute)
+        assertEquals("/api", serviceRoute!!.path)
+        assertEquals("example.HelloService", serviceRoute.target)
+    }
+
+    fun testCollectGrpcServiceRegistrationWithBuild() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+            import com.linecorp.armeria.server.grpc.GrpcService
+
+            fun main() {
+                Server.builder()
+                    .service("/grpc", GrpcService.builder(HelloGrpcService()).build())
+                    .build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloGrpcService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val grpcRoute = routes.firstOrNull { it.routeMatch == RouteMatch.NON_HTTP }
+        assertNotNull(grpcRoute)
+        assertEquals("example.HelloGrpcService", grpcRoute!!.target)
+        assertFalse(grpcRoute.target.equals("build", ignoreCase = true))
+    }
+
+    fun testCollectDocServiceRegistrationWithBuild() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+            import com.linecorp.armeria.server.docs.DocService
+
+            fun main() {
+                Server.builder()
+                    .service("/docs", DocService.builder().build())
+                    .build()
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val docRoute = routes.firstOrNull { it.isDocService }
+        assertNotNull(docRoute)
+        assertEquals("com.linecorp.armeria.server.docs.DocService", docRoute!!.target)
+    }
+
+    fun testCollectUnresolvedNewExpressionTarget() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder()
+                    .service("/api", MissingService())
+                    .build()
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val serviceRoute = routes.firstOrNull { it.path == "/api" }
+        assertNotNull(serviceRoute)
+        assertTrue(serviceRoute!!.targetUnresolved)
+    }
+
+    fun testCollectAnnotatedServiceRegistration() {
+        myFixture.configureByText(
+            "HelloService.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.annotation.Get
+
+            class HelloService {
+                @Get("/hello")
+                fun hello(): String = "hello"
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder()
+                    .annotatedService(HelloService())
+                    .build()
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val registrationRoute = routes.firstOrNull { it.routeMatch == RouteMatch.ANNOTATED_SERVICE }
+        assertNotNull(registrationRoute)
+        assertEquals("/", registrationRoute!!.path)
+        assertFalse(registrationRoute.annotatedServiceHasPathPrefix)
+        assertEquals(
+            "Server.builder().annotatedService(…)",
+            ArmeriaRouteDetailFormatter.registrationSummary(registrationRoute),
+        )
+
+        val annotatedMethodRoute = routes.firstOrNull { it.path == "/hello" }
+        assertNotNull(annotatedMethodRoute)
+        assertEquals(RouteMatch.ANNOTATED_HTTP, annotatedMethodRoute!!.routeMatch)
+    }
+
+    fun testCollectPathPrefix() {
+        myFixture.configureByText(
+            "PrefixedService.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.annotation.Get
+            import com.linecorp.armeria.server.annotation.PathPrefix
+
+            @PathPrefix("/v1")
+            class PrefixedService {
+                @Get("/items")
+                fun items(): String = "items"
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        assertEquals(1, routes.size)
+        assertEquals("/v1/items", routes.single().path)
+    }
+
+    fun testNoFalsePositiveForUnrelatedServiceCall() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder()
+                    .build()
+                Client.service("/oops", Any())
+            }
+
+            object Client {
+                fun service(path: String, handler: Any) {}
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        assertNull(routes.firstOrNull { it.path == "/oops" })
     }
 
     private fun registerArmeriaStubs() {
@@ -36,6 +284,93 @@ class ArmeriaKotlinRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
             public @interface Get {
                 String value() default "";
                 String path() default "";
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.server.annotation;
+
+            public @interface PathPrefix {
+                String value();
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.server;
+
+            public final class Server {
+                public static ServerBuilder builder() {
+                    return null;
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.server;
+
+            public final class ServerBuilder {
+                public ServerBuilder service(String path, Object service) {
+                    return this;
+                }
+
+                public ServerBuilder serviceUnder(String prefix, Object service) {
+                    return this;
+                }
+
+                public ServerBuilder annotatedService(Object service) {
+                    return this;
+                }
+
+                public com.linecorp.armeria.server.Server build() {
+                    return null;
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.server.grpc;
+
+            public final class GrpcService {
+                public static GrpcServiceBuilder builder(Object bindableService) {
+                    return null;
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.server.grpc;
+
+            public final class GrpcServiceBuilder {
+                public com.linecorp.armeria.server.grpc.GrpcService build() {
+                    return null;
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.server.docs;
+
+            public final class DocService {
+                public static DocServiceBuilder builder() {
+                    return null;
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.server.docs;
+
+            public final class DocServiceBuilder {
+                public com.linecorp.armeria.server.docs.DocService build() {
+                    return null;
+                }
             }
             """.trimIndent(),
         )

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorTest.kt
@@ -641,6 +641,29 @@ class ArmeriaKotlinRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
         assertNull(routes.firstOrNull { it.path == "/oops" })
     }
 
+    fun testCollectServiceRegistrationFromFullyQualifiedServerBuilder() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            fun main() {
+                com.linecorp.armeria.server.Server.builder()
+                    .service("/api", Any())
+                    .build()
+            }
+            """.trimIndent(),
+        )
+
+        val serviceRoute = ArmeriaRouteCollector.collect(project)
+            .firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
+        assertNotNull(serviceRoute)
+        assertEquals(
+            "Server.builder().service(\"/api\", …)",
+            ArmeriaRouteDetailFormatter.registrationSummary(serviceRoute!!),
+        )
+    }
+
     fun testResolvedConstructorTargetIsNotMarkedUnresolved() {
         myFixture.configureByText(
             "Main.kt",

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorTest.kt
@@ -764,6 +764,59 @@ class ArmeriaKotlinRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
         assertTrue(serviceRoute!!.targetUnresolved)
     }
 
+    fun testCollectUnresolvedGrpcServiceBuilderTarget() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+            import com.linecorp.armeria.server.grpc.GrpcService
+
+            fun main() {
+                Server.builder()
+                    .service("/grpc", GrpcService.builder(MissingService()).build())
+                    .build()
+            }
+            """.trimIndent(),
+        )
+
+        val serviceRoute = ArmeriaRouteCollector.collect(project).firstOrNull { it.path == "/grpc" }
+        assertNotNull(serviceRoute)
+        assertTrue(serviceRoute!!.targetUnresolved)
+    }
+
+    fun testCollectServiceRegistrationFromNullableServerBuilderVariable() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+            import com.linecorp.armeria.server.ServerBuilder
+
+            fun main() {
+                val sb: ServerBuilder? = Server.builder()
+                sb!!.service("/api", HelloService())
+                sb.build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val serviceRoute = ArmeriaRouteCollector.collect(project)
+            .firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
+        assertNotNull(serviceRoute)
+        assertEquals("example.HelloService", serviceRoute!!.target)
+    }
+
     private fun registerArmeriaStubs() {
         myFixture.addClass(
             """

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorTest.kt
@@ -988,6 +988,78 @@ class ArmeriaKotlinRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
         assertEquals("example.HelloService", serviceRoute!!.target)
     }
 
+    fun testCollectServiceRegistrationFromParenthesizedServerBuilderReceiver() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+            import com.linecorp.armeria.server.ServerBuilder
+
+            fun main() {
+                val sb: ServerBuilder = Server.builder()
+                (sb).service("/api", HelloService())
+                sb.build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val serviceRoute = ArmeriaRouteCollector.collect(project)
+            .firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
+        assertNotNull(serviceRoute)
+        assertEquals("example.HelloService", serviceRoute!!.target)
+    }
+
+    fun testNoFalsePositiveForNonArmeriaQualifiedServerBuilder() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder().build()
+                com.foo.Server.builder()
+                    .service("/oops", Any())
+                    .build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package com.foo;
+
+            public final class Server {
+                public static FakeBuilder builder() {
+                    return null;
+                }
+            }
+
+            class FakeBuilder {
+                public FakeBuilder service(String path, Object handler) {
+                    return this;
+                }
+
+                public void build() {}
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        assertNull(routes.firstOrNull { it.path == "/oops" })
+    }
+
     private fun registerArmeriaStubs() {
         myFixture.addClass(
             """

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorTest.kt
@@ -882,6 +882,112 @@ class ArmeriaKotlinRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
         assertFalse(serviceRoute.targetUnresolved)
     }
 
+    fun testCollectServiceRegistrationWithJavaStaticFinalPath() {
+        myFixture.addClass(
+            """
+            package example;
+
+            public final class Routes {
+                public static final String API_PATH = "/api";
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder()
+                    .service(Routes.API_PATH, HelloService())
+                    .build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val serviceRoute = ArmeriaRouteCollector.collect(project)
+            .firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
+        assertNotNull(serviceRoute)
+    }
+
+    fun testCollectServiceRegistrationFromServerBuilderExtensionFunction() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+            import com.linecorp.armeria.server.ServerBuilder
+
+            fun ServerBuilder.configure() {
+                service("/api", HelloService())
+            }
+
+            fun main() {
+                Server.builder()
+                    .configure()
+                    .build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val serviceRoute = ArmeriaRouteCollector.collect(project)
+            .firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
+        assertNotNull(serviceRoute)
+        assertEquals("example.HelloService", serviceRoute!!.target)
+    }
+
+    fun testCollectServiceRegistrationFromServerBuilderTypeAlias() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+            import com.linecorp.armeria.server.ServerBuilder
+
+            typealias SB = ServerBuilder
+
+            fun main() {
+                val sb: SB = Server.builder()
+                sb.service("/api", HelloService())
+                sb.build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val serviceRoute = ArmeriaRouteCollector.collect(project)
+            .firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
+        assertNotNull(serviceRoute)
+        assertEquals("example.HelloService", serviceRoute!!.target)
+    }
+
     private fun registerArmeriaStubs() {
         myFixture.addClass(
             """

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorTest.kt
@@ -464,6 +464,31 @@ class ArmeriaKotlinRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
         assertNull(routes.firstOrNull { it.path == "/oops" })
     }
 
+    fun testNoFalsePositiveForServerBuilderNamedNonArmeriaVariable() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder().build()
+                val serverBuilderHelper = FakeBuilder()
+                serverBuilderHelper.service("/oops", Any())
+            }
+
+            class FakeBuilder {
+                fun service(path: String, handler: Any) {}
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        assertNull(routes.firstOrNull { it.path == "/oops" })
+    }
+
     fun testCollectUnresolvedParenthesizedNewExpressionTarget() {
         myFixture.configureByText(
             "Main.kt",
@@ -553,6 +578,10 @@ class ArmeriaKotlinRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
                 }
 
                 public ServerBuilder annotatedService(Object service) {
+                    return this;
+                }
+
+                public ServerBuilder annotatedService(String prefix, Object service) {
                     return this;
                 }
 

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorTest.kt
@@ -817,6 +817,71 @@ class ArmeriaKotlinRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
         assertEquals("example.HelloService", serviceRoute!!.target)
     }
 
+    fun testCollectServiceRegistrationFromAnnotatedServerBuilderVariable() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+            import com.linecorp.armeria.server.ServerBuilder
+
+            annotation class Ann
+
+            fun main() {
+                val sb: @Ann ServerBuilder? = Server.builder()
+                sb!!.service("/api", HelloService())
+                sb!!.build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val serviceRoute = ArmeriaRouteCollector.collect(project)
+            .firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
+        assertNotNull(serviceRoute)
+        assertEquals("example.HelloService", serviceRoute!!.target)
+        assertFalse(serviceRoute.targetUnresolved)
+    }
+
+    fun testCollectServiceRegistrationWithKotlinDefinedServiceClass() {
+        myFixture.configureByText(
+            "HelloService.kt",
+            """
+            package example
+
+            class HelloService
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder()
+                    .service("/api", HelloService())
+                    .build()
+            }
+            """.trimIndent(),
+        )
+
+        val serviceRoute = ArmeriaRouteCollector.collect(project)
+            .firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
+        assertNotNull(serviceRoute)
+        assertEquals("example.HelloService", serviceRoute!!.target)
+        assertFalse(serviceRoute.targetUnresolved)
+    }
+
     private fun registerArmeriaStubs() {
         myFixture.addClass(
             """

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorTest.kt
@@ -402,6 +402,75 @@ class ArmeriaKotlinRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
         assertEquals("example.HelloService", serviceRoute.target)
     }
 
+    fun testCollectServiceUnderRegistrationWithPathPrefixNamedArgument() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder()
+                    .serviceUnder(service = HelloService(), pathPrefix = "/v1")
+                    .build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val serviceRoute = routes.firstOrNull { it.routeMatch == RouteMatch.SERVICE_UNDER }
+        assertNotNull(serviceRoute)
+        assertEquals("/v1", serviceRoute!!.path)
+        assertEquals("example.HelloService", serviceRoute.target)
+    }
+
+    fun testCollectAnnotatedServiceWithPathPrefixNamedArgument() {
+        myFixture.configureByText(
+            "HelloService.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.annotation.Get
+
+            class HelloService {
+                @Get("/hello")
+                fun hello(): String = "hello"
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder()
+                    .annotatedService(service = HelloService(), pathPrefix = "/v1")
+                    .build()
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val registrationRoute = routes.firstOrNull { it.routeMatch == RouteMatch.ANNOTATED_SERVICE }
+        assertNotNull(registrationRoute)
+        assertEquals("/v1", registrationRoute!!.path)
+        assertTrue(registrationRoute.annotatedServiceHasPathPrefix)
+    }
+
     fun testCollectAnnotatedServiceWithPathPrefix() {
         myFixture.configureByText(
             "HelloService.kt",
@@ -462,6 +531,68 @@ class ArmeriaKotlinRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
         val routes = ArmeriaRouteCollector.collect(project)
 
         assertNull(routes.firstOrNull { it.path == "/oops" })
+    }
+
+    fun testNoFalsePositiveForMyServerBuilderCall() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder().build()
+                MyServer.builder()
+                    .service("/oops", Any())
+                    .build()
+            }
+
+            object MyServer {
+                fun builder(): FakeBuilder = FakeBuilder()
+            }
+
+            class FakeBuilder {
+                fun service(path: String, handler: Any): FakeBuilder = this
+                fun build() {}
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        assertNull(routes.firstOrNull { it.path == "/oops" })
+    }
+
+    fun testResolvedConstructorTargetIsNotMarkedUnresolved() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder()
+                    .service("/api", HelloService())
+                    .build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val serviceRoute = ArmeriaRouteCollector.collect(project)
+            .firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
+        assertNotNull(serviceRoute)
+        assertEquals("example.HelloService", serviceRoute!!.target)
+        assertFalse(serviceRoute.targetUnresolved)
     }
 
     fun testNoFalsePositiveForServerBuilderNamedNonArmeriaVariable() {
@@ -573,7 +704,7 @@ class ArmeriaKotlinRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
                     return this;
                 }
 
-                public ServerBuilder serviceUnder(String prefix, Object service) {
+                public ServerBuilder serviceUnder(String pathPrefix, Object service) {
                     return this;
                 }
 
@@ -581,7 +712,7 @@ class ArmeriaKotlinRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
                     return this;
                 }
 
-                public ServerBuilder annotatedService(String prefix, Object service) {
+                public ServerBuilder annotatedService(String pathPrefix, Object service) {
                     return this;
                 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Kotlin source support to the Armeria Route Explorer.

- Discovers annotated HTTP routes from Kotlin classes via indexed `AnnotatedElementsSearch` (no duplicate Kotlin walk)
- Detects `Server.builder().service()`, `serviceUnder()`, and `annotatedService()` in Kotlin via a fallback scanner that delegates to shared route-building logic
- Adds optional Kotlin plugin dependency, K2 compatibility, and bundled Kotlin plugin for compilation

## Latest fix (round 10)

- **Optional Kotlin dependency (M3):** Moved `resolveKotlinTypeReferenceText` from always-loaded `ArmeriaRouteSupport` into `ArmeriaKotlinRouteCollector`, so Java-only features no longer hard-link Kotlin PSI types when the Kotlin plugin is disabled

## Test plan

- [x] `./gradlew :plugin:compileKotlin :plugin:test`
- [x] Added regression tests for non-Armeria FQCN `Server.builder()` guard and parenthesized `ServerBuilder` receivers
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2021-9dd6-73e2-bdb9-83969a21a5fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2021-9dd6-73e2-bdb9-83969a21a5fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

