### PR TITLE
feat: project-wide duplicate route inspection

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 ### Added
 - Implemented Armeria run configuration with module classpath and main class selection.
-- Added project-wide duplicate route registration inspection for ServerBuilder and annotated routes.
+- Added project-wide duplicate route registration inspection for ServerBuilder and annotated routes, with module-scoped caching and cross-registration conflict detection.
 - Added Kotlin source support to Route Explorer for annotated services and Server.builder registrations.
 - Added Velocity-based regression tests for New Project Wizard file templates.
 - Added `plugin/src/test/resources/wizard-verification-matrix.md` documenting representative wizard scenarios.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Added
 - Implemented Armeria run configuration with module classpath and main class selection.
+- Added project-wide duplicate route registration inspection for ServerBuilder and annotated routes.
 - Added Kotlin source support to Route Explorer for annotated services and Server.builder registrations.
 - Added Velocity-based regression tests for New Project Wizard file templates.
 - Added `plugin/src/test/resources/wizard-verification-matrix.md` documenting representative wizard scenarios.

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndex.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndex.kt
@@ -40,11 +40,11 @@ internal object ArmeriaRouteDuplicateIndex {
 
     internal fun findDuplicateGroups(routes: List<ArmeriaRoute>): List<DuplicateRegistrationGroup> {
         val groups = mutableListOf<DuplicateRegistrationGroup>()
-        for ((_, bucketRoutes) in routes.filter { it.routeMatch in CHECKED_MATCHES }.groupBy { BucketKey(it.moduleName, it.path) }) {
-            if (bucketRoutes.size < 2) {
+        for ((_, moduleRoutes) in routes.filter { it.routeMatch in CHECKED_MATCHES }.groupBy { it.moduleName }) {
+            if (moduleRoutes.size < 2) {
                 continue
             }
-            for (component in findConnectedComponents(bucketRoutes)) {
+            for (component in findConnectedComponents(moduleRoutes)) {
                 if (component.size < 2 || isJavaInClassAnnotatedHttpOnly(component)) {
                     continue
                 }
@@ -88,7 +88,7 @@ internal object ArmeriaRouteDuplicateIndex {
 
         for (first in routes.indices) {
             for (second in first + 1 until routes.size) {
-                if (httpMethodsOverlap(routes[first], routes[second])) {
+                if (routesOverlap(routes[first], routes[second]) && httpMethodsOverlap(routes[first], routes[second])) {
                     union(first, second)
                 }
             }
@@ -118,6 +118,41 @@ internal object ArmeriaRouteDuplicateIndex {
             }
         }
         return true
+    }
+
+    private fun routesOverlap(first: ArmeriaRoute, second: ArmeriaRoute): Boolean =
+        pathsOverlap(first.path, first.routeMatch, second.path, second.routeMatch)
+
+    private fun pathsOverlap(
+        firstPath: String,
+        firstMatch: RouteMatch,
+        secondPath: String,
+        secondMatch: RouteMatch,
+    ): Boolean {
+        val firstIsPrefixMount = isPrefixMount(firstMatch)
+        val secondIsPrefixMount = isPrefixMount(secondMatch)
+        return when {
+            firstIsPrefixMount && secondIsPrefixMount ->
+                pathIsUnder(firstPath, secondPath) || pathIsUnder(secondPath, firstPath)
+            firstIsPrefixMount -> pathIsUnder(secondPath, firstPath)
+            secondIsPrefixMount -> pathIsUnder(firstPath, secondPath)
+            else -> firstPath == secondPath
+        }
+    }
+
+    private fun isPrefixMount(routeMatch: RouteMatch): Boolean =
+        routeMatch == RouteMatch.SERVICE_UNDER || routeMatch == RouteMatch.ANNOTATED_SERVICE
+
+    private fun pathIsUnder(path: String, prefix: String): Boolean {
+        val normalizedPath = ArmeriaRouteSupport.normalizePath(path)
+        val normalizedPrefix = ArmeriaRouteSupport.normalizePath(prefix)
+        if (normalizedPrefix == "/") {
+            return true
+        }
+        if (normalizedPath == normalizedPrefix) {
+            return true
+        }
+        return normalizedPath.startsWith("${normalizedPrefix.removeSuffix("/")}/")
     }
 
     private fun httpMethodsOverlap(first: ArmeriaRoute, second: ArmeriaRoute): Boolean {
@@ -156,7 +191,7 @@ internal object ArmeriaRouteDuplicateIndex {
     }
 
     private fun overlappingRouteCount(route: ArmeriaRoute, routes: List<ArmeriaRoute>): Int =
-        routes.count { httpMethodsOverlap(route, it) }
+        routes.count { routesOverlap(route, it) && httpMethodsOverlap(route, it) }
 
     private fun registrationLabel(route: ArmeriaRoute): String =
         when (route.routeMatch) {
@@ -164,11 +199,6 @@ internal object ArmeriaRouteDuplicateIndex {
             else -> route.path
         }
 }
-
-private data class BucketKey(
-    val moduleName: String,
-    val path: String,
-)
 
 internal data class DuplicateRegistrationGroup(
     val routes: List<ArmeriaRoute>,

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndex.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndex.kt
@@ -160,14 +160,19 @@ internal object ArmeriaRouteDuplicateIndex {
 
     private fun pathIsUnder(path: String, prefix: String): Boolean {
         val normalizedPath = ArmeriaRouteSupport.normalizePath(path)
-        val normalizedPrefix = ArmeriaRouteSupport.normalizePath(prefix)
+        val normalizedPrefix = normalizePrefixMount(prefix)
         if (normalizedPrefix == "/") {
             return true
         }
-        if (normalizedPath == normalizedPrefix) {
+        if (normalizedPath == normalizedPrefix || normalizedPath.removeSuffix("/") == normalizedPrefix) {
             return true
         }
-        return normalizedPath.startsWith("${normalizedPrefix.removeSuffix("/")}/")
+        return normalizedPath.startsWith("$normalizedPrefix/")
+    }
+
+    private fun normalizePrefixMount(prefix: String): String {
+        val normalized = ArmeriaRouteSupport.normalizePath(prefix)
+        return if (normalized == "/") "/" else normalized.removeSuffix("/")
     }
 
     private fun httpMethodsOverlap(first: ArmeriaRoute, second: ArmeriaRoute): Boolean {

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndex.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndex.kt
@@ -1,6 +1,8 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
+import com.intellij.lang.java.JavaLanguage
 import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiMethod
@@ -15,7 +17,7 @@ import com.intellij.psi.util.PsiModificationTracker
  * `.annotatedService` registrations. Excludes non-HTTP protocols such as gRPC.
  *
  * Cross-registration conflicts are detected, for example `@Get("/foo")` versus
- * `.service("/foo", …)`. In-class annotated duplicate HTTP routes are excluded because
+ * `.service("/foo", …)`. Java in-class annotated duplicate HTTP routes are excluded because
  * [com.linecorp.intellij.plugins.armeria.inspection.ArmeriaDuplicateRouteInspection] covers them.
  */
 internal object ArmeriaRouteDuplicateIndex {
@@ -41,7 +43,7 @@ internal object ArmeriaRouteDuplicateIndex {
                 continue
             }
             for (component in findConnectedComponents(bucketRoutes)) {
-                if (component.size < 2 || isInClassAnnotatedHttpOnly(component)) {
+                if (component.size < 2 || isJavaInClassAnnotatedHttpOnly(component)) {
                     continue
                 }
                 groups += DuplicateRegistrationGroup(component)
@@ -96,14 +98,24 @@ internal object ArmeriaRouteDuplicateIndex {
             .map { indices -> indices.map { routes[it] } }
     }
 
-    private fun isInClassAnnotatedHttpOnly(routes: List<ArmeriaRoute>): Boolean {
+    private fun isJavaInClassAnnotatedHttpOnly(routes: List<ArmeriaRoute>): Boolean {
         if (routes.any { it.routeMatch != RouteMatch.ANNOTATED_HTTP }) {
             return false
         }
-        val containingClasses = routes.mapNotNull { route ->
-            (route.pointer.element as? PsiMethod)?.containingClass
-        }.toSet()
-        return containingClasses.size == 1
+        var containingClass: PsiClass? = null
+        for (route in routes) {
+            val method = route.pointer.element as? PsiMethod ?: return false
+            if (!method.language.isKindOf(JavaLanguage.INSTANCE)) {
+                return false
+            }
+            val routeClass = method.containingClass ?: return false
+            if (containingClass == null) {
+                containingClass = routeClass
+            } else if (containingClass != routeClass) {
+                return false
+            }
+        }
+        return true
     }
 
     private fun httpMethodsOverlap(first: ArmeriaRoute, second: ArmeriaRoute): Boolean {
@@ -133,13 +145,16 @@ internal object ArmeriaRouteDuplicateIndex {
                     DuplicateRegistrationHit(
                         element = element,
                         registrationLabel = registrationLabel(route),
-                        registrationCount = group.routes.size,
+                        registrationCount = overlappingRouteCount(route, group.routes),
                     ),
                 )
             }
         }
         return hitsByFile
     }
+
+    private fun overlappingRouteCount(route: ArmeriaRoute, routes: List<ArmeriaRoute>): Int =
+        routes.count { httpMethodsOverlap(route, it) }
 
     private fun registrationLabel(route: ArmeriaRoute): String =
         when (route.routeMatch) {

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndex.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndex.kt
@@ -7,6 +7,7 @@ import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiMethod
+import com.intellij.psi.SmartPsiElementPointer
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.PsiModificationTracker
@@ -69,21 +70,35 @@ internal object ArmeriaRouteDuplicateIndex {
 
     private fun findConnectedComponents(routes: List<ArmeriaRoute>): List<List<ArmeriaRoute>> {
         val parent = IntArray(routes.size) { it }
+        val size = IntArray(routes.size) { 1 }
 
         fun find(index: Int): Int {
             var root = index
             while (parent[root] != root) {
                 root = parent[root]
             }
+            var current = index
+            while (parent[current] != root) {
+                val next = parent[current]
+                parent[current] = root
+                current = next
+            }
             return root
         }
 
         fun union(first: Int, second: Int) {
-            val firstRoot = find(first)
-            val secondRoot = find(second)
-            if (firstRoot != secondRoot) {
-                parent[secondRoot] = firstRoot
+            var firstRoot = find(first)
+            var secondRoot = find(second)
+            if (firstRoot == secondRoot) {
+                return
             }
+            if (size[firstRoot] < size[secondRoot]) {
+                val smallerRoot = firstRoot
+                firstRoot = secondRoot
+                secondRoot = smallerRoot
+            }
+            parent[secondRoot] = firstRoot
+            size[firstRoot] += size[secondRoot]
         }
 
         for (first in routes.indices) {
@@ -180,7 +195,7 @@ internal object ArmeriaRouteDuplicateIndex {
                 val virtualFile = element.containingFile?.virtualFile ?: continue
                 hitsByVirtualFile.getOrPut(virtualFile) { mutableListOf() }.add(
                     DuplicateRegistrationHit(
-                        element = element,
+                        pointer = route.pointer,
                         registrationLabel = registrationLabel(route),
                         registrationCount = overlappingRouteCount(route, group.routes),
                     ),
@@ -205,7 +220,7 @@ internal data class DuplicateRegistrationGroup(
 )
 
 internal data class DuplicateRegistrationHit(
-    val element: PsiElement,
+    val pointer: SmartPsiElementPointer<PsiElement>,
     val registrationLabel: String,
     val registrationCount: Int,
 )

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndex.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndex.kt
@@ -2,6 +2,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 
 import com.intellij.lang.java.JavaLanguage
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
@@ -29,7 +30,8 @@ internal object ArmeriaRouteDuplicateIndex {
     )
 
     fun duplicateHitsInFile(project: Project, file: PsiFile): List<DuplicateRegistrationHit> {
-        return getIndex(project).hitsByFile[file].orEmpty()
+        val virtualFile = file.virtualFile ?: return emptyList()
+        return getIndex(project).hitsByVirtualFile[virtualFile].orEmpty()
     }
 
     internal fun duplicateGroups(project: Project): List<DuplicateRegistrationGroup> {
@@ -58,7 +60,7 @@ internal object ArmeriaRouteDuplicateIndex {
             CachedValueProvider.Result.create(
                 DuplicateRegistrationIndex(
                     groups = groups,
-                    hitsByFile = buildHitsByFile(groups),
+                    hitsByVirtualFile = buildHitsByVirtualFile(groups),
                 ),
                 PsiModificationTracker.MODIFICATION_COUNT,
             )
@@ -131,8 +133,8 @@ internal object ArmeriaRouteDuplicateIndex {
             RouteMatch.ANNOTATED_HTTP, RouteMatch.NON_HTTP -> false
         }
 
-    private fun buildHitsByFile(groups: List<DuplicateRegistrationGroup>): Map<PsiFile, List<DuplicateRegistrationHit>> {
-        val hitsByFile = mutableMapOf<PsiFile, MutableList<DuplicateRegistrationHit>>()
+    private fun buildHitsByVirtualFile(groups: List<DuplicateRegistrationGroup>): Map<VirtualFile, List<DuplicateRegistrationHit>> {
+        val hitsByVirtualFile = mutableMapOf<VirtualFile, MutableList<DuplicateRegistrationHit>>()
         for (group in groups) {
             val seenElements = mutableSetOf<PsiElement>()
             for (route in group.routes) {
@@ -140,8 +142,8 @@ internal object ArmeriaRouteDuplicateIndex {
                 if (!seenElements.add(element)) {
                     continue
                 }
-                val file = element.containingFile ?: continue
-                hitsByFile.getOrPut(file) { mutableListOf() }.add(
+                val virtualFile = element.containingFile?.virtualFile ?: continue
+                hitsByVirtualFile.getOrPut(virtualFile) { mutableListOf() }.add(
                     DuplicateRegistrationHit(
                         element = element,
                         registrationLabel = registrationLabel(route),
@@ -150,7 +152,7 @@ internal object ArmeriaRouteDuplicateIndex {
                 )
             }
         }
-        return hitsByFile
+        return hitsByVirtualFile
     }
 
     private fun overlappingRouteCount(route: ArmeriaRoute, routes: List<ArmeriaRoute>): Int =
@@ -180,5 +182,5 @@ internal data class DuplicateRegistrationHit(
 
 private data class DuplicateRegistrationIndex(
     val groups: List<DuplicateRegistrationGroup>,
-    val hitsByFile: Map<PsiFile, List<DuplicateRegistrationHit>>,
+    val hitsByVirtualFile: Map<VirtualFile, List<DuplicateRegistrationHit>>,
 )

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndex.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndex.kt
@@ -1,0 +1,169 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
+import com.intellij.psi.util.PsiModificationTracker
+
+/**
+ * Detects duplicate HTTP route registrations within the same module.
+ *
+ * Includes annotated HTTP methods and ServerBuilder `.service`, `.serviceUnder`, and
+ * `.annotatedService` registrations. Excludes non-HTTP protocols such as gRPC.
+ *
+ * Cross-registration conflicts are detected, for example `@Get("/foo")` versus
+ * `.service("/foo", …)`. In-class annotated duplicate HTTP routes are excluded because
+ * [com.linecorp.intellij.plugins.armeria.inspection.ArmeriaDuplicateRouteInspection] covers them.
+ */
+internal object ArmeriaRouteDuplicateIndex {
+    private val CHECKED_MATCHES = setOf(
+        RouteMatch.ANNOTATED_HTTP,
+        RouteMatch.ANNOTATED_SERVICE,
+        RouteMatch.SERVICE,
+        RouteMatch.SERVICE_UNDER,
+    )
+
+    fun duplicateHitsInFile(project: Project, file: PsiFile): List<DuplicateRegistrationHit> {
+        return getIndex(project).hitsByFile[file].orEmpty()
+    }
+
+    internal fun duplicateGroups(project: Project): List<DuplicateRegistrationGroup> {
+        return getIndex(project).groups
+    }
+
+    internal fun findDuplicateGroups(routes: List<ArmeriaRoute>): List<DuplicateRegistrationGroup> {
+        val groups = mutableListOf<DuplicateRegistrationGroup>()
+        for ((_, bucketRoutes) in routes.filter { it.routeMatch in CHECKED_MATCHES }.groupBy { BucketKey(it.moduleName, it.path) }) {
+            if (bucketRoutes.size < 2) {
+                continue
+            }
+            for (component in findConnectedComponents(bucketRoutes)) {
+                if (component.size < 2 || isInClassAnnotatedHttpOnly(component)) {
+                    continue
+                }
+                groups += DuplicateRegistrationGroup(component)
+            }
+        }
+        return groups
+    }
+
+    private fun getIndex(project: Project): DuplicateRegistrationIndex {
+        return CachedValuesManager.getManager(project).getCachedValue(project) {
+            val groups = findDuplicateGroups(ArmeriaRouteCollector.collect(project))
+            CachedValueProvider.Result.create(
+                DuplicateRegistrationIndex(
+                    groups = groups,
+                    hitsByFile = buildHitsByFile(groups),
+                ),
+                PsiModificationTracker.MODIFICATION_COUNT,
+            )
+        }
+    }
+
+    private fun findConnectedComponents(routes: List<ArmeriaRoute>): List<List<ArmeriaRoute>> {
+        val parent = IntArray(routes.size) { it }
+
+        fun find(index: Int): Int {
+            var root = index
+            while (parent[root] != root) {
+                root = parent[root]
+            }
+            return root
+        }
+
+        fun union(first: Int, second: Int) {
+            val firstRoot = find(first)
+            val secondRoot = find(second)
+            if (firstRoot != secondRoot) {
+                parent[secondRoot] = firstRoot
+            }
+        }
+
+        for (first in routes.indices) {
+            for (second in first + 1 until routes.size) {
+                if (httpMethodsOverlap(routes[first], routes[second])) {
+                    union(first, second)
+                }
+            }
+        }
+
+        return routes.indices
+            .groupBy(::find)
+            .values
+            .map { indices -> indices.map { routes[it] } }
+    }
+
+    private fun isInClassAnnotatedHttpOnly(routes: List<ArmeriaRoute>): Boolean {
+        if (routes.any { it.routeMatch != RouteMatch.ANNOTATED_HTTP }) {
+            return false
+        }
+        val containingClasses = routes.mapNotNull { route ->
+            (route.pointer.element as? PsiMethod)?.containingClass
+        }.toSet()
+        return containingClasses.size == 1
+    }
+
+    private fun httpMethodsOverlap(first: ArmeriaRoute, second: ArmeriaRoute): Boolean {
+        if (matchesAllHttpMethods(first) || matchesAllHttpMethods(second)) {
+            return true
+        }
+        return first.httpMethod.equals(second.httpMethod, ignoreCase = true)
+    }
+
+    private fun matchesAllHttpMethods(route: ArmeriaRoute): Boolean =
+        when (route.routeMatch) {
+            RouteMatch.SERVICE, RouteMatch.SERVICE_UNDER, RouteMatch.ANNOTATED_SERVICE -> true
+            RouteMatch.ANNOTATED_HTTP, RouteMatch.NON_HTTP -> false
+        }
+
+    private fun buildHitsByFile(groups: List<DuplicateRegistrationGroup>): Map<PsiFile, List<DuplicateRegistrationHit>> {
+        val hitsByFile = mutableMapOf<PsiFile, MutableList<DuplicateRegistrationHit>>()
+        for (group in groups) {
+            val seenElements = mutableSetOf<PsiElement>()
+            for (route in group.routes) {
+                val element = route.pointer.element ?: continue
+                if (!seenElements.add(element)) {
+                    continue
+                }
+                val file = element.containingFile ?: continue
+                hitsByFile.getOrPut(file) { mutableListOf() }.add(
+                    DuplicateRegistrationHit(
+                        element = element,
+                        registrationLabel = registrationLabel(route),
+                        registrationCount = group.routes.size,
+                    ),
+                )
+            }
+        }
+        return hitsByFile
+    }
+
+    private fun registrationLabel(route: ArmeriaRoute): String =
+        when (route.routeMatch) {
+            RouteMatch.ANNOTATED_HTTP -> "${route.httpMethod} ${route.path}"
+            else -> route.path
+        }
+}
+
+private data class BucketKey(
+    val moduleName: String,
+    val path: String,
+)
+
+internal data class DuplicateRegistrationGroup(
+    val routes: List<ArmeriaRoute>,
+)
+
+internal data class DuplicateRegistrationHit(
+    val element: PsiElement,
+    val registrationLabel: String,
+    val registrationCount: Int,
+)
+
+private data class DuplicateRegistrationIndex(
+    val groups: List<DuplicateRegistrationGroup>,
+    val hitsByFile: Map<PsiFile, List<DuplicateRegistrationHit>>,
+)

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndex.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndex.kt
@@ -136,27 +136,26 @@ internal object ArmeriaRouteDuplicateIndex {
     }
 
     private fun routesOverlap(first: ArmeriaRoute, second: ArmeriaRoute): Boolean =
-        pathsOverlap(first.path, first.routeMatch, second.path, second.routeMatch)
+        pathsOverlap(first, second)
 
-    private fun pathsOverlap(
-        firstPath: String,
-        firstMatch: RouteMatch,
-        secondPath: String,
-        secondMatch: RouteMatch,
-    ): Boolean {
-        val firstIsPrefixMount = isPrefixMount(firstMatch)
-        val secondIsPrefixMount = isPrefixMount(secondMatch)
+    private fun pathsOverlap(first: ArmeriaRoute, second: ArmeriaRoute): Boolean {
+        val firstIsPrefixMount = isPrefixMount(first)
+        val secondIsPrefixMount = isPrefixMount(second)
         return when {
             firstIsPrefixMount && secondIsPrefixMount ->
-                pathIsUnder(firstPath, secondPath) || pathIsUnder(secondPath, firstPath)
-            firstIsPrefixMount -> pathIsUnder(secondPath, firstPath)
-            secondIsPrefixMount -> pathIsUnder(firstPath, secondPath)
-            else -> firstPath == secondPath
+                pathIsUnder(first.path, second.path) || pathIsUnder(second.path, first.path)
+            firstIsPrefixMount -> pathIsUnder(second.path, first.path)
+            secondIsPrefixMount -> pathIsUnder(first.path, second.path)
+            else -> first.path == second.path
         }
     }
 
-    private fun isPrefixMount(routeMatch: RouteMatch): Boolean =
-        routeMatch == RouteMatch.SERVICE_UNDER || routeMatch == RouteMatch.ANNOTATED_SERVICE
+    private fun isPrefixMount(route: ArmeriaRoute): Boolean =
+        when (route.routeMatch) {
+            RouteMatch.SERVICE_UNDER -> true
+            RouteMatch.ANNOTATED_SERVICE -> route.annotatedServiceHasPathPrefix
+            else -> false
+        }
 
     private fun pathIsUnder(path: String, prefix: String): Boolean {
         val normalizedPath = ArmeriaRouteSupport.normalizePath(path)

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspection.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspection.kt
@@ -4,56 +4,33 @@ import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiFile
-import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRoute
-import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteCollector
-import com.linecorp.intellij.plugins.armeria.explorer.RouteMatch
+import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteDuplicateIndex
 import com.linecorp.intellij.plugins.armeria.message
 
 class ArmeriaDuplicateRegistrationInspection : LocalInspectionTool() {
     override fun getDisplayName(): String = message("inspection.duplicate.registration.display.name")
 
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
-        val file = holder.file
-        val duplicates = findProjectDuplicates(holder.project)
-        if (duplicates.isEmpty()) {
+        val hits = ArmeriaRouteDuplicateIndex.duplicateHitsInFile(holder.project, holder.file)
+        if (hits.isEmpty()) {
             return PsiElementVisitor.EMPTY_VISITOR
         }
         return object : PsiElementVisitor() {
-            override fun visitFile(file: PsiFile) {
-                for ((_, routes) in duplicates) {
-                    for (route in routes) {
-                        val element = route.pointer.element ?: continue
-                        if (element.containingFile != file) {
-                            continue
-                        }
-                        holder.registerProblem(
-                            element,
-                            message("inspection.duplicate.registration.problem", route.path, routes.size),
-                        )
-                    }
+            override fun visitFile(visitedFile: PsiFile) {
+                if (visitedFile != holder.file) {
+                    return
+                }
+                for (hit in hits) {
+                    holder.registerProblem(
+                        hit.element,
+                        message(
+                            "inspection.duplicate.registration.problem",
+                            hit.registrationLabel,
+                            hit.registrationCount,
+                        ),
+                    )
                 }
             }
         }
     }
-
-    companion object {
-        private val CHECKED_MATCHES = setOf(
-            RouteMatch.ANNOTATED_HTTP,
-            RouteMatch.SERVICE,
-            RouteMatch.SERVICE_UNDER,
-        )
-
-        internal fun findProjectDuplicates(project: com.intellij.openapi.project.Project): Map<RouteKey, List<ArmeriaRoute>> {
-            return ArmeriaRouteCollector.collect(project)
-                .filter { it.routeMatch in CHECKED_MATCHES }
-                .groupBy { RouteKey(it.httpMethod, it.path, it.routeMatch) }
-                .filter { it.value.size > 1 }
-        }
-    }
 }
-
-internal data class RouteKey(
-    val httpMethod: String,
-    val path: String,
-    val routeMatch: RouteMatch,
-)

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspection.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspection.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiMethod
 import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteDuplicateIndex
 import com.linecorp.intellij.plugins.armeria.message
 
-class ArmeriaDuplicateRegistrationInspection : LocalInspectionTool() {
+open class ArmeriaDuplicateRegistrationInspection : LocalInspectionTool() {
     override fun getDisplayName(): String = message("inspection.duplicate.registration.display.name")
 
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspection.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspection.kt
@@ -4,6 +4,7 @@ import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiMethod
 import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteDuplicateIndex
 import com.linecorp.intellij.plugins.armeria.message
 
@@ -21,8 +22,9 @@ class ArmeriaDuplicateRegistrationInspection : LocalInspectionTool() {
                     return
                 }
                 for (hit in hits) {
+                    val highlightElement = (hit.element as? PsiMethod)?.nameIdentifier ?: hit.element
                     holder.registerProblem(
-                        hit.element,
+                        highlightElement,
                         message(
                             "inspection.duplicate.registration.problem",
                             hit.registrationLabel,

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspection.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspection.kt
@@ -1,0 +1,59 @@
+package com.linecorp.intellij.plugins.armeria.inspection
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiFile
+import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRoute
+import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteCollector
+import com.linecorp.intellij.plugins.armeria.explorer.RouteMatch
+import com.linecorp.intellij.plugins.armeria.message
+
+class ArmeriaDuplicateRegistrationInspection : LocalInspectionTool() {
+    override fun getDisplayName(): String = message("inspection.duplicate.registration.display.name")
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        val file = holder.file
+        val duplicates = findProjectDuplicates(holder.project)
+        if (duplicates.isEmpty()) {
+            return PsiElementVisitor.EMPTY_VISITOR
+        }
+        return object : PsiElementVisitor() {
+            override fun visitFile(file: PsiFile) {
+                for ((_, routes) in duplicates) {
+                    for (route in routes) {
+                        val element = route.pointer.element ?: continue
+                        if (element.containingFile != file) {
+                            continue
+                        }
+                        holder.registerProblem(
+                            element,
+                            message("inspection.duplicate.registration.problem", route.path, routes.size),
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        private val CHECKED_MATCHES = setOf(
+            RouteMatch.ANNOTATED_HTTP,
+            RouteMatch.SERVICE,
+            RouteMatch.SERVICE_UNDER,
+        )
+
+        internal fun findProjectDuplicates(project: com.intellij.openapi.project.Project): Map<RouteKey, List<ArmeriaRoute>> {
+            return ArmeriaRouteCollector.collect(project)
+                .filter { it.routeMatch in CHECKED_MATCHES }
+                .groupBy { RouteKey(it.httpMethod, it.path, it.routeMatch) }
+                .filter { it.value.size > 1 }
+        }
+    }
+}
+
+internal data class RouteKey(
+    val httpMethod: String,
+    val path: String,
+    val routeMatch: RouteMatch,
+)

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspection.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspection.kt
@@ -2,11 +2,13 @@ package com.linecorp.intellij.plugins.armeria.inspection
 
 import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiMethod
 import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteDuplicateIndex
 import com.linecorp.intellij.plugins.armeria.message
+import org.jetbrains.kotlin.psi.KtNamedFunction
 
 open class ArmeriaDuplicateRegistrationInspection : LocalInspectionTool() {
     override fun getDisplayName(): String = message("inspection.duplicate.registration.display.name")
@@ -22,9 +24,8 @@ open class ArmeriaDuplicateRegistrationInspection : LocalInspectionTool() {
                     return
                 }
                 for (hit in hits) {
-                    val highlightElement = (hit.element as? PsiMethod)?.nameIdentifier ?: hit.element
                     holder.registerProblem(
-                        highlightElement,
+                        highlightElement(hit.element),
                         message(
                             "inspection.duplicate.registration.problem",
                             hit.registrationLabel,
@@ -33,6 +34,14 @@ open class ArmeriaDuplicateRegistrationInspection : LocalInspectionTool() {
                     )
                 }
             }
+        }
+    }
+
+    private fun highlightElement(element: PsiElement): PsiElement {
+        return when (val source = element.navigationElement) {
+            is PsiMethod -> source.nameIdentifier ?: source
+            is KtNamedFunction -> source.nameIdentifier ?: source
+            else -> source
         }
     }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspection.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspection.kt
@@ -20,8 +20,9 @@ open class ArmeriaDuplicateRegistrationInspection : LocalInspectionTool() {
         return object : PsiElementVisitor() {
             override fun visitFile(visitedFile: PsiFile) {
                 for (hit in hits) {
+                    val element = hit.pointer.element ?: continue
                     holder.registerProblem(
-                        highlightElement(hit.element),
+                        highlightElement(element),
                         message(
                             "inspection.duplicate.registration.problem",
                             hit.registrationLabel,

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspection.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspection.kt
@@ -8,7 +8,6 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiMethod
 import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteDuplicateIndex
 import com.linecorp.intellij.plugins.armeria.message
-import org.jetbrains.kotlin.psi.KtNamedFunction
 
 open class ArmeriaDuplicateRegistrationInspection : LocalInspectionTool() {
     override fun getDisplayName(): String = message("inspection.duplicate.registration.display.name")
@@ -20,9 +19,6 @@ open class ArmeriaDuplicateRegistrationInspection : LocalInspectionTool() {
         }
         return object : PsiElementVisitor() {
             override fun visitFile(visitedFile: PsiFile) {
-                if (visitedFile != holder.file) {
-                    return
-                }
                 for (hit in hits) {
                     holder.registerProblem(
                         highlightElement(hit.element),
@@ -37,11 +33,11 @@ open class ArmeriaDuplicateRegistrationInspection : LocalInspectionTool() {
         }
     }
 
-    private fun highlightElement(element: PsiElement): PsiElement {
-        return when (val source = element.navigationElement) {
-            is PsiMethod -> source.nameIdentifier ?: source
-            is KtNamedFunction -> source.nameIdentifier ?: source
-            else -> source
+    protected open fun highlightElement(element: PsiElement): PsiElement {
+        val source = element.navigationElement
+        if (source is PsiMethod) {
+            return source.nameIdentifier ?: source
         }
+        return source
     }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationKotlinInspection.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationKotlinInspection.kt
@@ -1,0 +1,7 @@
+package com.linecorp.intellij.plugins.armeria.inspection
+
+import com.linecorp.intellij.plugins.armeria.message
+
+class ArmeriaDuplicateRegistrationKotlinInspection : ArmeriaDuplicateRegistrationInspection() {
+    override fun getDisplayName(): String = message("inspection.duplicate.registration.kotlin.display.name")
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationKotlinInspection.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationKotlinInspection.kt
@@ -1,7 +1,17 @@
 package com.linecorp.intellij.plugins.armeria.inspection
 
+import com.intellij.psi.PsiElement
 import com.linecorp.intellij.plugins.armeria.message
+import org.jetbrains.kotlin.psi.KtNamedFunction
 
 class ArmeriaDuplicateRegistrationKotlinInspection : ArmeriaDuplicateRegistrationInspection() {
     override fun getDisplayName(): String = message("inspection.duplicate.registration.kotlin.display.name")
+
+    override fun highlightElement(element: PsiElement): PsiElement {
+        val source = element.navigationElement
+        if (source is KtNamedFunction) {
+            return source.nameIdentifier ?: source
+        }
+        return super.highlightElement(element)
+    }
 }

--- a/plugin/src/main/resources/META-INF/kotlin-integration.xml
+++ b/plugin/src/main/resources/META-INF/kotlin-integration.xml
@@ -3,12 +3,12 @@
     <extensions defaultExtensionNs="com.intellij">
         <localInspection language="kotlin"
                          bundle="messages.ArmeriaBundle"
-                         key="inspection.duplicate.registration.display.name"
+                         key="inspection.duplicate.registration.kotlin.display.name"
                          groupBundle="messages.ArmeriaBundle"
                          groupKey="inspection.group.armeria"
                          shortName="ArmeriaDuplicateRegistrationKotlin"
                          enabledByDefault="true"
                          level="WARNING"
-                         implementationClass="com.linecorp.intellij.plugins.armeria.inspection.ArmeriaDuplicateRegistrationInspection" />
+                         implementationClass="com.linecorp.intellij.plugins.armeria.inspection.ArmeriaDuplicateRegistrationKotlinInspection" />
     </extensions>
 </idea-plugin>

--- a/plugin/src/main/resources/META-INF/kotlin-integration.xml
+++ b/plugin/src/main/resources/META-INF/kotlin-integration.xml
@@ -1,3 +1,14 @@
 <idea-plugin>
     <supportsKotlinPluginMode supportsK2="true"/>
+    <extensions defaultExtensionNs="com.intellij">
+        <localInspection language="kotlin"
+                         bundle="messages.ArmeriaBundle"
+                         key="inspection.duplicate.registration.display.name"
+                         groupBundle="messages.ArmeriaBundle"
+                         groupKey="inspection.group.armeria"
+                         shortName="ArmeriaDuplicateRegistrationKotlin"
+                         enabledByDefault="true"
+                         level="WARNING"
+                         implementationClass="com.linecorp.intellij.plugins.armeria.inspection.ArmeriaDuplicateRegistrationInspection" />
+    </extensions>
 </idea-plugin>

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -20,6 +20,15 @@
                     icon="/icons/armeria.svg" />
         <localInspection language="JAVA"
                          bundle="messages.ArmeriaBundle"
+                         key="inspection.duplicate.registration.display.name"
+                         groupBundle="messages.ArmeriaBundle"
+                         groupKey="inspection.group.armeria"
+                         shortName="ArmeriaDuplicateRegistration"
+                         enabledByDefault="true"
+                         level="WARNING"
+                         implementationClass="com.linecorp.intellij.plugins.armeria.inspection.ArmeriaDuplicateRegistrationInspection" />
+        <localInspection language="JAVA"
+                         bundle="messages.ArmeriaBundle"
                          key="inspection.duplicate.route.display.name"
                          groupBundle="messages.ArmeriaBundle"
                          groupKey="inspection.group.armeria"

--- a/plugin/src/main/resources/messages/ArmeriaBundle.properties
+++ b/plugin/src/main/resources/messages/ArmeriaBundle.properties
@@ -9,7 +9,7 @@ inspection.duplicate.route.display.name=Duplicate annotated Armeria route
 inspection.duplicate.route.problem=This annotated Armeria route duplicates another HTTP method/path combination in the same service class.
 inspection.duplicate.registration.display.name=Duplicate Armeria route registration
 inspection.duplicate.registration.kotlin.display.name=Duplicate Armeria route registration (Kotlin)
-inspection.duplicate.registration.problem=This Armeria route {0} is registered {1} times in this module.
+inspection.duplicate.registration.problem=This Armeria route {0} is part of a group of {1} conflicting registrations in this module.
 
 module.category.armeria.title=Armeria Artifacts
 module.category.armeria.description=Armeria Artifacts

--- a/plugin/src/main/resources/messages/ArmeriaBundle.properties
+++ b/plugin/src/main/resources/messages/ArmeriaBundle.properties
@@ -8,7 +8,7 @@ inspection.group.armeria=Armeria
 inspection.duplicate.route.display.name=Duplicate annotated Armeria route
 inspection.duplicate.route.problem=This annotated Armeria route duplicates another HTTP method/path combination in the same service class.
 inspection.duplicate.registration.display.name=Duplicate Armeria route registration
-inspection.duplicate.registration.problem=This Armeria route path ''{0}'' is registered {1} times across the project.
+inspection.duplicate.registration.problem=This Armeria route {0} is registered {1} times in this module.
 
 module.category.armeria.title=Armeria Artifacts
 module.category.armeria.description=Armeria Artifacts

--- a/plugin/src/main/resources/messages/ArmeriaBundle.properties
+++ b/plugin/src/main/resources/messages/ArmeriaBundle.properties
@@ -8,6 +8,7 @@ inspection.group.armeria=Armeria
 inspection.duplicate.route.display.name=Duplicate annotated Armeria route
 inspection.duplicate.route.problem=This annotated Armeria route duplicates another HTTP method/path combination in the same service class.
 inspection.duplicate.registration.display.name=Duplicate Armeria route registration
+inspection.duplicate.registration.kotlin.display.name=Duplicate Armeria route registration (Kotlin)
 inspection.duplicate.registration.problem=This Armeria route {0} is registered {1} times in this module.
 
 module.category.armeria.title=Armeria Artifacts

--- a/plugin/src/main/resources/messages/ArmeriaBundle.properties
+++ b/plugin/src/main/resources/messages/ArmeriaBundle.properties
@@ -7,6 +7,8 @@ inspection.entrypoint.armeria=Armeria Methods
 inspection.group.armeria=Armeria
 inspection.duplicate.route.display.name=Duplicate annotated Armeria route
 inspection.duplicate.route.problem=This annotated Armeria route duplicates another HTTP method/path combination in the same service class.
+inspection.duplicate.registration.display.name=Duplicate Armeria route registration
+inspection.duplicate.registration.problem=This Armeria route path ''{0}'' is registered {1} times across the project.
 
 module.category.armeria.title=Armeria Artifacts
 module.category.armeria.description=Armeria Artifacts

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndexTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndexTest.kt
@@ -347,6 +347,49 @@ class ArmeriaRouteDuplicateIndexTest : LightJavaCodeInsightFixtureTestCase() {
         assertEquals(2, groups.single().routes.size)
     }
 
+    fun testServiceUnderConflictsWithAnnotatedRouteUnderPrefix() {
+        myFixture.configureByText(
+            "Main.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.Server;
+
+            public class Main {
+                public static void main(String[] args) {
+                    Server.builder()
+                        .serviceUnder("/api", new ApiService())
+                        .build();
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Get;
+
+            public class AnnotatedHandler {
+                @Get("/api/foo")
+                public String handle() {
+                    return "foo";
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass("package example; public class ApiService {}")
+
+        val groups = ArmeriaRouteDuplicateIndex.duplicateGroups(project)
+
+        assertEquals(1, groups.size)
+        assertEquals(2, groups.single().routes.size)
+        assertEquals(
+            setOf(RouteMatch.SERVICE_UNDER, RouteMatch.ANNOTATED_HTTP),
+            groups.single().routes.map { it.routeMatch }.toSet(),
+        )
+    }
+
     fun testDuplicateHitsAreIndexedByFile() {
         myFixture.configureByText(
             "First.java",
@@ -427,6 +470,10 @@ class ArmeriaRouteDuplicateIndexTest : LightJavaCodeInsightFixtureTestCase() {
 
             public final class ServerBuilder {
                 public ServerBuilder service(String path, Object service) {
+                    return this;
+                }
+
+                public ServerBuilder serviceUnder(String pathPrefix, Object service) {
                     return this;
                 }
 

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndexTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndexTest.kt
@@ -111,7 +111,7 @@ class ArmeriaRouteDuplicateIndexTest : LightJavaCodeInsightFixtureTestCase() {
         assertEquals(2, groups.single().routes.size)
     }
 
-    fun testInClassAnnotatedDuplicatesAreExcluded() {
+    fun testInClassJavaAnnotatedDuplicatesAreExcluded() {
         myFixture.configureByText(
             "BadService.java",
             """
@@ -134,6 +134,97 @@ class ArmeriaRouteDuplicateIndexTest : LightJavaCodeInsightFixtureTestCase() {
         )
 
         assertTrue(ArmeriaRouteDuplicateIndex.duplicateGroups(project).isEmpty())
+    }
+
+    fun testInClassKotlinAnnotatedDuplicatesAreReported() {
+        myFixture.configureByText(
+            "BadService.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.annotation.Get
+
+            class BadService {
+                @Get("/dup")
+                fun first(): String = "first"
+
+                @Get("/dup")
+                fun second(): String = "second"
+            }
+            """.trimIndent(),
+        )
+
+        val groups = ArmeriaRouteDuplicateIndex.duplicateGroups(project)
+
+        assertEquals(1, groups.size)
+        assertEquals(2, groups.single().routes.size)
+    }
+
+    fun testCatchAllServiceCountsOverlapsPerRoute() {
+        myFixture.configureByText(
+            "Main.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.Server;
+
+            public class Main {
+                public static void main(String[] args) {
+                    Server.builder()
+                        .service("/shared", new ServiceHandler())
+                        .build();
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Get;
+            import com.linecorp.armeria.server.annotation.Post;
+
+            public class AnnotatedHandler {
+                @Get("/shared")
+                public String read() {
+                    return "read";
+                }
+
+                @Post("/shared")
+                public String write() {
+                    return "write";
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass("package example; public class ServiceHandler {}")
+
+        val groups = ArmeriaRouteDuplicateIndex.duplicateGroups(project)
+        assertEquals(1, groups.size)
+
+        val routes = groups.single().routes
+        val getRoute = routes.single { it.httpMethod == "GET" }
+        val postRoute = routes.single { it.httpMethod == "POST" }
+        val serviceRoute = routes.single { it.routeMatch == RouteMatch.SERVICE }
+
+        assertEquals(
+            2,
+            ArmeriaRouteDuplicateIndex.duplicateHitsInFile(project, getRoute.pointer.element!!.containingFile)
+                .single { it.registrationLabel == "GET /shared" }
+                .registrationCount,
+        )
+        assertEquals(
+            2,
+            ArmeriaRouteDuplicateIndex.duplicateHitsInFile(project, postRoute.pointer.element!!.containingFile)
+                .single { it.registrationLabel == "POST /shared" }
+                .registrationCount,
+        )
+        assertEquals(
+            3,
+            ArmeriaRouteDuplicateIndex.duplicateHitsInFile(project, serviceRoute.pointer.element!!.containingFile)
+                .single()
+                .registrationCount,
+        )
     }
 
     fun testAnnotatedRouteConflictsWithServiceRegistration() {

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndexTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndexTest.kt
@@ -1,0 +1,352 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+
+class ArmeriaRouteDuplicateIndexTest : LightJavaCodeInsightFixtureTestCase() {
+    override fun setUp() {
+        super.setUp()
+        registerArmeriaStubs()
+    }
+
+    fun testDuplicateServiceRegistrationsInDifferentFilesAreReported() {
+        myFixture.configureByText(
+            "Main.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.Server;
+
+            public class Main {
+                public static void main(String[] args) {
+                    Server.builder()
+                        .service("/dup", new FirstService())
+                        .build();
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            import com.linecorp.armeria.server.Server;
+
+            public class Extra {
+                public static void register(com.linecorp.armeria.server.ServerBuilder sb) {
+                    sb.service("/dup", new SecondService());
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass("package example; public class FirstService {}")
+        myFixture.addClass("package example; public class SecondService {}")
+
+        val groups = ArmeriaRouteDuplicateIndex.duplicateGroups(project)
+
+        assertEquals(1, groups.size)
+        assertEquals(2, groups.single().routes.size)
+        assertEquals(setOf("/dup"), groups.single().routes.map { it.path }.toSet())
+    }
+
+    fun testDifferentHttpMethodsOnSamePathAreNotDuplicates() {
+        myFixture.configureByText(
+            "Routes.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Get;
+            import com.linecorp.armeria.server.annotation.Post;
+
+            public class Routes {
+                @Get("/resource")
+                public String read() {
+                    return "read";
+                }
+
+                @Post("/resource")
+                public String write() {
+                    return "write";
+                }
+            }
+            """.trimIndent(),
+        )
+
+        assertTrue(ArmeriaRouteDuplicateIndex.duplicateGroups(project).isEmpty())
+    }
+
+    fun testCrossClassAnnotatedRoutesAreReported() {
+        myFixture.configureByText(
+            "First.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Get;
+
+            public class First {
+                @Get("/shared")
+                public String first() {
+                    return "first";
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Get;
+
+            public class Second {
+                @Get("/shared")
+                public String second() {
+                    return "second";
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val groups = ArmeriaRouteDuplicateIndex.duplicateGroups(project)
+
+        assertEquals(1, groups.size)
+        assertEquals(2, groups.single().routes.size)
+    }
+
+    fun testInClassAnnotatedDuplicatesAreExcluded() {
+        myFixture.configureByText(
+            "BadService.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Get;
+
+            public class BadService {
+                @Get("/dup")
+                public String first() {
+                    return "first";
+                }
+
+                @Get("/dup")
+                public String second() {
+                    return "second";
+                }
+            }
+            """.trimIndent(),
+        )
+
+        assertTrue(ArmeriaRouteDuplicateIndex.duplicateGroups(project).isEmpty())
+    }
+
+    fun testAnnotatedRouteConflictsWithServiceRegistration() {
+        myFixture.configureByText(
+            "Main.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.Server;
+
+            public class Main {
+                public static void main(String[] args) {
+                    Server.builder()
+                        .service("/shared", new ServiceHandler())
+                        .build();
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Get;
+
+            public class AnnotatedHandler {
+                @Get("/shared")
+                public String handle() {
+                    return "shared";
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass("package example; public class ServiceHandler {}")
+
+        val groups = ArmeriaRouteDuplicateIndex.duplicateGroups(project)
+
+        assertEquals(1, groups.size)
+        assertEquals(2, groups.single().routes.size)
+        assertEquals(
+            setOf(RouteMatch.SERVICE, RouteMatch.ANNOTATED_HTTP),
+            groups.single().routes.map { it.routeMatch }.toSet(),
+        )
+    }
+
+    fun testDuplicateAnnotatedServiceRegistrationsAreReported() {
+        myFixture.configureByText(
+            "FirstMain.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.Server;
+
+            public class FirstMain {
+                public static void main(String[] args) {
+                    Server.builder()
+                        .annotatedService("/api", new FirstService())
+                        .build();
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            import com.linecorp.armeria.server.Server;
+
+            public class SecondMain {
+                public static void main(String[] args) {
+                    Server.builder()
+                        .annotatedService("/api", new SecondService())
+                        .build();
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass("package example; public class FirstService {}")
+        myFixture.addClass("package example; public class SecondService {}")
+
+        val groups = ArmeriaRouteDuplicateIndex.duplicateGroups(project)
+
+        assertEquals(1, groups.size)
+        assertEquals(2, groups.single().routes.size)
+        assertTrue(groups.single().routes.all { it.routeMatch == RouteMatch.ANNOTATED_SERVICE })
+    }
+
+    fun testDuplicateKotlinServiceRegistrationsAreReported() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder()
+                    .service("/dup", FirstService())
+                    .build()
+            }
+
+            fun secondMain() {
+                Server.builder()
+                    .service("/dup", SecondService())
+                    .build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass("package example; public class FirstService {}")
+        myFixture.addClass("package example; public class SecondService {}")
+
+        val groups = ArmeriaRouteDuplicateIndex.duplicateGroups(project)
+
+        assertEquals(1, groups.size)
+        assertEquals(2, groups.single().routes.size)
+    }
+
+    fun testDuplicateHitsAreIndexedByFile() {
+        myFixture.configureByText(
+            "First.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Get;
+
+            public class First {
+                @Get("/shared")
+                public String first() {
+                    return "first";
+                }
+            }
+            """.trimIndent(),
+        )
+        val secondClass = myFixture.addClass(
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Get;
+
+            public class Second {
+                @Get("/shared")
+                public String second() {
+                    return "second";
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val firstFile = myFixture.file
+        val secondFile = secondClass.containingFile
+        val firstHits = ArmeriaRouteDuplicateIndex.duplicateHitsInFile(project, firstFile)
+        val secondHits = ArmeriaRouteDuplicateIndex.duplicateHitsInFile(project, secondFile)
+
+        assertEquals(1, firstHits.size)
+        assertEquals(1, secondHits.size)
+        assertEquals("GET /shared", firstHits.single().registrationLabel)
+        assertEquals(2, firstHits.single().registrationCount)
+    }
+
+    private fun registerArmeriaStubs() {
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.server.annotation;
+
+            public @interface Get {
+                String value() default "";
+                String path() default "";
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.server.annotation;
+
+            public @interface Post {
+                String value() default "";
+                String path() default "";
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.server;
+
+            public final class Server {
+                public static ServerBuilder builder() {
+                    return null;
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.server;
+
+            public final class ServerBuilder {
+                public ServerBuilder service(String path, Object service) {
+                    return this;
+                }
+
+                public ServerBuilder annotatedService(Object service) {
+                    return this;
+                }
+
+                public ServerBuilder annotatedService(String pathPrefix, Object service) {
+                    return this;
+                }
+
+                public com.linecorp.armeria.server.Server build() {
+                    return null;
+                }
+            }
+            """.trimIndent(),
+        )
+    }
+}

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndexTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndexTest.kt
@@ -347,6 +347,42 @@ class ArmeriaRouteDuplicateIndexTest : LightJavaCodeInsightFixtureTestCase() {
         assertEquals(2, groups.single().routes.size)
     }
 
+    fun testServiceUnderWithTrailingSlashConflictsWithAnnotatedRoute() {
+        myFixture.configureByText(
+            "Main.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.Server;
+
+            public class Main {
+                public static void main(String[] args) {
+                    Server.builder()
+                        .serviceUnder("/api/", new ApiService())
+                        .build();
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Get;
+
+            public class AnnotatedHandler {
+                @Get("/api/foo")
+                public String handle() {
+                    return "foo";
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass("package example; public class ApiService {}")
+
+        assertEquals(1, ArmeriaRouteDuplicateIndex.duplicateGroups(project).size)
+    }
+
     fun testServiceUnderConflictsWithAnnotatedRouteUnderPrefix() {
         myFixture.configureByText(
             "Main.java",

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndexTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndexTest.kt
@@ -158,6 +158,11 @@ class ArmeriaRouteDuplicateIndexTest : LightJavaCodeInsightFixtureTestCase() {
 
         assertEquals(1, groups.size)
         assertEquals(2, groups.single().routes.size)
+
+        val hits = ArmeriaRouteDuplicateIndex.duplicateHitsInFile(project, myFixture.file)
+        assertEquals(2, hits.size)
+        assertEquals(setOf("GET /dup"), hits.map { it.registrationLabel }.toSet())
+        assertTrue(hits.all { it.registrationCount == 2 })
     }
 
     fun testCatchAllServiceCountsOverlapsPerRoute() {

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndexTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndexTest.kt
@@ -347,6 +347,44 @@ class ArmeriaRouteDuplicateIndexTest : LightJavaCodeInsightFixtureTestCase() {
         assertEquals(2, groups.single().routes.size)
     }
 
+    fun testAnnotatedServiceWithoutPrefixDoesNotConflictWithUnrelatedRoutes() {
+        myFixture.configureByText(
+            "Main.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.Server;
+
+            public class Main {
+                public static void main(String[] args) {
+                    Server.builder()
+                        .annotatedService(new AnnotatedService())
+                        .service("/foo", new FooService())
+                        .build();
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Get;
+
+            public class AnnotatedHandler {
+                @Get("/bar")
+                public String handle() {
+                    return "bar";
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass("package example; public class AnnotatedService {}")
+        myFixture.addClass("package example; public class FooService {}")
+
+        assertTrue(ArmeriaRouteDuplicateIndex.duplicateGroups(project).isEmpty())
+    }
+
     fun testServiceUnderWithTrailingSlashConflictsWithAnnotatedRoute() {
         myFixture.configureByText(
             "Main.java",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Index duplicate registration hits by `VirtualFile` instead of `PsiFile` identity so Kotlin light methods resolve to the same source file the inspection visits
- Add `duplicateHitsInFile` assertions to the Kotlin in-class duplicate test to guard against regressions
- Give the Kotlin duplicate registration inspection a distinct display name in IDE settings
- Highlight duplicate registrations on `navigationElement` source identifiers for Kotlin light methods
- Move Kotlin PSI handling into the Kotlin-only inspection subclass so the base inspection loads without the optional Kotlin plugin
- Remove redundant `visitedFile != holder.file` guard in the inspection visitor
- Detect `serviceUnder` prefix overlaps so routes under a prefix mount are compared against annotated and exact-path registrations
- Store duplicate hits as `SmartPsiElementPointer` and optimize union-find with path compression
- Normalize trailing slashes on prefix mounts and clarify inspection message wording

## Test plan

- [x] `./gradlew :plugin:test --tests "com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteDuplicateIndexTest"`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2021-9dd6-73e2-bdb9-83969a21a5fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2021-9dd6-73e2-bdb9-83969a21a5fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

