### PR TITLE
feat: gRPC proto route discovery

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Implemented Armeria run configuration with module classpath and main class selection via ApplicationConfigurationBase.
 - Added project-wide duplicate route registration inspection for ServerBuilder and annotated routes.
 - Added programmatic `ServerBuilder.decorator()` detection in Route Explorer.
-- Added gRPC route discovery from `.proto` service definitions.
+- Added gRPC route discovery from `.proto` service definitions with brace-aware parsing and a registry kill-switch.
 - Added Kotlin source support to Route Explorer for annotated services and Server.builder registrations.
 - Added Velocity-based regression tests for New Project Wizard file templates.
 - Added `plugin/src/test/resources/wizard-verification-matrix.md` documenting representative wizard scenarios.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Implemented Armeria run configuration with module classpath and main class selection via ApplicationConfigurationBase.
 - Added project-wide duplicate route registration inspection for ServerBuilder and annotated routes.
 - Added programmatic `ServerBuilder.decorator()` detection in Route Explorer.
+- Added gRPC route discovery from `.proto` service definitions.
 - Added Kotlin source support to Route Explorer for annotated services and Server.builder registrations.
 - Added Velocity-based regression tests for New Project Wizard file templates.
 - Added `plugin/src/test/resources/wizard-verification-matrix.md` documenting representative wizard scenarios.

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollector.kt
@@ -45,7 +45,7 @@ internal object ArmeriaGrpcRouteCollector {
                 routes += ArmeriaRoute.create(
                     element = element,
                     protocol = message("route.explorer.protocol.grpc"),
-                    httpMethod = "RPC",
+                    httpMethod = "",
                     path = path,
                     target = "$fqService.$methodName",
                     routeMatch = RouteMatch.NON_HTTP,

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollector.kt
@@ -18,24 +18,35 @@ internal object ArmeriaGrpcRouteCollector {
         if (!isProtoRouteDiscoveryEnabled()) {
             return
         }
+        val seenProtoRoutes = mutableSetOf<String>()
         for (virtualFile in FilenameIndex.getAllFilesByExt(project, "proto", scope)) {
             ArmeriaRouteCollectionMetrics.current()?.filesScanned?.incrementAndGet()
             val psiFile = PsiManager.getInstance(project).findFile(virtualFile) ?: continue
-            collectFromProtoText(psiFile.text, psiFile, routes)
+            collectFromProtoText(psiFile.text, psiFile, routes, seenProtoRoutes)
         }
     }
 
-    internal fun collectFromProtoText(text: String, element: PsiElement, routes: MutableList<ArmeriaRoute>) {
-        val packageName = PACKAGE_PATTERN.find(text)?.groupValues?.get(1).orEmpty()
-        for ((serviceName, body) in findServiceBodies(text)) {
+    internal fun collectFromProtoText(
+        text: String,
+        element: PsiElement,
+        routes: MutableList<ArmeriaRoute>,
+        seenProtoRoutes: MutableSet<String> = mutableSetOf(),
+    ) {
+        val strippedText = stripProtoComments(text)
+        val packageName = PACKAGE_PATTERN.find(strippedText)?.groupValues?.get(1).orEmpty()
+        for ((serviceName, body) in findServiceBodies(strippedText)) {
             val fqService = if (packageName.isBlank()) serviceName else "$packageName.$serviceName"
             for (rpc in RPC_PATTERN.findAll(body)) {
                 val methodName = rpc.groupValues[1]
+                val path = "/$fqService/$methodName"
+                if (!seenProtoRoutes.add(path)) {
+                    continue
+                }
                 routes += ArmeriaRoute.create(
                     element = element,
                     protocol = message("route.explorer.protocol.grpc"),
                     httpMethod = "RPC",
-                    path = "/$fqService/$methodName",
+                    path = path,
                     target = "$fqService.$methodName",
                     routeMatch = RouteMatch.NON_HTTP,
                 )
@@ -57,7 +68,11 @@ internal object ArmeriaGrpcRouteCollector {
             val match = SERVICE_HEADER_PATTERN.find(text, searchFrom) ?: break
             val serviceName = match.groupValues[1]
             val openBraceIndex = match.range.last
-            val closeBraceIndex = findMatchingCloseBrace(text, openBraceIndex) ?: break
+            val closeBraceIndex = findMatchingCloseBrace(text, openBraceIndex)
+            if (closeBraceIndex == null) {
+                searchFrom = openBraceIndex + 1
+                continue
+            }
             val body = text.substring(openBraceIndex + 1, closeBraceIndex)
             results += serviceName to body
             searchFrom = closeBraceIndex + 1
@@ -82,5 +97,27 @@ internal object ArmeriaGrpcRouteCollector {
             }
         }
         return null
+    }
+
+    private fun stripProtoComments(text: String): String {
+        val result = StringBuilder(text.length)
+        var index = 0
+        while (index < text.length) {
+            when {
+                text.startsWith("//", index) -> {
+                    val lineEnd = text.indexOf('\n', index)
+                    index = if (lineEnd < 0) text.length else lineEnd
+                }
+                text.startsWith("/*", index) -> {
+                    val blockEnd = text.indexOf("*/", index + 2)
+                    index = if (blockEnd < 0) text.length else blockEnd + 2
+                }
+                else -> {
+                    result.append(text[index])
+                    index++
+                }
+            }
+        }
+        return result.toString()
     }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollector.kt
@@ -1,37 +1,86 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.registry.Registry
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiManager
 import com.intellij.psi.search.FilenameIndex
 import com.intellij.psi.search.GlobalSearchScope
 import com.linecorp.intellij.plugins.armeria.message
+import java.util.MissingResourceException
 
 internal object ArmeriaGrpcRouteCollector {
-    private val SERVICE_PATTERN = Regex("""service\s+(\w+)\s*\{([^}]*)\}""", RegexOption.DOT_MATCHES_ALL)
-    private val RPC_PATTERN = Regex("""rpc\s+(\w+)\s*\(""")
+    private val SERVICE_HEADER_PATTERN = Regex("""\bservice\s+(\w+)\s*\{""")
+    private val RPC_PATTERN = Regex("""\brpc\s+(\w+)\s*\(""")
+    private val PACKAGE_PATTERN = Regex("""\bpackage\s+([\w.]+)\s*;?""")
 
     fun collect(project: Project, scope: GlobalSearchScope, routes: MutableList<ArmeriaRoute>) {
+        if (!isProtoRouteDiscoveryEnabled()) {
+            return
+        }
         for (virtualFile in FilenameIndex.getAllFilesByExt(project, "proto", scope)) {
+            ArmeriaRouteCollectionMetrics.current()?.filesScanned?.incrementAndGet()
             val psiFile = PsiManager.getInstance(project).findFile(virtualFile) ?: continue
-            val packageName = PACKAGE_PATTERN.find(psiFile.text)?.groupValues?.get(1).orEmpty()
-            for (match in SERVICE_PATTERN.findAll(psiFile.text)) {
-                val serviceName = match.groupValues[1]
-                val body = match.groupValues[2]
-                val fqService = if (packageName.isBlank()) serviceName else "$packageName.$serviceName"
-                for (rpc in RPC_PATTERN.findAll(body)) {
-                    val methodName = rpc.groupValues[1]
-                    routes += ArmeriaRoute.create(
-                        element = psiFile,
-                        protocol = message("route.explorer.protocol.grpc"),
-                        httpMethod = "RPC",
-                        path = "/$fqService/$methodName",
-                        target = "$fqService.$methodName",
-                        routeMatch = RouteMatch.NON_HTTP,
-                    )
-                }
+            collectFromProtoText(psiFile.text, psiFile, routes)
+        }
+    }
+
+    internal fun collectFromProtoText(text: String, element: PsiElement, routes: MutableList<ArmeriaRoute>) {
+        val packageName = PACKAGE_PATTERN.find(text)?.groupValues?.get(1).orEmpty()
+        for ((serviceName, body) in findServiceBodies(text)) {
+            val fqService = if (packageName.isBlank()) serviceName else "$packageName.$serviceName"
+            for (rpc in RPC_PATTERN.findAll(body)) {
+                val methodName = rpc.groupValues[1]
+                routes += ArmeriaRoute.create(
+                    element = element,
+                    protocol = message("route.explorer.protocol.grpc"),
+                    httpMethod = "RPC",
+                    path = "/$fqService/$methodName",
+                    target = "$fqService.$methodName",
+                    routeMatch = RouteMatch.NON_HTTP,
+                )
             }
         }
     }
 
-    private val PACKAGE_PATTERN = Regex("""package\s+([\w.]+)\s*;""")
+    private fun isProtoRouteDiscoveryEnabled(): Boolean =
+        try {
+            Registry.`is`("armeria.grpc.proto.routes.enabled")
+        } catch (_: MissingResourceException) {
+            true
+        }
+
+    private fun findServiceBodies(text: String): List<Pair<String, String>> {
+        val results = mutableListOf<Pair<String, String>>()
+        var searchFrom = 0
+        while (searchFrom < text.length) {
+            val match = SERVICE_HEADER_PATTERN.find(text, searchFrom) ?: break
+            val serviceName = match.groupValues[1]
+            val openBraceIndex = match.range.last
+            val closeBraceIndex = findMatchingCloseBrace(text, openBraceIndex) ?: break
+            val body = text.substring(openBraceIndex + 1, closeBraceIndex)
+            results += serviceName to body
+            searchFrom = closeBraceIndex + 1
+        }
+        return results
+    }
+
+    private fun findMatchingCloseBrace(text: String, openBraceIndex: Int): Int? {
+        if (openBraceIndex !in text.indices || text[openBraceIndex] != '{') {
+            return null
+        }
+        var depth = 0
+        for (index in openBraceIndex until text.length) {
+            when (text[index]) {
+                '{' -> depth++
+                '}' -> {
+                    depth--
+                    if (depth == 0) {
+                        return index
+                    }
+                }
+            }
+        }
+        return null
+    }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollector.kt
@@ -1,0 +1,37 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+import com.linecorp.intellij.plugins.armeria.message
+
+internal object ArmeriaGrpcRouteCollector {
+    private val SERVICE_PATTERN = Regex("""service\s+(\w+)\s*\{([^}]*)\}""", RegexOption.DOT_MATCHES_ALL)
+    private val RPC_PATTERN = Regex("""rpc\s+(\w+)\s*\(""")
+
+    fun collect(project: Project, scope: GlobalSearchScope, routes: MutableList<ArmeriaRoute>) {
+        for (virtualFile in FilenameIndex.getAllFilesByExt(project, "proto", scope)) {
+            val psiFile = PsiManager.getInstance(project).findFile(virtualFile) ?: continue
+            val packageName = PACKAGE_PATTERN.find(psiFile.text)?.groupValues?.get(1).orEmpty()
+            for (match in SERVICE_PATTERN.findAll(psiFile.text)) {
+                val serviceName = match.groupValues[1]
+                val body = match.groupValues[2]
+                val fqService = if (packageName.isBlank()) serviceName else "$packageName.$serviceName"
+                for (rpc in RPC_PATTERN.findAll(body)) {
+                    val methodName = rpc.groupValues[1]
+                    routes += ArmeriaRoute.create(
+                        element = psiFile,
+                        protocol = message("route.explorer.protocol.grpc"),
+                        httpMethod = "RPC",
+                        path = "/$fqService/$methodName",
+                        target = "$fqService.$methodName",
+                        routeMatch = RouteMatch.NON_HTTP,
+                    )
+                }
+            }
+        }
+    }
+
+    private val PACKAGE_PATTERN = Regex("""package\s+([\w.]+)\s*;""")
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollector.kt
@@ -105,10 +105,12 @@ internal object ArmeriaGrpcRouteCollector {
         while (index < text.length) {
             when {
                 text.startsWith("//", index) -> {
+                    ensureTrailingWhitespace(result)
                     val lineEnd = text.indexOf('\n', index)
                     index = if (lineEnd < 0) text.length else lineEnd
                 }
                 text.startsWith("/*", index) -> {
+                    ensureTrailingWhitespace(result)
                     val blockEnd = text.indexOf("*/", index + 2)
                     index = if (blockEnd < 0) text.length else blockEnd + 2
                 }
@@ -119,5 +121,11 @@ internal object ArmeriaGrpcRouteCollector {
             }
         }
         return result.toString()
+    }
+
+    private fun ensureTrailingWhitespace(result: StringBuilder) {
+        if (result.isNotEmpty() && !result.last().isWhitespace()) {
+            result.append(' ')
+        }
     }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
@@ -75,6 +75,7 @@ object ArmeriaRouteCollector {
                 seenServiceRegistrations,
             )
         }
+        ArmeriaGrpcRouteCollector.collect(project, scope, routes)
 
         return CachedValueProvider.Result.create(
             routes.sortedWith(

--- a/plugin/src/main/resources/META-INF/grpc-integration.xml
+++ b/plugin/src/main/resources/META-INF/grpc-integration.xml
@@ -1,7 +1,2 @@
 <idea-plugin>
-    <extensions defaultExtensionNs="com.intellij">
-        <registryKey key="armeria.grpc.proto.routes.enabled"
-                     defaultValue="true"
-                     description="Include gRPC routes parsed from .proto files in Route Explorer"/>
-    </extensions>
 </idea-plugin>

--- a/plugin/src/main/resources/META-INF/grpc-integration.xml
+++ b/plugin/src/main/resources/META-INF/grpc-integration.xml
@@ -1,2 +1,7 @@
 <idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <registryKey key="armeria.grpc.proto.routes.enabled"
+                     defaultValue="true"
+                     description="Include gRPC routes parsed from .proto files in Route Explorer"/>
+    </extensions>
 </idea-plugin>

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -40,6 +40,9 @@
         <registryKey key="armeria.route.explorer.metrics"
                      defaultValue="false"
                      description="Log Armeria Route Explorer collection metrics at INFO level"/>
+        <registryKey key="armeria.grpc.proto.routes.enabled"
+                     defaultValue="true"
+                     description="Include gRPC routes parsed from .proto files in Route Explorer"/>
 
         <!-- Run configuration -->
         <configurationType implementation="com.linecorp.intellij.plugins.armeria.run.ArmeriaRunConfigurationType" />

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollectorTest.kt
@@ -102,6 +102,24 @@ class ArmeriaGrpcRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
     )
   }
 
+  fun testInlineBlockCommentBetweenTokensDoesNotMergeRpcName() {
+    myFixture.configureByText(
+      "greeter.proto",
+      """
+      syntax = "proto3";
+      package com.example;
+
+      service Greeter {
+        rpc/*inline*/SayHello(HelloRequest) returns (HelloResponse);
+      }
+      """.trimIndent(),
+    )
+
+    val routes = ArmeriaRouteCollector.collect(project)
+
+    assertEquals(listOf("/com.example.Greeter/SayHello"), routes.map { it.path })
+  }
+
   fun testCommentedRpcIsIgnored() {
     myFixture.configureByText(
       "greeter.proto",

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollectorTest.kt
@@ -1,0 +1,174 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+
+class ArmeriaGrpcRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
+  override fun setUp() {
+    super.setUp()
+    registerArmeriaStubs()
+  }
+
+  fun testCollectGrpcRoutesFromProto() {
+    myFixture.configureByText(
+      "greeter.proto",
+      """
+      syntax = "proto3";
+      package com.example;
+
+      service Greeter {
+        rpc SayHello(HelloRequest) returns (HelloResponse);
+        rpc SayGoodbye(HelloRequest) returns (HelloResponse);
+      }
+      """.trimIndent(),
+    )
+
+    val routes = ArmeriaRouteCollector.collect(project)
+    val protoRoutes = routes.filter { it.path.startsWith("/com.example.Greeter/") }.sortedBy { it.path }
+
+    assertEquals(2, protoRoutes.size)
+    assertEquals("/com.example.Greeter/SayGoodbye", protoRoutes[0].path)
+    assertEquals("com.example.Greeter.SayGoodbye", protoRoutes[0].target)
+    assertEquals(RouteMatch.NON_HTTP, protoRoutes[0].routeMatch)
+    assertEquals("/com.example.Greeter/SayHello", protoRoutes[1].path)
+    assertEquals("com.example.Greeter.SayHello", protoRoutes[1].target)
+  }
+
+  fun testCollectGrpcRoutesFromProtoWithoutPackage() {
+    myFixture.configureByText(
+      "greeter.proto",
+      """
+      syntax = "proto3";
+
+      service Greeter {
+        rpc Ping(PingRequest) returns (PingResponse);
+      }
+      """.trimIndent(),
+    )
+
+    val routes = ArmeriaRouteCollector.collect(project)
+    val protoRoute = routes.single { it.path == "/Greeter/Ping" }
+
+    assertEquals("Greeter.Ping", protoRoute.target)
+    assertEquals(RouteMatch.NON_HTTP, protoRoute.routeMatch)
+  }
+
+  fun testCollectGrpcRoutesFromProtoWithNestedHttpOptions() {
+    myFixture.configureByText(
+      "greeter.proto",
+      """
+      syntax = "proto3";
+      package com.example;
+
+      service Greeter {
+        rpc SayHello(HelloRequest) returns (HelloResponse) {
+          option (google.api.http) = {
+            post: "/v1/hello"
+            body: "*"
+          };
+        }
+      }
+      """.trimIndent(),
+    )
+
+    val routes = ArmeriaRouteCollector.collect(project)
+    val protoRoute = routes.firstOrNull { it.path == "/com.example.Greeter/SayHello" }
+
+    assertNotNull(protoRoute)
+    assertEquals("com.example.Greeter.SayHello", protoRoute!!.target)
+  }
+
+  fun testProtoRoutesCoexistWithGrpcServiceRegistration() {
+    myFixture.configureByText(
+      "greeter.proto",
+      """
+      syntax = "proto3";
+      package com.example;
+
+      service Greeter {
+        rpc SayHello(HelloRequest) returns (HelloResponse);
+      }
+      """.trimIndent(),
+    )
+    myFixture.configureByText(
+      "Main.java",
+      """
+      package example;
+
+      import com.linecorp.armeria.server.Server;
+      import com.linecorp.armeria.server.grpc.GrpcService;
+
+      public class Main {
+          public static void main(String[] args) {
+              Server.builder()
+                  .service("/grpc", GrpcService.builder(new HelloGrpcService()).build())
+                  .build();
+          }
+      }
+      """.trimIndent(),
+    )
+    myFixture.addClass(
+      """
+      package example;
+
+      public class HelloGrpcService {
+      }
+      """.trimIndent(),
+    )
+
+    val routes = ArmeriaRouteCollector.collect(project)
+
+    assertNotNull(routes.firstOrNull { it.path == "/grpc" })
+    assertNotNull(routes.firstOrNull { it.path == "/com.example.Greeter/SayHello" })
+  }
+
+  private fun registerArmeriaStubs() {
+    myFixture.addClass(
+      """
+      package com.linecorp.armeria.server;
+
+      public final class Server {
+          public static ServerBuilder builder() {
+              return new ServerBuilder();
+          }
+      }
+      """.trimIndent(),
+    )
+    myFixture.addClass(
+      """
+      package com.linecorp.armeria.server;
+
+      public final class ServerBuilder {
+          public ServerBuilder service(String path, Object service) {
+              return this;
+          }
+
+          public com.linecorp.armeria.server.Server build() {
+              return null;
+          }
+      }
+      """.trimIndent(),
+    )
+    myFixture.addClass(
+      """
+      package com.linecorp.armeria.server.grpc;
+
+      public final class GrpcService {
+          public static GrpcServiceBuilder builder(Object bindableService) {
+              return null;
+          }
+      }
+      """.trimIndent(),
+    )
+    myFixture.addClass(
+      """
+      package com.linecorp.armeria.server.grpc;
+
+      public final class GrpcServiceBuilder {
+          public com.linecorp.armeria.server.grpc.GrpcService build() {
+              return null;
+          }
+      }
+      """.trimIndent(),
+    )
+  }
+}

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollectorTest.kt
@@ -29,6 +29,7 @@ class ArmeriaGrpcRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
     assertEquals("/com.example.Greeter/SayGoodbye", protoRoutes[0].path)
     assertEquals("com.example.Greeter.SayGoodbye", protoRoutes[0].target)
     assertEquals(RouteMatch.NON_HTTP, protoRoutes[0].routeMatch)
+    assertEquals("", protoRoutes[0].httpMethod)
     assertEquals("/com.example.Greeter/SayHello", protoRoutes[1].path)
     assertEquals("com.example.Greeter.SayHello", protoRoutes[1].target)
   }

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollectorTest.kt
@@ -77,6 +77,94 @@ class ArmeriaGrpcRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
     assertEquals("com.example.Greeter.SayHello", protoRoute!!.target)
   }
 
+  fun testCollectGrpcRoutesFromMultipleServicesInOneProto() {
+    myFixture.configureByText(
+      "services.proto",
+      """
+      syntax = "proto3";
+      package com.example;
+
+      service Greeter {
+        rpc SayHello(HelloRequest) returns (HelloResponse);
+      }
+
+      service Admin {
+        rpc Ping(PingRequest) returns (PingResponse);
+      }
+      """.trimIndent(),
+    )
+
+    val routes = ArmeriaRouteCollector.collect(project).map { it.path }.sorted()
+
+    assertEquals(
+      listOf("/com.example.Admin/Ping", "/com.example.Greeter/SayHello"),
+      routes,
+    )
+  }
+
+  fun testCommentedRpcIsIgnored() {
+    myFixture.configureByText(
+      "greeter.proto",
+      """
+      syntax = "proto3";
+      package com.example;
+
+      service Greeter {
+        // rpc Deprecated(HelloRequest) returns (HelloResponse);
+        rpc SayHello(HelloRequest) returns (HelloResponse);
+      }
+      """.trimIndent(),
+    )
+
+    val routes = ArmeriaRouteCollector.collect(project)
+
+    assertEquals(listOf("/com.example.Greeter/SayHello"), routes.map { it.path })
+  }
+
+  fun testUnbalancedBraceDoesNotSkipLaterServices() {
+    val file = myFixture.configureByText(
+      "broken.proto",
+      """
+      syntax = "proto3";
+      package com.example;
+
+      service Broken {
+        rpc MissingBrace(HelloRequest) returns (HelloResponse) {
+      }
+
+      service Greeter {
+        rpc SayHello(HelloRequest) returns (HelloResponse);
+      }
+      """.trimIndent(),
+    )
+    val routes = mutableListOf<ArmeriaRoute>()
+    ArmeriaGrpcRouteCollector.collectFromProtoText(file.text, file, routes)
+
+    assertEquals(listOf("/com.example.Greeter/SayHello"), routes.map { it.path })
+  }
+
+  fun testDuplicateProtoRoutesAreDeduplicated() {
+    val file = myFixture.configureByText(
+      "greeter.proto",
+      """
+      syntax = "proto3";
+      package com.example;
+
+      service Greeter {
+        rpc SayHello(HelloRequest) returns (HelloResponse);
+      }
+      """.trimIndent(),
+    )
+    val routes = mutableListOf<ArmeriaRoute>()
+    val seenProtoRoutes = mutableSetOf<String>()
+    val element = file
+    ArmeriaGrpcRouteCollector.collectFromProtoText(file.text, element, routes, seenProtoRoutes)
+    ArmeriaGrpcRouteCollector.collectFromProtoText(file.text, element, routes, seenProtoRoutes)
+
+    assertEquals(1, routes.size)
+    assertEquals("/com.example.Greeter/SayHello", routes.single().path)
+  }
+
   fun testProtoRoutesCoexistWithGrpcServiceRegistration() {
     myFixture.configureByText(
       "greeter.proto",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Discovers gRPC routes from `.proto` service and RPC definitions in Route Explorer.

## Changes

- `ArmeriaGrpcRouteCollector` parses `.proto` service and RPC definitions
- Registry kill-switch: `armeria.grpc.proto.routes.enabled` (defaults to enabled when the key is not registered); registry key in `plugin.xml`
- Brace-aware parsing with brace-depth matching for nested `google.api.http` option blocks; unbalanced braces on one service do not abort later services
- Comment stripping ignores commented-out `rpc` declarations; inline block comments preserve token boundaries
- Proto-derived routes deduplicated by path
- `ArmeriaGrpcRouteCollectorTest` covers basic proto discovery, missing package, nested HTTP options, coexistence with `ServerBuilder` gRPC registrations, multi-service protos, comment false positives, inline block comments, brace recovery, and dedup

## Depends on

- #167 (Decorator analysis)

## Test plan

- [x] `./gradlew :plugin:compileKotlin :plugin:test`
- [x] `ArmeriaGrpcRouteCollectorTest` (9 cases)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2021-9dd6-73e2-bdb9-83969a21a5fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2021-9dd6-73e2-bdb9-83969a21a5fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

