### PR TITLE
feat: HTTP request generation from Route Explorer

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Implemented Armeria run configuration with module classpath and main class selection.
 - Added project-wide duplicate route registration inspection for ServerBuilder and annotated routes, with module-scoped caching and cross-registration conflict detection.
 - Added programmatic `ServerBuilder.decorator()` detection in Route Explorer.
-- Added HTTP Request file generation from Route Explorer routes.
+- Added HTTP Request file generation from Route Explorer routes, with method-aware filenames and toolbar enablement tied to the current tree selection.
 - Added Kotlin source support to Route Explorer for annotated services and Server.builder registrations.
 - Added Velocity-based regression tests for New Project Wizard file templates.
 - Added `plugin/src/test/resources/wizard-verification-matrix.md` documenting representative wizard scenarios.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Implemented Armeria run configuration with module classpath and main class selection.
 - Added project-wide duplicate route registration inspection for ServerBuilder and annotated routes, with module-scoped caching and cross-registration conflict detection.
 - Added programmatic `ServerBuilder.decorator()` detection in Route Explorer.
+- Added HTTP Request file generation from Route Explorer routes.
 - Added Kotlin source support to Route Explorer for annotated services and Server.builder registrations.
 - Added Velocity-based regression tests for New Project Wizard file templates.
 - Added `plugin/src/test/resources/wizard-verification-matrix.md` documenting representative wizard scenarios.

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGenerateHttpRequestAction.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGenerateHttpRequestAction.kt
@@ -1,0 +1,55 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.DumbAwareAction
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.linecorp.intellij.plugins.armeria.message
+import java.nio.file.Path
+
+class ArmeriaGenerateHttpRequestAction : DumbAwareAction(
+    message("route.explorer.action.generateHttpRequest"),
+) {
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val route = e.getData(ArmeriaRouteDataKeys.SELECTED_ROUTE) ?: return
+        if (route.httpMethod.isBlank() && route.routeMatch != RouteMatch.SERVICE) {
+            return
+        }
+        val httpMethod = route.httpMethod.ifBlank { "GET" }
+        val requestText = buildString {
+            appendLine("### ${route.path}")
+            appendLine("$httpMethod http://localhost:8080${route.path}")
+            appendLine("Accept: application/json")
+            appendLine()
+        }
+        createHttpFile(project, route.path, requestText)
+    }
+
+    private fun createHttpFile(project: Project, path: String, content: String) {
+        val fileName = "armeria-${path.trim('/').replace('/', '-')}.http"
+        val baseDir = project.basePath ?: return
+        val filePath = Path.of(baseDir, ".idea", "httpRequests", fileName)
+        ApplicationManager.getApplication().invokeLater {
+            WriteCommandAction.runWriteCommandAction(project) {
+                val parentDir = filePath.parent.toFile()
+                if (!parentDir.exists()) {
+                    parentDir.mkdirs()
+                }
+                val parent = LocalFileSystem.getInstance().refreshAndFindFileByPath(parentDir.path)
+                    ?: return@runWriteCommandAction
+                val existing = parent.findChild(fileName)
+                if (existing != null) {
+                    FileEditorManager.getInstance(project).openFile(existing, true)
+                    return@runWriteCommandAction
+                }
+                val virtualFile = parent.createChildData(this, fileName)
+                virtualFile.setBinaryContent(content.toByteArray())
+                FileEditorManager.getInstance(project).openFile(virtualFile, true)
+            }
+        }
+    }
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGenerateHttpRequestAction.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGenerateHttpRequestAction.kt
@@ -13,7 +13,8 @@ internal class ArmeriaGenerateHttpRequestAction(
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
 
     override fun update(e: AnActionEvent) {
-        if (e.project == null) {
+        val project = e.project
+        if (project == null || project.basePath == null) {
             e.presentation.isEnabled = false
             return
         }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGenerateHttpRequestAction.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGenerateHttpRequestAction.kt
@@ -1,55 +1,30 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.command.WriteCommandAction
-import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.DumbAwareAction
-import com.intellij.openapi.project.Project
-import com.intellij.openapi.vfs.LocalFileSystem
 import com.linecorp.intellij.plugins.armeria.message
-import java.nio.file.Path
 
-class ArmeriaGenerateHttpRequestAction : DumbAwareAction(
+class ArmeriaGenerateHttpRequestAction(
+    private val selectedRouteProvider: () -> ArmeriaRoute?,
+) : DumbAwareAction(
     message("route.explorer.action.generateHttpRequest"),
 ) {
-    override fun actionPerformed(e: AnActionEvent) {
-        val project = e.project ?: return
-        val route = e.getData(ArmeriaRouteDataKeys.SELECTED_ROUTE) ?: return
-        if (route.httpMethod.isBlank() && route.routeMatch != RouteMatch.SERVICE) {
-            return
-        }
-        val httpMethod = route.httpMethod.ifBlank { "GET" }
-        val requestText = buildString {
-            appendLine("### ${route.path}")
-            appendLine("$httpMethod http://localhost:8080${route.path}")
-            appendLine("Accept: application/json")
-            appendLine()
-        }
-        createHttpFile(project, route.path, requestText)
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
+
+    override fun update(e: AnActionEvent) {
+        val route = selectedRouteProvider()
+        e.presentation.isEnabled = e.project != null &&
+            route != null &&
+            ArmeriaHttpRequestGenerator.supports(route)
     }
 
-    private fun createHttpFile(project: Project, path: String, content: String) {
-        val fileName = "armeria-${path.trim('/').replace('/', '-')}.http"
-        val baseDir = project.basePath ?: return
-        val filePath = Path.of(baseDir, ".idea", "httpRequests", fileName)
-        ApplicationManager.getApplication().invokeLater {
-            WriteCommandAction.runWriteCommandAction(project) {
-                val parentDir = filePath.parent.toFile()
-                if (!parentDir.exists()) {
-                    parentDir.mkdirs()
-                }
-                val parent = LocalFileSystem.getInstance().refreshAndFindFileByPath(parentDir.path)
-                    ?: return@runWriteCommandAction
-                val existing = parent.findChild(fileName)
-                if (existing != null) {
-                    FileEditorManager.getInstance(project).openFile(existing, true)
-                    return@runWriteCommandAction
-                }
-                val virtualFile = parent.createChildData(this, fileName)
-                virtualFile.setBinaryContent(content.toByteArray())
-                FileEditorManager.getInstance(project).openFile(virtualFile, true)
-            }
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val route = selectedRouteProvider() ?: return
+        if (!ArmeriaHttpRequestGenerator.supports(route)) {
+            return
         }
+        ArmeriaHttpRequestFileWriter.createOrUpdate(project, route)
     }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGenerateHttpRequestAction.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGenerateHttpRequestAction.kt
@@ -5,7 +5,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAwareAction
 import com.linecorp.intellij.plugins.armeria.message
 
-class ArmeriaGenerateHttpRequestAction(
+internal class ArmeriaGenerateHttpRequestAction(
     private val selectedRouteProvider: () -> ArmeriaRoute?,
 ) : DumbAwareAction(
     message("route.explorer.action.generateHttpRequest"),

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGenerateHttpRequestAction.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGenerateHttpRequestAction.kt
@@ -13,10 +13,12 @@ internal class ArmeriaGenerateHttpRequestAction(
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
 
     override fun update(e: AnActionEvent) {
+        if (e.project == null) {
+            e.presentation.isEnabled = false
+            return
+        }
         val route = selectedRouteProvider()
-        e.presentation.isEnabled = e.project != null &&
-            route != null &&
-            ArmeriaHttpRequestGenerator.supports(route)
+        e.presentation.isEnabled = route != null && ArmeriaHttpRequestGenerator.supports(route)
     }
 
     override fun actionPerformed(e: AnActionEvent) {

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestFileWriter.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestFileWriter.kt
@@ -2,6 +2,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
@@ -10,6 +11,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Path
 
 internal object ArmeriaHttpRequestFileWriter {
+    private val LOG = logger<ArmeriaHttpRequestFileWriter>()
     fun createOrUpdate(project: Project, route: ArmeriaRoute) {
         val content = ArmeriaHttpRequestGenerator.requestText(route)
         val fileName = ArmeriaHttpRequestGenerator.fileName(route)
@@ -24,20 +26,27 @@ internal object ArmeriaHttpRequestFileWriter {
                 message("route.explorer.action.generateHttpRequest"),
                 null,
                 {
-                    val parentDir = filePath.parent.toFile()
-                    when {
-                        parentDir.exists() && !parentDir.isDirectory -> return@runWriteCommandAction
-                        !parentDir.exists() && !parentDir.mkdirs() -> return@runWriteCommandAction
+                    try {
+                        val parentDir = filePath.parent.toFile()
+                        when {
+                            parentDir.exists() && !parentDir.isDirectory -> return@runWriteCommandAction
+                            !parentDir.exists() && !parentDir.mkdirs() -> return@runWriteCommandAction
+                        }
+                        val parent = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(parentDir)
+                            ?: return@runWriteCommandAction
+                        if (!parent.isDirectory) {
+                            return@runWriteCommandAction
+                        }
+                        val existing = parent.findChild(fileName)
+                        if (existing != null && existing.isDirectory) {
+                            return@runWriteCommandAction
+                        }
+                        val virtualFile = existing ?: parent.createChildData(this, fileName)
+                        virtualFile.setBinaryContent(content.toByteArray(StandardCharsets.UTF_8))
+                        FileEditorManager.getInstance(project).openFile(virtualFile, true)
+                    } catch (e: Exception) {
+                        LOG.warn("Failed to create or update HTTP request file: $fileName", e)
                     }
-                    val parent = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(parentDir)
-                        ?: return@runWriteCommandAction
-                    if (!parent.isDirectory) {
-                        return@runWriteCommandAction
-                    }
-                    val virtualFile = parent.findChild(fileName)
-                        ?: parent.createChildData(this, fileName)
-                    virtualFile.setBinaryContent(content.toByteArray(StandardCharsets.UTF_8))
-                    FileEditorManager.getInstance(project).openFile(virtualFile, true)
                 },
             )
         }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestFileWriter.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestFileWriter.kt
@@ -25,10 +25,10 @@ internal object ArmeriaHttpRequestFileWriter {
                 null,
                 {
                     val parentDir = filePath.parent.toFile()
-                    if (!parentDir.exists()) {
-                        parentDir.mkdirs()
+                    if (!parentDir.exists() && !parentDir.mkdirs()) {
+                        return@runWriteCommandAction
                     }
-                    val parent = LocalFileSystem.getInstance().refreshAndFindFileByPath(parentDir.path)
+                    val parent = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(parentDir)
                         ?: return@runWriteCommandAction
                     val virtualFile = parent.findChild(fileName)
                         ?: parent.createChildData(this, fileName)

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestFileWriter.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestFileWriter.kt
@@ -1,0 +1,41 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.linecorp.intellij.plugins.armeria.message
+import java.nio.charset.StandardCharsets
+import java.nio.file.Path
+
+internal object ArmeriaHttpRequestFileWriter {
+    fun createOrUpdate(project: Project, route: ArmeriaRoute) {
+        val content = ArmeriaHttpRequestGenerator.requestText(route)
+        val fileName = ArmeriaHttpRequestGenerator.fileName(route)
+        val baseDir = project.basePath ?: return
+        val filePath = Path.of(baseDir, ".idea", "httpRequests", fileName)
+        ApplicationManager.getApplication().invokeLater {
+            if (project.isDisposed) {
+                return@invokeLater
+            }
+            WriteCommandAction.runWriteCommandAction(
+                project,
+                message("route.explorer.action.generateHttpRequest"),
+                null,
+                {
+                    val parentDir = filePath.parent.toFile()
+                    if (!parentDir.exists()) {
+                        parentDir.mkdirs()
+                    }
+                    val parent = LocalFileSystem.getInstance().refreshAndFindFileByPath(parentDir.path)
+                        ?: return@runWriteCommandAction
+                    val virtualFile = parent.findChild(fileName)
+                        ?: parent.createChildData(this, fileName)
+                    virtualFile.setBinaryContent(content.toByteArray(StandardCharsets.UTF_8))
+                    FileEditorManager.getInstance(project).openFile(virtualFile, true)
+                },
+            )
+        }
+    }
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestFileWriter.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestFileWriter.kt
@@ -25,11 +25,15 @@ internal object ArmeriaHttpRequestFileWriter {
                 null,
                 {
                     val parentDir = filePath.parent.toFile()
-                    if (!parentDir.exists() && !parentDir.mkdirs()) {
-                        return@runWriteCommandAction
+                    when {
+                        parentDir.exists() && !parentDir.isDirectory -> return@runWriteCommandAction
+                        !parentDir.exists() && !parentDir.mkdirs() -> return@runWriteCommandAction
                     }
                     val parent = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(parentDir)
                         ?: return@runWriteCommandAction
+                    if (!parent.isDirectory) {
+                        return@runWriteCommandAction
+                    }
                     val virtualFile = parent.findChild(fileName)
                         ?: parent.createChildData(this, fileName)
                     virtualFile.setBinaryContent(content.toByteArray(StandardCharsets.UTF_8))

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestFileWriter.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestFileWriter.kt
@@ -29,16 +29,27 @@ internal object ArmeriaHttpRequestFileWriter {
                     try {
                         val parentDir = filePath.parent.toFile()
                         when {
-                            parentDir.exists() && !parentDir.isDirectory -> return@runWriteCommandAction
-                            !parentDir.exists() && !parentDir.mkdirs() -> return@runWriteCommandAction
+                            parentDir.exists() && !parentDir.isDirectory -> {
+                                LOG.warn("HTTP request parent path exists but is not a directory: $parentDir")
+                                return@runWriteCommandAction
+                            }
+                            !parentDir.exists() && !parentDir.mkdirs() -> {
+                                LOG.warn("Failed to create HTTP request directory: $parentDir")
+                                return@runWriteCommandAction
+                            }
                         }
                         val parent = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(parentDir)
-                            ?: return@runWriteCommandAction
+                        if (parent == null) {
+                            LOG.warn("Failed to resolve HTTP request directory in VFS: $parentDir")
+                            return@runWriteCommandAction
+                        }
                         if (!parent.isDirectory) {
+                            LOG.warn("HTTP request parent path is not a directory in VFS: $parentDir")
                             return@runWriteCommandAction
                         }
                         val existing = parent.findChild(fileName)
                         if (existing != null && existing.isDirectory) {
+                            LOG.warn("Cannot create HTTP request file because path exists as a directory: ${existing.path}")
                             return@runWriteCommandAction
                         }
                         val virtualFile = existing ?: parent.createChildData(this, fileName)

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGenerator.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGenerator.kt
@@ -1,7 +1,11 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
+import java.util.Locale
+
 internal object ArmeriaHttpRequestGenerator {
     const val DEFAULT_BASE_URL = "http://localhost:8080"
+
+    private val NON_SLUG_CHARACTERS = Regex("[^a-zA-Z0-9._-]")
 
     fun supports(route: ArmeriaRoute): Boolean {
         return when (route.routeMatch) {
@@ -21,7 +25,7 @@ internal object ArmeriaHttpRequestGenerator {
     }
 
     fun fileName(route: ArmeriaRoute): String {
-        val method = httpMethod(route).lowercase()
+        val method = httpMethod(route).lowercase(Locale.ROOT)
         return "armeria-$method-${pathSlug(route.path)}.http"
     }
 
@@ -42,6 +46,6 @@ internal object ArmeriaHttpRequestGenerator {
         }
         return trimmed
             .replace('/', '-')
-            .replace(Regex("[^a-zA-Z0-9._-]"), "-")
+            .replace(NON_SLUG_CHARACTERS, "-")
     }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGenerator.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGenerator.kt
@@ -15,7 +15,8 @@ internal object ArmeriaHttpRequestGenerator {
         return when (route.routeMatch) {
             RouteMatch.ANNOTATED_HTTP -> route.httpMethod
             RouteMatch.SERVICE, RouteMatch.SERVICE_UNDER -> "GET"
-            else -> "GET"
+            RouteMatch.ANNOTATED_SERVICE, RouteMatch.NON_HTTP ->
+                error("Unsupported route match: ${route.routeMatch}")
         }
     }
 

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGenerator.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGenerator.kt
@@ -1,0 +1,46 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+internal object ArmeriaHttpRequestGenerator {
+    const val DEFAULT_BASE_URL = "http://localhost:8080"
+
+    fun supports(route: ArmeriaRoute): Boolean {
+        return when (route.routeMatch) {
+            RouteMatch.ANNOTATED_HTTP -> route.httpMethod.isNotBlank()
+            RouteMatch.SERVICE, RouteMatch.SERVICE_UNDER -> true
+            RouteMatch.ANNOTATED_SERVICE, RouteMatch.NON_HTTP -> false
+        }
+    }
+
+    fun httpMethod(route: ArmeriaRoute): String {
+        return when (route.routeMatch) {
+            RouteMatch.ANNOTATED_HTTP -> route.httpMethod
+            RouteMatch.SERVICE, RouteMatch.SERVICE_UNDER -> "GET"
+            else -> "GET"
+        }
+    }
+
+    fun fileName(route: ArmeriaRoute): String {
+        val method = httpMethod(route).lowercase()
+        return "armeria-$method-${pathSlug(route.path)}.http"
+    }
+
+    fun requestText(route: ArmeriaRoute, baseUrl: String = DEFAULT_BASE_URL): String {
+        val method = httpMethod(route)
+        return buildString {
+            appendLine("### ${route.path}")
+            appendLine("$method $baseUrl${route.path}")
+            appendLine("Accept: application/json")
+            appendLine()
+        }
+    }
+
+    private fun pathSlug(path: String): String {
+        val trimmed = path.trim('/')
+        if (trimmed.isEmpty()) {
+            return "root"
+        }
+        return trimmed
+            .replace('/', '-')
+            .replace(Regex("[^a-zA-Z0-9._-]"), "-")
+    }
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDataKeys.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDataKeys.kt
@@ -1,7 +1,0 @@
-package com.linecorp.intellij.plugins.armeria.explorer
-
-import com.intellij.openapi.actionSystem.DataKey
-
-object ArmeriaRouteDataKeys {
-    val SELECTED_ROUTE: DataKey<ArmeriaRoute> = DataKey.create("ARMERIA_SELECTED_ROUTE")
-}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDataKeys.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDataKeys.kt
@@ -1,0 +1,7 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.intellij.openapi.actionSystem.DataKey
+
+object ArmeriaRouteDataKeys {
+    val SELECTED_ROUTE: DataKey<ArmeriaRoute> = DataKey.create("ARMERIA_SELECTED_ROUTE")
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerPanel.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerPanel.kt
@@ -4,10 +4,8 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.actionSystem.DataSink
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.actionSystem.ToggleAction
-import com.intellij.openapi.actionSystem.UiDataProvider
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.fileEditor.FileEditorManager
@@ -41,9 +39,8 @@ import javax.swing.tree.TreePath
 
 class ArmeriaRouteExplorerPanel(
     private val project: Project,
-) : SimpleToolWindowPanel(true, true), Disposable, UiDataProvider {
+) : SimpleToolWindowPanel(true, true), Disposable {
     private var currentRoutes: List<ArmeriaRoute> = emptyList()
-    private var selectedRoute: ArmeriaRoute? = null
     private var currentModuleOnly = false
     private var initialRefreshScheduled = false
 
@@ -76,7 +73,7 @@ class ArmeriaRouteExplorerPanel(
                     updateStatusLabel()
                 }
             })
-            add(ArmeriaGenerateHttpRequestAction())
+            add(ArmeriaGenerateHttpRequestAction { selectedRouteFromTree() })
         }
         toolbar = ActionManager.getInstance().createActionToolbar("ArmeriaRouteExplorer", actionGroup, true).also {
             it.targetComponent = this
@@ -96,8 +93,7 @@ class ArmeriaRouteExplorerPanel(
             true,
         )
         routeTree.addTreeSelectionListener { _: TreeSelectionEvent ->
-            selectedRoute = ArmeriaRouteTreeBuilder.selectedRoute(routeTree.lastSelectedPathComponent)
-            routeDetailPanel.setRoute(selectedRoute)
+            routeDetailPanel.setRoute(selectedRouteFromTree())
         }
         routeTree.addMouseListener(object : MouseAdapter() {
             override fun mouseClicked(event: MouseEvent) {
@@ -269,8 +265,8 @@ class ArmeriaRouteExplorerPanel(
             .submit(AppExecutorUtil.getAppExecutorService())
     }
 
-    override fun uiDataSnapshot(sink: DataSink) {
-        selectedRoute?.let { sink[ArmeriaRouteDataKeys.SELECTED_ROUTE] = it }
+    private fun selectedRouteFromTree(): ArmeriaRoute? {
+        return ArmeriaRouteTreeBuilder.selectedRoute(routeTree.lastSelectedPathComponent)
     }
 
     override fun dispose() = Unit

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerPanel.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerPanel.kt
@@ -4,8 +4,10 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DataSink
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.actionSystem.ToggleAction
+import com.intellij.openapi.actionSystem.UiDataProvider
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.fileEditor.FileEditorManager
@@ -39,8 +41,9 @@ import javax.swing.tree.TreePath
 
 class ArmeriaRouteExplorerPanel(
     private val project: Project,
-) : SimpleToolWindowPanel(true, true), Disposable {
+) : SimpleToolWindowPanel(true, true), Disposable, UiDataProvider {
     private var currentRoutes: List<ArmeriaRoute> = emptyList()
+    private var selectedRoute: ArmeriaRoute? = null
     private var currentModuleOnly = false
     private var initialRefreshScheduled = false
 
@@ -73,6 +76,7 @@ class ArmeriaRouteExplorerPanel(
                     updateStatusLabel()
                 }
             })
+            add(ArmeriaGenerateHttpRequestAction())
         }
         toolbar = ActionManager.getInstance().createActionToolbar("ArmeriaRouteExplorer", actionGroup, true).also {
             it.targetComponent = this
@@ -92,7 +96,8 @@ class ArmeriaRouteExplorerPanel(
             true,
         )
         routeTree.addTreeSelectionListener { _: TreeSelectionEvent ->
-            routeDetailPanel.setRoute(ArmeriaRouteTreeBuilder.selectedRoute(routeTree.lastSelectedPathComponent))
+            selectedRoute = ArmeriaRouteTreeBuilder.selectedRoute(routeTree.lastSelectedPathComponent)
+            routeDetailPanel.setRoute(selectedRoute)
         }
         routeTree.addMouseListener(object : MouseAdapter() {
             override fun mouseClicked(event: MouseEvent) {
@@ -262,6 +267,10 @@ class ArmeriaRouteExplorerPanel(
                 navigatable?.navigate(true)
             }
             .submit(AppExecutorUtil.getAppExecutorService())
+    }
+
+    override fun uiDataSnapshot(sink: DataSink) {
+        selectedRoute?.let { sink[ArmeriaRouteDataKeys.SELECTED_ROUTE] = it }
     }
 
     override fun dispose() = Unit

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerPanel.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerPanel.kt
@@ -252,7 +252,7 @@ class ArmeriaRouteExplorerPanel(
     }
 
     private fun navigateToSelection() {
-        val route = ArmeriaRouteTreeBuilder.selectedRoute(routeTree.lastSelectedPathComponent) ?: return
+        val route = selectedRouteFromTree() ?: return
         ReadAction.nonBlocking<Navigatable?> {
             val element = route.pointer.element as? Navigatable
             element?.takeIf { it.canNavigate() }

--- a/plugin/src/main/resources/messages/ArmeriaBundle.properties
+++ b/plugin/src/main/resources/messages/ArmeriaBundle.properties
@@ -186,5 +186,6 @@ route.explorer.summary.docService=DocService detected
 route.explorer.summary.moduleFilterNoEditor=Open a file in the module to filter routes.
 route.explorer.empty=No Armeria routes found
 route.explorer.action.refresh=Refresh
+route.explorer.action.generateHttpRequest=Generate HTTP Request
 route.explorer.footnote.static=Routes are discovered by static analysis and may differ from runtime.
 route.explorer.tree.module={0} ({1})

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGeneratorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGeneratorTest.kt
@@ -1,0 +1,134 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.SmartPsiElementPointer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ArmeriaHttpRequestGeneratorTest {
+    @Test
+    fun supports_annotatedHttpRouteWithMethod() {
+        val route = route(httpMethod = "POST", routeMatch = RouteMatch.ANNOTATED_HTTP)
+
+        assertTrue(ArmeriaHttpRequestGenerator.supports(route))
+    }
+
+    @Test
+    fun supports_rejectsAnnotatedHttpRouteWithoutMethod() {
+        val route = route(httpMethod = "", routeMatch = RouteMatch.ANNOTATED_HTTP)
+
+        assertFalse(ArmeriaHttpRequestGenerator.supports(route))
+    }
+
+    @Test
+    fun supports_serviceRouteWithBlankMethod() {
+        val route = route(httpMethod = "", routeMatch = RouteMatch.SERVICE)
+
+        assertTrue(ArmeriaHttpRequestGenerator.supports(route))
+    }
+
+    @Test
+    fun supports_serviceUnderRouteWithBlankMethod() {
+        val route = route(httpMethod = "", path = "/v1", routeMatch = RouteMatch.SERVICE_UNDER)
+
+        assertTrue(ArmeriaHttpRequestGenerator.supports(route))
+    }
+
+    @Test
+    fun supports_rejectsNonHttpRoutes() {
+        assertFalse(ArmeriaHttpRequestGenerator.supports(route(routeMatch = RouteMatch.ANNOTATED_SERVICE)))
+        assertFalse(
+            ArmeriaHttpRequestGenerator.supports(
+                route(protocol = "gRPC", routeMatch = RouteMatch.NON_HTTP),
+            ),
+        )
+    }
+
+    @Test
+    fun httpMethod_defaultsServiceRoutesToGet() {
+        assertEquals("GET", ArmeriaHttpRequestGenerator.httpMethod(route(routeMatch = RouteMatch.SERVICE)))
+        assertEquals("GET", ArmeriaHttpRequestGenerator.httpMethod(route(path = "/v1", routeMatch = RouteMatch.SERVICE_UNDER)))
+    }
+
+    @Test
+    fun httpMethod_usesAnnotatedHttpMethod() {
+        assertEquals("PATCH", ArmeriaHttpRequestGenerator.httpMethod(route(httpMethod = "PATCH")))
+    }
+
+    @Test
+    fun fileName_includesMethodAndPathSlug() {
+        val route = route(httpMethod = "POST", path = "/api/users/{id}")
+
+        assertEquals("armeria-post-api-users--id-.http", ArmeriaHttpRequestGenerator.fileName(route))
+    }
+
+    @Test
+    fun fileName_usesRootSlugForEmptyPath() {
+        assertEquals("armeria-get-root.http", ArmeriaHttpRequestGenerator.fileName(route(path = "/")))
+    }
+
+    @Test
+    fun fileName_distinguishesMethodsOnSamePath() {
+        val getRoute = route(httpMethod = "GET", path = "/api/users")
+        val postRoute = route(httpMethod = "POST", path = "/api/users")
+
+        assertEquals("armeria-get-api-users.http", ArmeriaHttpRequestGenerator.fileName(getRoute))
+        assertEquals("armeria-post-api-users.http", ArmeriaHttpRequestGenerator.fileName(postRoute))
+    }
+
+    @Test
+    fun requestText_includesMethodPathAndDefaultHost() {
+        val route = route(httpMethod = "POST", path = "/api/users")
+
+        assertEquals(
+            """
+            ### /api/users
+            POST http://localhost:8080/api/users
+            Accept: application/json
+
+            """.trimIndent() + "\n",
+            ArmeriaHttpRequestGenerator.requestText(route),
+        )
+    }
+
+    private fun route(
+        httpMethod: String = "GET",
+        path: String = "/api",
+        protocol: String = "HTTP",
+        routeMatch: RouteMatch = RouteMatch.ANNOTATED_HTTP,
+    ): ArmeriaRoute {
+        return ArmeriaRoute(
+            protocol = protocol,
+            httpMethod = httpMethod,
+            path = path,
+            target = "Handler",
+            routeMatch = routeMatch,
+            moduleName = "app",
+            targetUnresolved = false,
+            isDocService = false,
+            decorators = emptyList(),
+            exceptionHandlers = emptyList(),
+            pointer = TestPsiPointer,
+        )
+    }
+
+    private object TestPsiPointer : SmartPsiElementPointer<PsiElement> {
+        override fun getElement(): PsiElement? = null
+
+        override fun getContainingFile(): PsiFile? = null
+
+        override fun getRange(): TextRange? = null
+
+        override fun getProject(): Project = throw UnsupportedOperationException()
+
+        override fun getVirtualFile(): VirtualFile = throw UnsupportedOperationException()
+
+        override fun getPsiRange(): TextRange? = null
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Generate IntelliJ HTTP Client `.http` files from the selected Route Explorer entry.

- Adds a toolbar action that writes `.idea/httpRequests/*.http` files and opens them in the editor
- `ArmeriaHttpRequestGenerator` handles route eligibility, request text, and method-aware filenames (e.g. `armeria-post-api-users.http`)
- `ArmeriaHttpRequestFileWriter` creates the output directory, overwrites existing files on regenerate, and resolves paths through the VFS
- Supports annotated HTTP routes (with method) and `service` / `serviceUnder` mounts (generated as GET)
- Disables the action when no route is selected, the project has no base path, or the route type is unsupported (gRPC, annotated-service-only, etc.)
- Reads the selected route from the tree at action time via a supplier so selection stays in sync after refresh or filter changes

## Depends on

- #168

## Test plan

- [x] `./gradlew :plugin:compileKotlin :plugin:test`
- [x] `ArmeriaHttpRequestGeneratorTest` (11 cases)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2021-9dd6-73e2-bdb9-83969a21a5fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2021-9dd6-73e2-bdb9-83969a21a5fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

