### PR TITLE
feat: Spring Boot Armeria route detection

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added project-wide duplicate route registration inspection for ServerBuilder and annotated routes, with module-scoped caching and cross-registration conflict detection.
 - Added programmatic `ServerBuilder.decorator()` detection in Route Explorer.
 - Added HTTP Request file generation from Route Explorer routes, with method-aware filenames and toolbar enablement tied to the current tree selection.
+- Added Spring Boot `@Bean` Server registration discovery.
 - Added Kotlin source support to Route Explorer for annotated services and Server.builder registrations.
 - Added Velocity-based regression tests for New Project Wizard file templates.
 - Added `plugin/src/test/resources/wizard-verification-matrix.md` documenting representative wizard scenarios.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Added project-wide duplicate route registration inspection for ServerBuilder and annotated routes, with module-scoped caching and cross-registration conflict detection.
 - Added programmatic `ServerBuilder.decorator()` detection in Route Explorer.
 - Added HTTP Request file generation from Route Explorer routes, with method-aware filenames and toolbar enablement tied to the current tree selection.
-- Added Spring Boot `@Bean` Server registration discovery.
+- Added Spring Boot `@Bean` Server registration discovery for Java and Kotlin sources.
 - Added Kotlin source support to Route Explorer for annotated services and Server.builder registrations.
 - Added Velocity-based regression tests for New Project Wizard file templates.
 - Added `plugin/src/test/resources/wizard-verification-matrix.md` documenting representative wizard scenarios.

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
@@ -65,12 +65,12 @@ internal object ArmeriaKotlinRouteCollector {
         }
     }
 
-    private fun collectServiceRegistrationsFromFile(
-        file: KtFile,
+    internal fun collectServiceRegistrationsInScope(
+        root: PsiElement,
         routes: MutableList<ArmeriaRoute>,
         seenServiceRegistrations: MutableSet<String>,
     ) {
-        file.forEachDescendant { element ->
+        root.forEachDescendant { element ->
             val call = element as? KtCallExpression ?: return@forEachDescendant
             ArmeriaRouteCollectionMetrics.current()?.methodCallsVisited?.incrementAndGet()
             val methodName = resolveCallName(call) ?: return@forEachDescendant
@@ -82,6 +82,14 @@ internal object ArmeriaKotlinRouteCollector {
             }
             addKotlinServiceRegistration(call, methodName, routes, seenServiceRegistrations)
         }
+    }
+
+    private fun collectServiceRegistrationsFromFile(
+        file: KtFile,
+        routes: MutableList<ArmeriaRoute>,
+        seenServiceRegistrations: MutableSet<String>,
+    ) {
+        collectServiceRegistrationsInScope(file, routes, seenServiceRegistrations)
     }
 
     private inline fun PsiElement.forEachDescendant(action: (PsiElement) -> Unit) {

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
@@ -75,6 +75,7 @@ object ArmeriaRouteCollector {
                 seenServiceRegistrations,
             )
         }
+        ArmeriaSpringBootRouteCollector.collect(project, scope, routes)
 
         return CachedValueProvider.Result.create(
             routes.sortedWith(

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
@@ -75,7 +75,13 @@ object ArmeriaRouteCollector {
                 seenServiceRegistrations,
             )
         }
-        ArmeriaSpringBootRouteCollector.collect(project, scope, routes)
+        ArmeriaSpringBootRouteCollector.collect(
+            project,
+            scope,
+            routes,
+            fallbackScannedFiles,
+            seenServiceRegistrations,
+        )
 
         return CachedValueProvider.Result.create(
             routes.sortedWith(
@@ -205,7 +211,7 @@ object ArmeriaRouteCollector {
         })
     }
 
-    private fun collectServiceRegistrationFromMethodCall(
+    internal fun collectServiceRegistrationFromMethodCall(
         expression: PsiMethodCallExpression,
         routes: MutableList<ArmeriaRoute>,
         seenServiceRegistrations: MutableSet<String>,

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
@@ -75,13 +75,15 @@ object ArmeriaRouteCollector {
                 seenServiceRegistrations,
             )
         }
-        ArmeriaSpringBootRouteCollector.collect(
-            project,
-            scope,
-            routes,
-            fallbackScannedFiles,
-            seenServiceRegistrations,
-        )
+        if (psiFacade.findClass(ArmeriaRouteSupport.SPRING_BEAN_ANNOTATION, scope) != null) {
+            ArmeriaSpringBootRouteCollector.collect(
+                project,
+                scope,
+                routes,
+                fallbackScannedFiles,
+                seenServiceRegistrations,
+            )
+        }
 
         return CachedValueProvider.Result.create(
             routes.sortedWith(

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
@@ -75,12 +75,11 @@ object ArmeriaRouteCollector {
                 seenServiceRegistrations,
             )
         }
-        if (psiFacade.findClass(ArmeriaRouteSupport.SPRING_BEAN_ANNOTATION, scope) != null) {
+        if (ArmeriaRouteSupport.isSpringBootArmeriaAvailable(psiFacade, scope)) {
             ArmeriaSpringBootRouteCollector.collect(
                 project,
                 scope,
                 routes,
-                fallbackScannedFiles,
                 seenServiceRegistrations,
             )
         }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
@@ -25,8 +25,12 @@ internal enum class ServiceRegistrationMethod(val methodName: String) {
 
 object ArmeriaRouteSupport {
     const val ARMERIA_PACKAGE_PREFIX = "com.linecorp.armeria"
+    const val ARMERIA_SPRING_PACKAGE_PREFIX = "com.linecorp.armeria.spring"
     const val ARMERIA_SERVER_PACKAGE_PREFIX = "com.linecorp.armeria.server"
+    const val ARMERIA_SERVER_CLASS = "com.linecorp.armeria.server.Server"
+    const val ARMERIA_SERVER_CONFIGURATOR_CLASS = "$ARMERIA_SPRING_PACKAGE_PREFIX.ArmeriaServerConfigurator"
     const val SERVER_BUILDER_CLASS = "com.linecorp.armeria.server.ServerBuilder"
+    const val SPRING_BEAN_ANNOTATION = "org.springframework.context.annotation.Bean"
     const val SERVER_BUILDER_SIMPLE_NAME = "ServerBuilder"
     const val ARMERIA_HEADER_SCAN_LIMIT = 4096
 

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
@@ -2,11 +2,14 @@ package com.linecorp.intellij.plugins.armeria.explorer
 
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.PsiAnnotationMemberValue
 import com.intellij.psi.PsiArrayInitializerMemberValue
 import com.intellij.psi.PsiField
 import com.intellij.psi.PsiLiteralExpression
-import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiVariable
 
 internal enum class ServiceRegistrationMethod(val methodName: String) {
@@ -173,6 +176,55 @@ object ArmeriaRouteSupport {
             return remainder.isNotEmpty() && !remainder.contains('/')
         }
         return normalizedRoute == normalizedPattern
+    }
+
+    fun isSpringBootArmeriaAvailable(psiFacade: JavaPsiFacade, scope: GlobalSearchScope): Boolean {
+        if (psiFacade.findClass(SPRING_BEAN_ANNOTATION, scope) == null) {
+            return false
+        }
+        return psiFacade.findClass(ARMERIA_SERVER_CONFIGURATOR_CLASS, scope) != null ||
+            psiFacade.findClass(SERVER_BUILDER_CLASS, scope) != null ||
+            psiFacade.findClass(ARMERIA_SERVER_CLASS, scope) != null
+    }
+
+    fun isArmeriaServerBeanReturnType(method: PsiMethod, scope: GlobalSearchScope): Boolean {
+        val returnType = method.returnType ?: return false
+        val psiClass = (returnType as? PsiClassType)?.resolve()
+        if (psiClass != null) {
+            return isArmeriaServerBeanReturnType(psiClass, JavaPsiFacade.getInstance(method.project), scope)
+        }
+        return isArmeriaServerBeanReturnType(returnType.canonicalText)
+    }
+
+    fun isArmeriaServerBeanReturnType(returnType: String): Boolean {
+        if (returnType == ARMERIA_SERVER_CLASS || isServerBuilderType(returnType)) {
+            return true
+        }
+        return returnType == ARMERIA_SERVER_CONFIGURATOR_CLASS
+    }
+
+    private fun isArmeriaServerBeanReturnType(
+        psiClass: PsiClass,
+        psiFacade: JavaPsiFacade,
+        scope: GlobalSearchScope,
+    ): Boolean {
+        val qualifiedName = psiClass.qualifiedName
+        if (qualifiedName == ARMERIA_SERVER_CLASS ||
+            qualifiedName == ARMERIA_SERVER_CONFIGURATOR_CLASS ||
+            isServerBuilderType(qualifiedName.orEmpty())
+        ) {
+            return true
+        }
+        val configuratorClass = psiFacade.findClass(ARMERIA_SERVER_CONFIGURATOR_CLASS, scope)
+        if (configuratorClass != null && psiClass.isInheritor(configuratorClass, true)) {
+            return true
+        }
+        val serverClass = psiFacade.findClass(ARMERIA_SERVER_CLASS, scope)
+        if (serverClass != null && psiClass.isInheritor(serverClass, true)) {
+            return true
+        }
+        val serverBuilderClass = psiFacade.findClass(SERVER_BUILDER_CLASS, scope)
+        return serverBuilderClass != null && psiClass.isInheritor(serverBuilderClass, true)
     }
 
     fun isServerBuilderType(typeText: String): Boolean {

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringBootRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringBootRouteCollector.kt
@@ -26,7 +26,6 @@ internal object ArmeriaSpringBootRouteCollector {
             if (!ArmeriaRouteSupport.isArmeriaServerBeanReturnType(method, scope)) {
                 return@forEach
             }
-            ArmeriaRouteCollectionMetrics.current()?.armeriaFiles?.incrementAndGet()
             collectServiceRegistrationsFromBeanMethod(method, routes, seenServiceRegistrations)
         }
     }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringBootRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringBootRouteCollector.kt
@@ -1,15 +1,19 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.JavaRecursiveElementWalkingVisitor
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiMethodCallExpression
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.AnnotatedElementsSearch
-import org.jetbrains.kotlin.asJava.elements.KtLightMethod
 
 internal object ArmeriaSpringBootRouteCollector {
+    private val KOTLIN_PLUGIN_ID = PluginId.getId("org.jetbrains.kotlin")
+    private const val KOTLIN_LIGHT_METHOD_CLASS = "org.jetbrains.kotlin.asJava.elements.KtLightMethod"
     fun collect(
         project: Project,
         scope: GlobalSearchScope,
@@ -35,8 +39,8 @@ internal object ArmeriaSpringBootRouteCollector {
         routes: MutableList<ArmeriaRoute>,
         seenServiceRegistrations: MutableSet<String>,
     ) {
-        val kotlinMethod = (method as? KtLightMethod)?.kotlinOrigin
-        if (kotlinMethod != null) {
+        val kotlinMethod = resolveKotlinOrigin(method)
+        if (kotlinMethod != null && isKotlinPluginAvailable()) {
             ArmeriaKotlinRouteCollector.collectServiceRegistrationsInScope(
                 kotlinMethod,
                 routes,
@@ -55,4 +59,18 @@ internal object ArmeriaSpringBootRouteCollector {
             }
         })
     }
+
+    private fun resolveKotlinOrigin(method: PsiMethod): PsiElement? {
+        if (method.javaClass.name != KOTLIN_LIGHT_METHOD_CLASS) {
+            return null
+        }
+        return try {
+            method.javaClass.getMethod("getKotlinOrigin").invoke(method) as? PsiElement
+        } catch (_: ReflectiveOperationException) {
+            null
+        }
+    }
+
+    private fun isKotlinPluginAvailable(): Boolean =
+        PluginManagerCore.isLoaded(KOTLIN_PLUGIN_ID)
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringBootRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringBootRouteCollector.kt
@@ -1,0 +1,70 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.intellij.ide.highlighter.JavaFileType
+import com.intellij.openapi.project.Project
+import com.intellij.psi.JavaRecursiveElementWalkingVisitor
+import com.intellij.psi.PsiJavaFile
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.psi.search.FileTypeIndex
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.util.PsiTreeUtil
+import com.linecorp.intellij.plugins.armeria.message
+
+internal object ArmeriaSpringBootRouteCollector {
+    private val SPRING_BOOT_INDICATORS = setOf(
+        "ArmeriaServerConfigurator",
+        "ArmeriaAutoConfiguration",
+        "spring-boot-starter-armeria",
+    )
+
+    fun collect(project: Project, scope: GlobalSearchScope, routes: MutableList<ArmeriaRoute>) {
+        for (virtualFile in FileTypeIndex.getFiles(JavaFileType.INSTANCE, scope)) {
+            val file = com.intellij.psi.PsiManager.getInstance(project).findFile(virtualFile) as? PsiJavaFile ?: continue
+            if (!referencesSpringBootArmeria(file)) {
+                continue
+            }
+            collectBeanServerRegistrations(file, routes)
+        }
+    }
+
+    private fun referencesSpringBootArmeria(file: PsiJavaFile): Boolean {
+        val text = file.text
+        return SPRING_BOOT_INDICATORS.any(text::contains) ||
+            file.importList?.allImportStatements?.any { import ->
+                import.importReference?.qualifiedName?.contains("armeria.spring") == true
+            } == true
+    }
+
+    private fun collectBeanServerRegistrations(file: PsiJavaFile, routes: MutableList<ArmeriaRoute>) {
+        file.accept(object : JavaRecursiveElementWalkingVisitor() {
+            override fun visitMethod(method: PsiMethod) {
+                if (!method.hasAnnotation("org.springframework.context.annotation.Bean")) {
+                    super.visitMethod(method)
+                    return
+                }
+                val returnType = method.returnType?.canonicalText.orEmpty()
+                if (!returnType.contains("Server") && !returnType.contains("ServerBuilder")) {
+                    super.visitMethod(method)
+                    return
+                }
+                PsiTreeUtil.findChildrenOfType(method, PsiMethodCallExpression::class.java).forEach { call ->
+                    val methodName = call.methodExpression.referenceName
+                    if (methodName in setOf("service", "serviceUnder", "annotatedService")) {
+                        ArmeriaRouteCollector.addServiceRegistrationFromCall(call, routes, mutableSetOf())
+                    }
+                }
+                routes += ArmeriaRoute.create(
+                    element = method,
+                    protocol = message("route.explorer.protocol.http"),
+                    httpMethod = "",
+                    path = "/",
+                    target = method.containingClass?.qualifiedName + "#" + method.name + "()",
+                    routeMatch = RouteMatch.ANNOTATED_SERVICE,
+                    decorators = listOf("Spring Boot @Bean"),
+                )
+                super.visitMethod(method)
+            }
+        })
+    }
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringBootRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringBootRouteCollector.kt
@@ -2,69 +2,93 @@ package com.linecorp.intellij.plugins.armeria.explorer
 
 import com.intellij.ide.highlighter.JavaFileType
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.JavaRecursiveElementWalkingVisitor
 import com.intellij.psi.PsiJavaFile
+import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiMethodCallExpression
 import com.intellij.psi.search.FileTypeIndex
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.util.PsiTreeUtil
-import com.linecorp.intellij.plugins.armeria.message
 
 internal object ArmeriaSpringBootRouteCollector {
-    private val SPRING_BOOT_INDICATORS = setOf(
+    private val SPRING_BOOT_FILE_INDICATORS = setOf(
         "ArmeriaServerConfigurator",
         "ArmeriaAutoConfiguration",
         "spring-boot-starter-armeria",
     )
 
-    fun collect(project: Project, scope: GlobalSearchScope, routes: MutableList<ArmeriaRoute>) {
+    fun collect(
+        project: Project,
+        scope: GlobalSearchScope,
+        routes: MutableList<ArmeriaRoute>,
+        fallbackScannedFiles: MutableSet<VirtualFile>,
+        seenServiceRegistrations: MutableSet<String>,
+    ) {
         for (virtualFile in FileTypeIndex.getFiles(JavaFileType.INSTANCE, scope)) {
-            val file = com.intellij.psi.PsiManager.getInstance(project).findFile(virtualFile) as? PsiJavaFile ?: continue
+            if (virtualFile in fallbackScannedFiles) {
+                continue
+            }
+            ArmeriaRouteCollectionMetrics.current()?.filesScanned?.incrementAndGet()
+            val file = PsiManager.getInstance(project).findFile(virtualFile) as? PsiJavaFile ?: continue
             if (!referencesSpringBootArmeria(file)) {
                 continue
             }
-            collectBeanServerRegistrations(file, routes)
+            fallbackScannedFiles += virtualFile
+            ArmeriaRouteCollectionMetrics.current()?.armeriaFiles?.incrementAndGet()
+            collectBeanServerRegistrations(file, routes, seenServiceRegistrations)
         }
     }
 
     private fun referencesSpringBootArmeria(file: PsiJavaFile): Boolean {
-        val text = file.text
-        return SPRING_BOOT_INDICATORS.any(text::contains) ||
-            file.importList?.allImportStatements?.any { import ->
-                import.importReference?.qualifiedName?.contains("armeria.spring") == true
-            } == true
+        val hasSpringImports = file.importList
+            ?.allImportStatements
+            ?.any { statement ->
+                statement.importReference?.qualifiedName?.startsWith(ArmeriaRouteSupport.ARMERIA_SPRING_PACKAGE_PREFIX) == true
+            } ?: false
+        if (hasSpringImports) {
+            return true
+        }
+        val searchWindow = file.text.take(ArmeriaRouteSupport.ARMERIA_HEADER_SCAN_LIMIT)
+        return SPRING_BOOT_FILE_INDICATORS.any(searchWindow::contains)
     }
 
-    private fun collectBeanServerRegistrations(file: PsiJavaFile, routes: MutableList<ArmeriaRoute>) {
+    private fun collectBeanServerRegistrations(
+        file: PsiJavaFile,
+        routes: MutableList<ArmeriaRoute>,
+        seenServiceRegistrations: MutableSet<String>,
+    ) {
         file.accept(object : JavaRecursiveElementWalkingVisitor() {
             override fun visitMethod(method: PsiMethod) {
-                if (!method.hasAnnotation("org.springframework.context.annotation.Bean")) {
+                if (!method.hasAnnotation(ArmeriaRouteSupport.SPRING_BEAN_ANNOTATION)) {
                     super.visitMethod(method)
                     return
                 }
-                val returnType = method.returnType?.canonicalText.orEmpty()
-                if (!returnType.contains("Server") && !returnType.contains("ServerBuilder")) {
+                if (!isArmeriaServerBeanReturnType(method)) {
                     super.visitMethod(method)
                     return
                 }
                 PsiTreeUtil.findChildrenOfType(method, PsiMethodCallExpression::class.java).forEach { call ->
-                    val methodName = call.methodExpression.referenceName
-                    if (methodName in setOf("service", "serviceUnder", "annotatedService")) {
-                        ArmeriaRouteCollector.addServiceRegistrationFromCall(call, routes, mutableSetOf())
-                    }
+                    ArmeriaRouteCollector.collectServiceRegistrationFromMethodCall(
+                        call,
+                        routes,
+                        seenServiceRegistrations,
+                    )
                 }
-                routes += ArmeriaRoute.create(
-                    element = method,
-                    protocol = message("route.explorer.protocol.http"),
-                    httpMethod = "",
-                    path = "/",
-                    target = method.containingClass?.qualifiedName + "#" + method.name + "()",
-                    routeMatch = RouteMatch.ANNOTATED_SERVICE,
-                    decorators = listOf("Spring Boot @Bean"),
-                )
                 super.visitMethod(method)
             }
         })
+    }
+
+    private fun isArmeriaServerBeanReturnType(method: PsiMethod): Boolean {
+        val returnType = method.returnType?.canonicalText.orEmpty()
+        if (returnType == ArmeriaRouteSupport.ARMERIA_SERVER_CLASS ||
+            ArmeriaRouteSupport.isServerBuilderType(returnType)
+        ) {
+            return true
+        }
+        return returnType == ArmeriaRouteSupport.ARMERIA_SERVER_CONFIGURATOR_CLASS ||
+            returnType.endsWith(".ArmeriaServerConfigurator")
     }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringBootRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringBootRouteCollector.kt
@@ -1,97 +1,59 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
-import com.intellij.ide.highlighter.JavaFileType
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.JavaRecursiveElementWalkingVisitor
-import com.intellij.psi.PsiJavaFile
-import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiMethodCallExpression
-import com.intellij.psi.search.FileTypeIndex
 import com.intellij.psi.search.GlobalSearchScope
-import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.search.searches.AnnotatedElementsSearch
+import org.jetbrains.kotlin.asJava.elements.KtLightMethod
 
 internal object ArmeriaSpringBootRouteCollector {
-    private val SPRING_BOOT_FILE_INDICATORS = setOf(
-        "ArmeriaServerConfigurator",
-        "ArmeriaAutoConfiguration",
-        "spring-boot-starter-armeria",
-    )
-
     fun collect(
         project: Project,
         scope: GlobalSearchScope,
         routes: MutableList<ArmeriaRoute>,
-        fallbackScannedFiles: MutableSet<VirtualFile>,
         seenServiceRegistrations: MutableSet<String>,
     ) {
-        for (virtualFile in FileTypeIndex.getFiles(JavaFileType.INSTANCE, scope)) {
-            if (virtualFile in fallbackScannedFiles) {
-                continue
+        val psiFacade = JavaPsiFacade.getInstance(project)
+        val beanAnnotation = psiFacade.findClass(ArmeriaRouteSupport.SPRING_BEAN_ANNOTATION, scope) ?: return
+        val seenBeanMethods = mutableSetOf<PsiMethod>()
+        AnnotatedElementsSearch.searchPsiMethods(beanAnnotation, scope).forEach { method ->
+            if (!seenBeanMethods.add(method)) {
+                return@forEach
             }
-            ArmeriaRouteCollectionMetrics.current()?.filesScanned?.incrementAndGet()
-            val file = PsiManager.getInstance(project).findFile(virtualFile) as? PsiJavaFile ?: continue
-            if (!referencesSpringBootArmeria(file)) {
-                continue
+            if (!ArmeriaRouteSupport.isArmeriaServerBeanReturnType(method, scope)) {
+                return@forEach
             }
-            fallbackScannedFiles += virtualFile
             ArmeriaRouteCollectionMetrics.current()?.armeriaFiles?.incrementAndGet()
-            collectBeanServerRegistrations(file, routes, seenServiceRegistrations)
+            collectServiceRegistrationsFromBeanMethod(method, routes, seenServiceRegistrations)
         }
     }
 
-    private fun referencesSpringBootArmeria(file: PsiJavaFile): Boolean {
-        val hasSpringImports = file.importList
-            ?.allImportStatements
-            ?.any { statement ->
-                statement.importReference?.qualifiedName?.startsWith(ArmeriaRouteSupport.ARMERIA_SPRING_PACKAGE_PREFIX) == true
-            } ?: false
-        if (hasSpringImports) {
-            return true
-        }
-        return referencesSpringBootIndicatorsInText(file.viewProvider.contents)
-    }
-
-    private fun collectBeanServerRegistrations(
-        file: PsiJavaFile,
+    private fun collectServiceRegistrationsFromBeanMethod(
+        method: PsiMethod,
         routes: MutableList<ArmeriaRoute>,
         seenServiceRegistrations: MutableSet<String>,
     ) {
-        file.accept(object : JavaRecursiveElementWalkingVisitor() {
-            override fun visitMethod(method: PsiMethod) {
-                if (!method.hasAnnotation(ArmeriaRouteSupport.SPRING_BEAN_ANNOTATION)) {
-                    super.visitMethod(method)
-                    return
-                }
-                if (!isArmeriaServerBeanReturnType(method)) {
-                    super.visitMethod(method)
-                    return
-                }
-                PsiTreeUtil.findChildrenOfType(method, PsiMethodCallExpression::class.java).forEach { call ->
-                    ArmeriaRouteCollector.collectServiceRegistrationFromMethodCall(
-                        call,
-                        routes,
-                        seenServiceRegistrations,
-                    )
-                }
-                super.visitMethod(method)
+        val kotlinMethod = (method as? KtLightMethod)?.kotlinOrigin
+        if (kotlinMethod != null) {
+            ArmeriaKotlinRouteCollector.collectServiceRegistrationsInScope(
+                kotlinMethod,
+                routes,
+                seenServiceRegistrations,
+            )
+            return
+        }
+        method.body?.accept(object : JavaRecursiveElementWalkingVisitor() {
+            override fun visitMethodCallExpression(expression: PsiMethodCallExpression) {
+                ArmeriaRouteCollector.collectServiceRegistrationFromMethodCall(
+                    expression,
+                    routes,
+                    seenServiceRegistrations,
+                )
+                super.visitMethodCallExpression(expression)
             }
         })
-    }
-
-    private fun isArmeriaServerBeanReturnType(method: PsiMethod): Boolean {
-        val returnType = method.returnType?.canonicalText.orEmpty()
-        if (returnType == ArmeriaRouteSupport.ARMERIA_SERVER_CLASS ||
-            ArmeriaRouteSupport.isServerBuilderType(returnType)
-        ) {
-            return true
-        }
-        return returnType == ArmeriaRouteSupport.ARMERIA_SERVER_CONFIGURATOR_CLASS
-    }
-
-    private fun referencesSpringBootIndicatorsInText(contents: CharSequence): Boolean {
-        val searchWindow = contents.subSequence(0, minOf(contents.length, ArmeriaRouteSupport.ARMERIA_HEADER_SCAN_LIMIT))
-        return SPRING_BOOT_FILE_INDICATORS.any(searchWindow::contains)
     }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringBootRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringBootRouteCollector.kt
@@ -50,8 +50,7 @@ internal object ArmeriaSpringBootRouteCollector {
         if (hasSpringImports) {
             return true
         }
-        val searchWindow = file.text.take(ArmeriaRouteSupport.ARMERIA_HEADER_SCAN_LIMIT)
-        return SPRING_BOOT_FILE_INDICATORS.any(searchWindow::contains)
+        return referencesSpringBootIndicatorsInText(file.viewProvider.contents)
     }
 
     private fun collectBeanServerRegistrations(
@@ -88,7 +87,11 @@ internal object ArmeriaSpringBootRouteCollector {
         ) {
             return true
         }
-        return returnType == ArmeriaRouteSupport.ARMERIA_SERVER_CONFIGURATOR_CLASS ||
-            returnType.endsWith(".ArmeriaServerConfigurator")
+        return returnType == ArmeriaRouteSupport.ARMERIA_SERVER_CONFIGURATOR_CLASS
+    }
+
+    private fun referencesSpringBootIndicatorsInText(contents: CharSequence): Boolean {
+        val searchWindow = contents.subSequence(0, minOf(contents.length, ArmeriaRouteSupport.ARMERIA_HEADER_SCAN_LIMIT))
+        return SPRING_BOOT_FILE_INDICATORS.any(searchWindow::contains)
     }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringBootRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringBootRouteCollector.kt
@@ -14,6 +14,21 @@ import com.intellij.psi.search.searches.AnnotatedElementsSearch
 internal object ArmeriaSpringBootRouteCollector {
     private val KOTLIN_PLUGIN_ID = PluginId.getId("org.jetbrains.kotlin")
     private const val KOTLIN_LIGHT_METHOD_CLASS = "org.jetbrains.kotlin.asJava.elements.KtLightMethod"
+
+    private val ktLightMethodClass: Class<*>? by lazy {
+        if (!isKotlinPluginAvailable()) {
+            return@lazy null
+        }
+        try {
+            Class.forName(KOTLIN_LIGHT_METHOD_CLASS, false, ArmeriaSpringBootRouteCollector::class.java.classLoader)
+        } catch (_: ClassNotFoundException) {
+            null
+        }
+    }
+
+    private val getKotlinOriginMethod: java.lang.reflect.Method? by lazy {
+        ktLightMethodClass?.getMethod("getKotlinOrigin")
+    }
     fun collect(
         project: Project,
         scope: GlobalSearchScope,
@@ -39,14 +54,16 @@ internal object ArmeriaSpringBootRouteCollector {
         routes: MutableList<ArmeriaRoute>,
         seenServiceRegistrations: MutableSet<String>,
     ) {
-        val kotlinMethod = resolveKotlinOrigin(method)
-        if (kotlinMethod != null && isKotlinPluginAvailable()) {
-            ArmeriaKotlinRouteCollector.collectServiceRegistrationsInScope(
-                kotlinMethod,
-                routes,
-                seenServiceRegistrations,
-            )
-            return
+        if (isKotlinPluginAvailable()) {
+            val kotlinMethod = resolveKotlinOrigin(method)
+            if (kotlinMethod != null) {
+                ArmeriaKotlinRouteCollector.collectServiceRegistrationsInScope(
+                    kotlinMethod,
+                    routes,
+                    seenServiceRegistrations,
+                )
+                return
+            }
         }
         method.body?.accept(object : JavaRecursiveElementWalkingVisitor() {
             override fun visitMethodCallExpression(expression: PsiMethodCallExpression) {
@@ -61,11 +78,13 @@ internal object ArmeriaSpringBootRouteCollector {
     }
 
     private fun resolveKotlinOrigin(method: PsiMethod): PsiElement? {
-        if (method.javaClass.name != KOTLIN_LIGHT_METHOD_CLASS) {
+        val lightMethodClass = ktLightMethodClass ?: return null
+        if (!lightMethodClass.isInstance(method)) {
             return null
         }
+        val getKotlinOrigin = getKotlinOriginMethod ?: return null
         return try {
-            method.javaClass.getMethod("getKotlinOrigin").invoke(method) as? PsiElement
+            getKotlinOrigin.invoke(method) as? PsiElement
         } catch (_: ReflectiveOperationException) {
             null
         }

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinSpringBootRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinSpringBootRouteCollectorTest.kt
@@ -1,0 +1,255 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+
+class ArmeriaKotlinSpringBootRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
+    override fun setUp() {
+        super.setUp()
+        registerArmeriaStubs()
+        registerSpringBootStubs()
+    }
+
+    fun testCollectServiceRegistrationFromBeanConfigurator() {
+        myFixture.configureByText(
+            "ArmeriaConfig.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.spring.ArmeriaServerConfigurator
+            import org.springframework.context.annotation.Bean
+            import org.springframework.context.annotation.Configuration
+
+            @Configuration
+            class ArmeriaConfig {
+                @Bean
+                fun armeriaServerConfigurator(): ArmeriaServerConfigurator =
+                    ArmeriaServerConfigurator { serverBuilder ->
+                        serverBuilder.service("/api", HelloService())
+                    }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val apiRoutes = routes.filter { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
+        assertEquals(1, apiRoutes.size)
+        assertEquals("example.HelloService", apiRoutes.single().target)
+        assertFalse(routes.any { it.path == "/" && it.target.contains("armeriaServerConfigurator") })
+    }
+
+    fun testDoesNotDuplicateIndexedServiceRegistration() {
+        myFixture.configureByText(
+            "ArmeriaConfig.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.ServerBuilder
+            import com.linecorp.armeria.spring.ArmeriaServerConfigurator
+            import org.springframework.context.annotation.Bean
+            import org.springframework.context.annotation.Configuration
+
+            @Configuration
+            class ArmeriaConfig {
+                @Bean
+                fun armeriaServerConfigurator(): ArmeriaServerConfigurator =
+                    ArmeriaServerConfigurator { serverBuilder ->
+                        serverBuilder.service("/api", HelloService())
+                    }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val apiRoutes = routes.filter { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
+        assertEquals(1, apiRoutes.size)
+    }
+
+    fun testCollectServiceRegistrationFromBeanServer() {
+        myFixture.configureByText(
+            "ArmeriaConfig.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+            import org.springframework.context.annotation.Bean
+            import org.springframework.context.annotation.Configuration
+
+            @Configuration
+            class ArmeriaConfig {
+                @Bean
+                fun armeriaServer(): Server =
+                    Server.builder()
+                        .service("/health", HelloService())
+                        .build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val healthRoutes = routes.filter { it.path == "/health" && it.routeMatch == RouteMatch.SERVICE }
+        assertEquals(1, healthRoutes.size)
+        assertEquals("example.HelloService", healthRoutes.single().target)
+    }
+
+    fun testIgnoresUnrelatedServiceCallInBeanMethod() {
+        myFixture.configureByText(
+            "ArmeriaConfig.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.spring.ArmeriaServerConfigurator
+            import org.springframework.context.annotation.Bean
+            import org.springframework.context.annotation.Configuration
+
+            @Configuration
+            class ArmeriaConfig {
+                @Bean
+                fun armeriaServerConfigurator(): ArmeriaServerConfigurator =
+                    ArmeriaServerConfigurator { serverBuilder ->
+                        Helper.service("ignored")
+                        serverBuilder.service("/api", HelloService())
+                    }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public final class Helper {
+                public static void service(String ignored) {
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val apiRoutes = routes.filter { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
+        assertEquals(1, apiRoutes.size)
+        assertFalse(routes.any { it.path == "ignored" })
+    }
+
+    fun testIgnoresBeanFunctionWithoutArmeriaReturnType() {
+        myFixture.configureByText(
+            "OtherConfig.kt",
+            """
+            package example
+
+            import org.springframework.context.annotation.Bean
+            import org.springframework.context.annotation.Configuration
+
+            @Configuration
+            class OtherConfig {
+                @Bean
+                fun unrelatedBean(): String = "value"
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        assertTrue(routes.isEmpty())
+    }
+
+    private fun registerArmeriaStubs() {
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.server;
+
+            public final class Server {
+                public static ServerBuilder builder() {
+                    return null;
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.server;
+
+            public final class ServerBuilder {
+                public ServerBuilder service(String path, Object service) {
+                    return this;
+                }
+
+                public ServerBuilder serviceUnder(String prefix, Object service) {
+                    return this;
+                }
+
+                public ServerBuilder annotatedService(Object service) {
+                    return this;
+                }
+
+                public Server build() {
+                    return null;
+                }
+            }
+            """.trimIndent(),
+        )
+    }
+
+    private fun registerSpringBootStubs() {
+        myFixture.addClass(
+            """
+            package org.springframework.context.annotation;
+
+            public @interface Bean {
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package org.springframework.context.annotation;
+
+            public @interface Configuration {
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.spring;
+
+            @FunctionalInterface
+            public interface ArmeriaServerConfigurator {
+                void configure(com.linecorp.armeria.server.ServerBuilder serverBuilder);
+            }
+            """.trimIndent(),
+        )
+    }
+}

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringBootRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringBootRouteCollectorTest.kt
@@ -5,11 +5,12 @@ import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
 class ArmeriaSpringBootRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
     override fun setUp() {
         super.setUp()
-        registerArmeriaStubs()
-        registerSpringBootStubs()
+        registerSpringAnnotationStubs()
     }
 
     fun testCollectServiceRegistrationFromBeanConfigurator() {
+        registerArmeriaStubs()
+        registerArmeriaSpringStubs()
         myFixture.configureByText(
             "ArmeriaConfig.java",
             """
@@ -46,6 +47,8 @@ class ArmeriaSpringBootRouteCollectorTest : LightJavaCodeInsightFixtureTestCase(
     }
 
     fun testDoesNotDuplicateIndexedServiceRegistration() {
+        registerArmeriaStubs()
+        registerArmeriaSpringStubs()
         myFixture.configureByText(
             "ArmeriaConfig.java",
             """
@@ -81,6 +84,8 @@ class ArmeriaSpringBootRouteCollectorTest : LightJavaCodeInsightFixtureTestCase(
     }
 
     fun testCollectServiceRegistrationFromBeanServer() {
+        registerArmeriaStubs()
+        registerArmeriaSpringStubs()
         myFixture.configureByText(
             "ArmeriaConfig.java",
             """
@@ -118,6 +123,8 @@ class ArmeriaSpringBootRouteCollectorTest : LightJavaCodeInsightFixtureTestCase(
     }
 
     fun testIgnoresUnrelatedServiceCallInBeanMethod() {
+        registerArmeriaStubs()
+        registerArmeriaSpringStubs()
         myFixture.configureByText(
             "ArmeriaConfig.java",
             """
@@ -166,6 +173,8 @@ class ArmeriaSpringBootRouteCollectorTest : LightJavaCodeInsightFixtureTestCase(
     }
 
     fun testIgnoresBeanMethodWithoutArmeriaReturnType() {
+        registerArmeriaStubs()
+        registerArmeriaSpringStubs()
         myFixture.configureByText(
             "OtherConfig.java",
             """
@@ -177,6 +186,168 @@ class ArmeriaSpringBootRouteCollectorTest : LightJavaCodeInsightFixtureTestCase(
 
             @Configuration
             public class OtherConfig {
+                @Bean
+                public String unrelatedBean() {
+                    return "value";
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        assertTrue(routes.isEmpty())
+    }
+
+    fun testCollectServiceRegistrationFromBeanServerBuilder() {
+        registerArmeriaStubs()
+        registerArmeriaSpringStubs()
+        myFixture.configureByText(
+            "ArmeriaConfig.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.Server;
+            import com.linecorp.armeria.server.ServerBuilder;
+            import org.springframework.context.annotation.Bean;
+            import org.springframework.context.annotation.Configuration;
+
+            @Configuration
+            public class ArmeriaConfig {
+                @Bean
+                public ServerBuilder armeriaServerBuilder() {
+                    return Server.builder()
+                        .service("/builder", new HelloService());
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val builderRoutes = routes.filter { it.path == "/builder" && it.routeMatch == RouteMatch.SERVICE }
+        assertEquals(1, builderRoutes.size)
+        assertEquals("example.HelloService", builderRoutes.single().target)
+    }
+
+    fun testCollectServiceUnderAndAnnotatedServiceFromBeanConfigurator() {
+        registerArmeriaStubs()
+        registerArmeriaSpringStubs()
+        myFixture.configureByText(
+            "ArmeriaConfig.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
+            import org.springframework.context.annotation.Bean;
+            import org.springframework.context.annotation.Configuration;
+
+            @Configuration
+            public class ArmeriaConfig {
+                @Bean
+                public ArmeriaServerConfigurator armeriaServerConfigurator() {
+                    return serverBuilder -> {
+                        serverBuilder.serviceUnder("/api", new HelloService());
+                        serverBuilder.annotatedService(new AnnotatedService());
+                    };
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class AnnotatedService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val serviceUnderRoutes = routes.filter { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE_UNDER }
+        assertEquals(1, serviceUnderRoutes.size)
+        val annotatedRoutes = routes.filter { it.routeMatch == RouteMatch.ANNOTATED_SERVICE }
+        assertEquals(1, annotatedRoutes.size)
+    }
+
+    fun testCollectServiceRegistrationFromConfiguratorSubtype() {
+        registerArmeriaStubs()
+        registerArmeriaSpringStubs()
+        myFixture.addClass(
+            """
+            package example;
+
+            import com.linecorp.armeria.server.ServerBuilder;
+            import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
+
+            public final class RoutingConfigurator implements ArmeriaServerConfigurator {
+                @Override
+                public void configure(ServerBuilder serverBuilder) {
+                    serverBuilder.service("/subtype", new HelloService());
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "ArmeriaConfig.java",
+            """
+            package example;
+
+            import org.springframework.context.annotation.Bean;
+            import org.springframework.context.annotation.Configuration;
+
+            @Configuration
+            public class ArmeriaConfig {
+                @Bean
+                public RoutingConfigurator customConfigurator() {
+                    return new RoutingConfigurator();
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val subtypeRoutes = routes.filter { it.path == "/subtype" && it.routeMatch == RouteMatch.SERVICE }
+        assertEquals(1, subtypeRoutes.size)
+    }
+
+    fun testSkipsCollectionWhenArmeriaSpringTypesAbsentOnClasspath() {
+        myFixture.configureByText(
+            "SpringOnlyConfig.java",
+            """
+            package example;
+
+            import org.springframework.context.annotation.Bean;
+            import org.springframework.context.annotation.Configuration;
+
+            @Configuration
+            public class SpringOnlyConfig {
                 @Bean
                 public String unrelatedBean() {
                     return "value";
@@ -227,7 +398,7 @@ class ArmeriaSpringBootRouteCollectorTest : LightJavaCodeInsightFixtureTestCase(
         )
     }
 
-    private fun registerSpringBootStubs() {
+    private fun registerSpringAnnotationStubs() {
         myFixture.addClass(
             """
             package org.springframework.context.annotation;
@@ -244,6 +415,9 @@ class ArmeriaSpringBootRouteCollectorTest : LightJavaCodeInsightFixtureTestCase(
             }
             """.trimIndent(),
         )
+    }
+
+    private fun registerArmeriaSpringStubs() {
         myFixture.addClass(
             """
             package com.linecorp.armeria.spring;

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringBootRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringBootRouteCollectorTest.kt
@@ -1,0 +1,258 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+
+class ArmeriaSpringBootRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
+    override fun setUp() {
+        super.setUp()
+        registerArmeriaStubs()
+        registerSpringBootStubs()
+    }
+
+    fun testCollectServiceRegistrationFromBeanConfigurator() {
+        myFixture.configureByText(
+            "ArmeriaConfig.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
+            import org.springframework.context.annotation.Bean;
+            import org.springframework.context.annotation.Configuration;
+
+            @Configuration
+            public class ArmeriaConfig {
+                @Bean
+                public ArmeriaServerConfigurator armeriaServerConfigurator() {
+                    return serverBuilder -> serverBuilder.service("/api", new HelloService());
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val apiRoutes = routes.filter { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
+        assertEquals(1, apiRoutes.size)
+        assertEquals("example.HelloService", apiRoutes.single().target)
+        assertFalse(routes.any { it.path == "/" && it.target.contains("armeriaServerConfigurator") })
+    }
+
+    fun testDoesNotDuplicateIndexedServiceRegistration() {
+        myFixture.configureByText(
+            "ArmeriaConfig.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.ServerBuilder;
+            import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
+            import org.springframework.context.annotation.Bean;
+            import org.springframework.context.annotation.Configuration;
+
+            @Configuration
+            public class ArmeriaConfig {
+                @Bean
+                public ArmeriaServerConfigurator armeriaServerConfigurator() {
+                    return serverBuilder -> serverBuilder.service("/api", new HelloService());
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val apiRoutes = routes.filter { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
+        assertEquals(1, apiRoutes.size)
+    }
+
+    fun testCollectServiceRegistrationFromBeanServer() {
+        myFixture.configureByText(
+            "ArmeriaConfig.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.Server;
+            import org.springframework.context.annotation.Bean;
+            import org.springframework.context.annotation.Configuration;
+
+            @Configuration
+            public class ArmeriaConfig {
+                @Bean
+                public Server armeriaServer() {
+                    return Server.builder()
+                        .service("/health", new HelloService())
+                        .build();
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val healthRoutes = routes.filter { it.path == "/health" && it.routeMatch == RouteMatch.SERVICE }
+        assertEquals(1, healthRoutes.size)
+        assertEquals("example.HelloService", healthRoutes.single().target)
+    }
+
+    fun testIgnoresUnrelatedServiceCallInBeanMethod() {
+        myFixture.configureByText(
+            "ArmeriaConfig.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
+            import org.springframework.context.annotation.Bean;
+            import org.springframework.context.annotation.Configuration;
+
+            @Configuration
+            public class ArmeriaConfig {
+                @Bean
+                public ArmeriaServerConfigurator armeriaServerConfigurator() {
+                    return serverBuilder -> {
+                        Helper.service("ignored");
+                        serverBuilder.service("/api", new HelloService());
+                    };
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public final class Helper {
+                public static void service(String ignored) {
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val apiRoutes = routes.filter { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
+        assertEquals(1, apiRoutes.size)
+        assertFalse(routes.any { it.path == "ignored" })
+    }
+
+    fun testIgnoresBeanMethodWithoutArmeriaReturnType() {
+        myFixture.configureByText(
+            "OtherConfig.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
+            import org.springframework.context.annotation.Bean;
+            import org.springframework.context.annotation.Configuration;
+
+            @Configuration
+            public class OtherConfig {
+                @Bean
+                public String unrelatedBean() {
+                    return "value";
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        assertTrue(routes.isEmpty())
+    }
+
+    private fun registerArmeriaStubs() {
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.server;
+
+            public final class Server {
+                public static ServerBuilder builder() {
+                    return null;
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.server;
+
+            public final class ServerBuilder {
+                public ServerBuilder service(String path, Object service) {
+                    return this;
+                }
+
+                public ServerBuilder serviceUnder(String prefix, Object service) {
+                    return this;
+                }
+
+                public ServerBuilder annotatedService(Object service) {
+                    return this;
+                }
+
+                public Server build() {
+                    return null;
+                }
+            }
+            """.trimIndent(),
+        )
+    }
+
+    private fun registerSpringBootStubs() {
+        myFixture.addClass(
+            """
+            package org.springframework.context.annotation;
+
+            public @interface Bean {
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package org.springframework.context.annotation;
+
+            public @interface Configuration {
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.spring;
+
+            @FunctionalInterface
+            public interface ArmeriaServerConfigurator {
+                void configure(com.linecorp.armeria.server.ServerBuilder serverBuilder);
+            }
+            """.trimIndent(),
+        )
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Discover Spring Boot `@Bean` Armeria Server configuration in Route Explorer (Java and Kotlin).

- Adds `ArmeriaSpringBootRouteCollector` using `AnnotatedElementsSearch` on `@Bean` methods that return `Server`, `ServerBuilder`, or `ArmeriaServerConfigurator` (including subtypes via `PsiClass.isInheritor`)
- Gates collection on both Spring `@Bean` and Armeria Spring types on the classpath
- Reuses `collectServiceRegistrationFromMethodCall` / `ArmeriaKotlinRouteCollector.collectServiceRegistrationsInScope` to extract routes from builder calls inside bean methods
- Shares `seenServiceRegistrations` with indexed and fallback collectors so the same registration is not reported twice
- Handles Kotlin `@Bean` functions via reflection on `KtLightMethod` with `Class.isInstance` (no hard optional-plugin dependency)

## Test plan

- [x] `./gradlew :plugin:compileKotlin`
- [x] `./gradlew :plugin:test --tests "com.linecorp.intellij.plugins.armeria.explorer.ArmeriaSpringBootRouteCollectorTest"`
- [x] `./gradlew :plugin:test --tests "com.linecorp.intellij.plugins.armeria.explorer.ArmeriaKotlinSpringBootRouteCollectorTest"`
- [x] `./gradlew :plugin:test`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2021-9dd6-73e2-bdb9-83969a21a5fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2021-9dd6-73e2-bdb9-83969a21a5fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

