### PR TITLE
feat: Wizard sample Main and logback generation

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Added Armeria Clients tool window for WebClient, GrpcClient, and ThriftClient discovery.
 - Added GraphQL schema and Thrift IDL route discovery with classpath gating and operation-level targets.
 - Added gRPC route discovery from `.proto` service definitions with brace-aware parsing and a registry kill-switch.
+- Added DocService runtime route sync action in Route Explorer.
+- Added New Project Wizard sample `Main` and `logback.xml` generation.
 - Added Kotlin source support to Route Explorer for annotated services and Server.builder registrations.
 - Added Velocity-based regression tests for New Project Wizard file templates.
 - Added `plugin/src/test/resources/wizard-verification-matrix.md` documenting representative wizard scenarios.

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/module/ArmeriaModuleBuilder.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/module/ArmeriaModuleBuilder.kt
@@ -75,6 +75,22 @@ class ArmeriaModuleBuilder: StarterModuleBuilder() {
             else -> "java"
         }
         val packageDir = starterContext.group.split(".")
+        val mainFileName = when (starterContext.language) {
+            KOTLIN_STARTER_LANGUAGE -> "Main.kt"
+            else -> "Main.java"
+        }
+        val mainTemplate = when (starterContext.language) {
+            KOTLIN_STARTER_LANGUAGE -> "armeria-main.kt"
+            else -> "armeria-main.java"
+        }
+        assets.add(GeneratorTemplateFile(
+            (listOf("src", "main", languageDir) + packageDir + mainFileName).joinToString("/"),
+            ftManager.getJ2eeTemplate(mainTemplate),
+        ))
+        assets.add(GeneratorTemplateFile(
+            "src/main/resources/logback.xml",
+            ftManager.getJ2eeTemplate("armeria-logback.xml"),
+        ))
         assets.add(GeneratorEmptyDirectory((listOf("src", "main", languageDir) + packageDir).joinToString("/")))
         assets.add(GeneratorEmptyDirectory((listOf("src", "test", languageDir) + packageDir).joinToString("/")))
 

--- a/plugin/src/main/resources/fileTemplates/j2ee/armeria-logback.xml.ft
+++ b/plugin/src/main/resources/fileTemplates/j2ee/armeria-logback.xml.ft
@@ -1,0 +1,10 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/plugin/src/main/resources/fileTemplates/j2ee/armeria-main.java.ft
+++ b/plugin/src/main/resources/fileTemplates/j2ee/armeria-main.java.ft
@@ -1,0 +1,20 @@
+package ${PACKAGE_NAME};
+
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.annotation.Get;
+
+public class Main {
+    public static void main(String[] args) {
+        Server.builder()
+              .http(8080)
+              .annotatedService(new Object() {
+                  @Get("/hello")
+                  public String hello() {
+                      return "Hello, Armeria";
+                  }
+              })
+              .build()
+              .start()
+              .join();
+    }
+}

--- a/plugin/src/main/resources/fileTemplates/j2ee/armeria-main.kt.ft
+++ b/plugin/src/main/resources/fileTemplates/j2ee/armeria-main.kt.ft
@@ -1,0 +1,16 @@
+package ${PACKAGE_NAME}
+
+import com.linecorp.armeria.server.Server
+import com.linecorp.armeria.server.annotation.Get
+
+fun main() {
+    Server.builder()
+        .http(8080)
+        .annotatedService(object {
+            @Get("/hello")
+            fun hello(): String = "Hello, Armeria"
+        })
+        .build()
+        .start()
+        .join()
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Generates sample Main and logback.xml in New Project Wizard.

**Superseded by #183**, which consolidates wizard sample generation and JUnit test templates rebased onto `main`. This PR is retained only for history; please review #183 instead.

## Test plan

- [x] `./gradlew :plugin:compileKotlin :plugin:test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2021-9dd6-73e2-bdb9-83969a21a5fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2021-9dd6-73e2-bdb9-83969a21a5fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

