### PR TITLE
refactor: centralize Armeria route constants for Kotlin Route Explorer (#164)

### DIFF
--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
@@ -21,10 +21,6 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 
 internal object ArmeriaKotlinRouteCollector {
-    private const val ARMERIA_SERVER_PACKAGE_PREFIX = "com.linecorp.armeria.server"
-    private const val SERVER_BUILDER_FQN = "com.linecorp.armeria.server.ServerBuilder"
-    private const val SERVER_BUILDER_SIMPLE = "ServerBuilder"
-    private val REGISTRATION_METHOD_NAMES = setOf("service", "serviceUnder", "annotatedService")
     private val BUILDER_SCOPE_METHOD_NAMES = setOf("apply", "run", "also", "let")
 
     fun collectServiceRegistrationsFallback(
@@ -57,7 +53,7 @@ internal object ArmeriaKotlinRouteCollector {
         for (call in file.collectDescendantsOfType<KtCallExpression>()) {
             ArmeriaRouteCollectionMetrics.current()?.methodCallsVisited?.incrementAndGet()
             val methodName = resolveCallName(call) ?: continue
-            if (methodName !in REGISTRATION_METHOD_NAMES) {
+            if (methodName !in ServiceRegistrationMethod.METHOD_NAMES) {
                 continue
             }
             if (!looksLikeArmeriaBuilderCall(call)) {
@@ -95,7 +91,7 @@ internal object ArmeriaKotlinRouteCollector {
         for (reference in dotQualified.references) {
             val resolved = reference.resolve()
             if (resolved is PsiMethod &&
-                resolved.containingClass?.qualifiedName?.startsWith(ARMERIA_SERVER_PACKAGE_PREFIX) == true
+                resolved.containingClass?.qualifiedName?.startsWith(ArmeriaRouteSupport.ARMERIA_SERVER_PACKAGE_PREFIX) == true
             ) {
                 return true
             }
@@ -111,25 +107,19 @@ internal object ArmeriaKotlinRouteCollector {
         if (receiver is KtNameReferenceExpression) {
             when (val resolved = receiver.references.firstOrNull()?.resolve()) {
                 is com.intellij.psi.PsiVariable -> {
-                    if (isServerBuilderType(resolved.type.canonicalText)) {
+                    if (ArmeriaRouteSupport.isServerBuilderType(resolved.type.canonicalText)) {
                         return true
                     }
                 }
                 is KtProperty -> {
                     val typeText = resolved.typeReference?.text
-                    if (typeText != null && isServerBuilderType(typeText)) {
+                    if (typeText != null && ArmeriaRouteSupport.isServerBuilderType(typeText)) {
                         return true
                     }
                 }
             }
         }
         return false
-    }
-
-    private fun isServerBuilderType(typeText: String): Boolean {
-        return typeText == SERVER_BUILDER_SIMPLE ||
-            typeText == SERVER_BUILDER_FQN ||
-            typeText.endsWith(".$SERVER_BUILDER_SIMPLE")
     }
 
     private fun hasServerBuilderImplicitReceiver(call: KtCallExpression): Boolean {
@@ -196,11 +186,13 @@ internal object ArmeriaKotlinRouteCollector {
     }
 
     private fun resolveServiceExpression(methodName: String, arguments: List<KtValueArgument>): KtExpression? {
-        return when (methodName) {
-            "annotatedService" ->
+        return when (ServiceRegistrationMethod.fromMethodName(methodName)) {
+            ServiceRegistrationMethod.ANNOTATED_SERVICE ->
                 findArgumentExpression(arguments, "service", 1)
                     ?: findArgumentExpression(arguments, "service", 0)
-            else -> findArgumentExpression(arguments, "service", 1)
+            ServiceRegistrationMethod.SERVICE, ServiceRegistrationMethod.SERVICE_UNDER ->
+                findArgumentExpression(arguments, "service", 1)
+            null -> null
         }
     }
 
@@ -216,17 +208,19 @@ internal object ArmeriaKotlinRouteCollector {
     }
 
     private fun extractRegistrationPath(methodName: String, arguments: List<KtValueArgument>): String? {
-        return when (methodName) {
-            "service" -> extractKotlinString(findArgumentExpression(arguments, "path", 0))
-            "serviceUnder" -> extractKotlinString(findArgumentExpression(arguments, "prefix", 0))
-            "annotatedService" -> {
+        return when (ServiceRegistrationMethod.fromMethodName(methodName)) {
+            ServiceRegistrationMethod.SERVICE ->
+                extractKotlinString(findArgumentExpression(arguments, "path", 0))
+            ServiceRegistrationMethod.SERVICE_UNDER ->
+                extractKotlinString(findArgumentExpression(arguments, "prefix", 0))
+            ServiceRegistrationMethod.ANNOTATED_SERVICE -> {
                 if (arguments.size > 1) {
                     extractKotlinString(findArgumentExpression(arguments, "prefix", 0))
                 } else {
                     "/"
                 }
             }
-            else -> null
+            null -> null
         }
     }
 

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
@@ -40,11 +40,7 @@ internal enum class RouteProtocol(private val messageKey: String) {
 
 object ArmeriaRouteCollector {
 
-    private const val ARMERIA_PACKAGE_PREFIX = "com.linecorp.armeria"
-    private const val ARMERIA_SERVER_PACKAGE_PREFIX = "com.linecorp.armeria.server"
-    private const val SERVER_BUILDER_CLASS = "com.linecorp.armeria.server.ServerBuilder"
     private const val ARMERIA_HEADER_SCAN_LIMIT = 4096
-    private val REGISTRATION_METHOD_NAMES = setOf("service", "serviceUnder", "annotatedService")
     private val KOTLIN_PLUGIN_ID = PluginId.getId("org.jetbrains.kotlin")
     private val ARMERIA_REFERENCE_PATTERN =
         Regex("""(?<![\w"])com\.linecorp\.armeria(?:\.[A-Za-z_][A-Za-z0-9_]*)+""")
@@ -68,7 +64,7 @@ object ArmeriaRouteCollector {
         val fallbackScannedFiles = linkedSetOf<VirtualFile>()
         val seenServiceRegistrations = mutableSetOf<String>()
         val psiFacade = JavaPsiFacade.getInstance(project)
-        val serverBuilderOnClasspath = psiFacade.findClass(SERVER_BUILDER_CLASS, scope) != null
+        val serverBuilderOnClasspath = psiFacade.findClass(ArmeriaRouteSupport.SERVER_BUILDER_CLASS, scope) != null
 
         collectAnnotatedRoutesIndexed(project, scope, routes)
         collectServiceRegistrationsIndexed(project, scope, routes, seenServiceRegistrations)
@@ -151,8 +147,8 @@ object ArmeriaRouteCollector {
         seenServiceRegistrations: MutableSet<String>,
     ) {
         val psiFacade = JavaPsiFacade.getInstance(project)
-        val builderClass = psiFacade.findClass(SERVER_BUILDER_CLASS, scope) ?: return
-        for (methodName in REGISTRATION_METHOD_NAMES) {
+        val builderClass = psiFacade.findClass(ArmeriaRouteSupport.SERVER_BUILDER_CLASS, scope) ?: return
+        for (methodName in ServiceRegistrationMethod.METHOD_NAMES) {
             for (method in builderClass.findMethodsByName(methodName, false)) {
                 ReferencesSearch.search(method, scope).forEach { reference ->
                     val call = PsiTreeUtil.getParentOfType(reference.element, PsiMethodCallExpression::class.java)
@@ -193,11 +189,11 @@ object ArmeriaRouteCollector {
             is PsiJavaFile -> file.importList
                 ?.allImportStatements
                 ?.any { statement ->
-                    statement.importReference?.qualifiedName?.startsWith(ARMERIA_PACKAGE_PREFIX) == true
+                    statement.importReference?.qualifiedName?.startsWith(ArmeriaRouteSupport.ARMERIA_PACKAGE_PREFIX) == true
                 } ?: false
 
             is KtFile -> file.importList?.imports?.any { import ->
-                import.importedFqName?.asString()?.startsWith(ARMERIA_PACKAGE_PREFIX) == true
+                import.importedFqName?.asString()?.startsWith(ArmeriaRouteSupport.ARMERIA_PACKAGE_PREFIX) == true
             } ?: false
 
             else -> false
@@ -230,7 +226,7 @@ object ArmeriaRouteCollector {
     ) {
         ArmeriaRouteCollectionMetrics.current()?.methodCallsVisited?.incrementAndGet()
         val methodName = expression.methodExpression.referenceName
-        if (methodName !in REGISTRATION_METHOD_NAMES) {
+        if (methodName !in ServiceRegistrationMethod.METHOD_NAMES) {
             return
         }
         if (!looksLikeArmeriaBuilderCall(expression)) {
@@ -248,9 +244,10 @@ object ArmeriaRouteCollector {
         val methodName = expression.methodExpression.referenceName ?: return
         val arguments = expression.argumentList.expressions
         val path = extractRegistrationPath(methodName, arguments) ?: return
-        val implementationExpression = when (methodName) {
-            "annotatedService" -> arguments.getOrNull(1) ?: arguments.getOrNull(0)
-            else -> arguments.getOrNull(1)
+        val implementationExpression = when (ServiceRegistrationMethod.fromMethodName(methodName)) {
+            ServiceRegistrationMethod.ANNOTATED_SERVICE -> arguments.getOrNull(1) ?: arguments.getOrNull(0)
+            ServiceRegistrationMethod.SERVICE, ServiceRegistrationMethod.SERVICE_UNDER -> arguments.getOrNull(1)
+            null -> null
         } ?: return
         val target = ArmeriaRouteTargetExtractor.extractTarget(implementationExpression)
         addServiceRegistrationRoute(
@@ -282,11 +279,11 @@ object ArmeriaRouteCollector {
         if (!seenServiceRegistrations.add(registrationKey)) {
             return
         }
-        val registrationMethod = RegistrationMethod.fromMethodName(methodName) ?: return
+        val registrationMethod = ServiceRegistrationMethod.fromMethodName(methodName) ?: return
         val protocol = ArmeriaRouteTargetExtractor.detectProtocol(implementationText)
         val routeMatch = resolveRouteMatch(registrationMethod, protocol)
         val annotatedServiceHasPathPrefix =
-            registrationMethod == RegistrationMethod.ANNOTATED_SERVICE && argumentCount > 1
+            registrationMethod == ServiceRegistrationMethod.ANNOTATED_SERVICE && argumentCount > 1
         routes += ArmeriaRoute.create(
             element = element,
             protocol = protocol.presentableName(),
@@ -300,14 +297,14 @@ object ArmeriaRouteCollector {
         )
     }
 
-    private fun resolveRouteMatch(registrationMethod: RegistrationMethod, protocol: RouteProtocol): RouteMatch {
+    private fun resolveRouteMatch(registrationMethod: ServiceRegistrationMethod, protocol: RouteProtocol): RouteMatch {
         if (protocol != RouteProtocol.HTTP) {
             return RouteMatch.NON_HTTP
         }
         return when (registrationMethod) {
-            RegistrationMethod.SERVICE -> RouteMatch.SERVICE
-            RegistrationMethod.ANNOTATED_SERVICE -> RouteMatch.ANNOTATED_SERVICE
-            RegistrationMethod.SERVICE_UNDER -> RouteMatch.SERVICE_UNDER
+            ServiceRegistrationMethod.SERVICE -> RouteMatch.SERVICE
+            ServiceRegistrationMethod.ANNOTATED_SERVICE -> RouteMatch.ANNOTATED_SERVICE
+            ServiceRegistrationMethod.SERVICE_UNDER -> RouteMatch.SERVICE_UNDER
         }
     }
 
@@ -327,7 +324,7 @@ object ArmeriaRouteCollector {
     private fun resolvesToArmeriaServerBuilder(expression: PsiMethodCallExpression): Boolean {
         ArmeriaRouteCollectionMetrics.current()?.resolveCount?.incrementAndGet()
         val resolvedClass = expression.resolveMethod()?.containingClass?.qualifiedName
-        return resolvedClass?.startsWith(ARMERIA_SERVER_PACKAGE_PREFIX) == true
+        return resolvedClass?.startsWith(ArmeriaRouteSupport.ARMERIA_SERVER_PACKAGE_PREFIX) == true
     }
 
     private fun buildMethodTarget(psiClass: PsiClass, method: PsiMethod): String {
@@ -335,28 +332,13 @@ object ArmeriaRouteCollector {
         return "$className#${method.name}()"
     }
 
-    private enum class RegistrationMethod {
-        SERVICE,
-        SERVICE_UNDER,
-        ANNOTATED_SERVICE;
-
-        companion object {
-            fun fromMethodName(name: String): RegistrationMethod? {
-                return when (name) {
-                    "service" -> SERVICE
-                    "serviceUnder" -> SERVICE_UNDER
-                    "annotatedService" -> ANNOTATED_SERVICE
-                    else -> null
-                }
-            }
-        }
-    }
-
     private fun extractRegistrationPath(methodName: String, arguments: Array<PsiExpression>): String? {
-        val method = RegistrationMethod.fromMethodName(methodName) ?: return null
-        return when (method) {
-            RegistrationMethod.SERVICE, RegistrationMethod.SERVICE_UNDER -> extractString(arguments.getOrNull(0))
-            RegistrationMethod.ANNOTATED_SERVICE -> if (arguments.size > 1) extractString(arguments.getOrNull(0)) else "/"
+        return when (ServiceRegistrationMethod.fromMethodName(methodName)) {
+            ServiceRegistrationMethod.SERVICE, ServiceRegistrationMethod.SERVICE_UNDER ->
+                extractString(arguments.getOrNull(0))
+            ServiceRegistrationMethod.ANNOTATED_SERVICE ->
+                if (arguments.size > 1) extractString(arguments.getOrNull(0)) else "/"
+            null -> null
         }
     }
 

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
@@ -7,7 +7,26 @@ import com.intellij.psi.PsiArrayInitializerMemberValue
 import com.intellij.psi.PsiLiteralExpression
 import com.intellij.psi.PsiMethod
 
+internal enum class ServiceRegistrationMethod(val methodName: String) {
+    SERVICE("service"),
+    SERVICE_UNDER("serviceUnder"),
+    ANNOTATED_SERVICE("annotatedService"),
+    ;
+
+    companion object {
+        val METHOD_NAMES: Set<String> = entries.mapTo(linkedSetOf()) { it.methodName }
+
+        fun fromMethodName(name: String): ServiceRegistrationMethod? =
+            entries.firstOrNull { it.methodName == name }
+    }
+}
+
 object ArmeriaRouteSupport {
+    const val ARMERIA_PACKAGE_PREFIX = "com.linecorp.armeria"
+    const val ARMERIA_SERVER_PACKAGE_PREFIX = "com.linecorp.armeria.server"
+    const val SERVER_BUILDER_CLASS = "com.linecorp.armeria.server.ServerBuilder"
+    const val SERVER_BUILDER_SIMPLE_NAME = "ServerBuilder"
+
     const val PATH_PREFIX_ANNOTATION = "com.linecorp.armeria.server.annotation.PathPrefix"
     const val DECORATOR_ANNOTATION = "com.linecorp.armeria.server.annotation.Decorator"
     const val EXCEPTION_HANDLER_ANNOTATION = "com.linecorp.armeria.server.annotation.ExceptionHandler"
@@ -113,5 +132,11 @@ object ArmeriaRouteSupport {
         }
         val candidate = path.trim()
         return if (candidate.startsWith("/")) candidate else "/$candidate"
+    }
+
+    fun isServerBuilderType(typeText: String): Boolean {
+        return typeText == SERVER_BUILDER_SIMPLE_NAME ||
+            typeText == SERVER_BUILDER_CLASS ||
+            typeText.endsWith(".$SERVER_BUILDER_SIMPLE_NAME")
     }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaMethodEntryPoint.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaMethodEntryPoint.kt
@@ -6,6 +6,7 @@ import com.intellij.codeInspection.reference.RefElement
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiMethod
 import com.intellij.util.xmlb.XmlSerializer
+import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteSupport
 import com.linecorp.intellij.plugins.armeria.message
 import org.jdom.Element
 
@@ -17,16 +18,11 @@ class ArmeriaMethodEntryPoint(
     override fun isEntryPoint(refElement: RefElement, psiElement: PsiElement) = isEntryPoint(psiElement)
 
     override fun isEntryPoint(psiElement: PsiElement): Boolean {
-        return psiElement is PsiMethod && AnnotationUtil.isAnnotated(psiElement, listOf(
-            "com.linecorp.armeria.server.annotation.Get",
-            "com.linecorp.armeria.server.annotation.Head",
-            "com.linecorp.armeria.server.annotation.Post",
-            "com.linecorp.armeria.server.annotation.Put",
-            "com.linecorp.armeria.server.annotation.Delete",
-            "com.linecorp.armeria.server.annotation.Options",
-            "com.linecorp.armeria.server.annotation.Patch",
-            "com.linecorp.armeria.server.annotation.Trace",
-        ), AnnotationUtil.CHECK_TYPE)
+        return psiElement is PsiMethod && AnnotationUtil.isAnnotated(
+            psiElement,
+            ArmeriaRouteSupport.routeAnnotations.keys.toList(),
+            AnnotationUtil.CHECK_TYPE,
+        )
     }
 
     override fun isSelected(): Boolean = wasSelected


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #164: deduplicate Armeria route-related constants that were introduced in both the Java and Kotlin route collectors.

## Changes

- **`ArmeriaRouteSupport`**: add shared package/class constants (`ARMERIA_PACKAGE_PREFIX`, `ARMERIA_SERVER_PACKAGE_PREFIX`, `SERVER_BUILDER_CLASS`, `SERVER_BUILDER_SIMPLE_NAME`) and `isServerBuilderType()`
- **`ServiceRegistrationMethod`**: extract enum with `METHOD_NAMES` and `fromMethodName()` so Java/Kotlin collectors share registration method names
- **`ArmeriaRouteCollector` / `ArmeriaKotlinRouteCollector`**: remove duplicated private constants and use shared definitions
- **`ArmeriaMethodEntryPoint`**: reuse `ArmeriaRouteSupport.routeAnnotations.keys` instead of hardcoded HTTP annotation FQNs

## Test plan

- [x] `./gradlew :plugin:compileKotlin :plugin:test --tests "com.linecorp.intellij.plugins.armeria.explorer.*"`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2068-6248-7c63-badb-d379b9311a06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2068-6248-7c63-badb-d379b9311a06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

