### PR TITLE
feat: Kotlin Spring Boot Armeria route detection

### DIFF
--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
@@ -93,6 +93,9 @@ internal object ArmeriaKotlinRouteCollector {
         collectServiceRegistrationsInScope(file, routes, seenServiceRegistrations)
     }
 
+    internal fun resolveKotlinReturnTypeText(typeReference: KtTypeReference?): String? =
+        resolveKotlinTypeReferenceText(typeReference)
+
     private fun resolveCallName(call: KtCallExpression): String? {
         val callee = call.calleeExpression ?: return null
         return when (callee) {

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
@@ -93,9 +93,6 @@ internal object ArmeriaKotlinRouteCollector {
         collectServiceRegistrationsInScope(file, routes, seenServiceRegistrations)
     }
 
-    internal fun resolveKotlinReturnTypeText(typeReference: KtTypeReference?): String? =
-        resolveKotlinTypeReferenceText(typeReference)
-
     private fun resolveCallName(call: KtCallExpression): String? {
         val callee = call.calleeExpression ?: return null
         return when (callee) {

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinSpringBootRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinSpringBootRouteCollector.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.idea.KotlinFileType
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+import java.io.IOException
 
 internal object ArmeriaKotlinSpringBootRouteCollector {
     fun collect(
@@ -24,6 +25,10 @@ internal object ArmeriaKotlinSpringBootRouteCollector {
                 continue
             }
             ArmeriaRouteCollectionMetrics.current()?.filesScanned?.incrementAndGet()
+            val contents = loadVirtualFileText(virtualFile) ?: continue
+            if (!ArmeriaRouteSupport.mayReferenceSpringBootArmeriaInText(contents)) {
+                continue
+            }
             val file = PsiManager.getInstance(project).findFile(virtualFile) as? KtFile ?: continue
             if (!referencesSpringBootArmeria(file)) {
                 continue
@@ -38,12 +43,22 @@ internal object ArmeriaKotlinSpringBootRouteCollector {
         if (ArmeriaKotlinRouteCollector.referencesArmeriaKotlinContent(file)) {
             return true
         }
-        val contents = file.viewProvider.contents
-        val searchWindow = contents.subSequence(0, minOf(contents.length, ArmeriaRouteSupport.ARMERIA_HEADER_SCAN_LIMIT))
+        return hasSpringBootArmeriaFileIndicators(file.viewProvider.contents)
+    }
+
+    private fun hasSpringBootArmeriaFileIndicators(contents: CharSequence): Boolean {
+        val header = contents.subSequence(0, minOf(contents.length, ArmeriaRouteSupport.ARMERIA_HEADER_SCAN_LIMIT))
         return ArmeriaRouteSupport.SPRING_BOOT_ARMERIA_FILE_INDICATORS.any { indicator ->
-            searchWindow.contains(indicator)
+            header.contains(indicator)
         }
     }
+
+    private fun loadVirtualFileText(virtualFile: VirtualFile): CharSequence? =
+        try {
+            String(virtualFile.contentsToByteArray(), virtualFile.charset)
+        } catch (_: IOException) {
+            null
+        }
 
     private fun collectBeanServerRegistrations(
         file: KtFile,

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinSpringBootRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinSpringBootRouteCollector.kt
@@ -35,13 +35,16 @@ internal object ArmeriaKotlinSpringBootRouteCollector {
     }
 
     private fun referencesSpringBootArmeria(file: KtFile): Boolean {
-        val hasSpringImports = file.importList?.imports?.any { import ->
-            import.importedFqName?.asString()?.startsWith(ArmeriaRouteSupport.ARMERIA_SPRING_PACKAGE_PREFIX) == true
+        val hasArmeriaImports = file.importList?.imports?.any { import ->
+            import.importedFqName?.asString()?.startsWith(ArmeriaRouteSupport.ARMERIA_PACKAGE_PREFIX) == true
         } ?: false
-        if (hasSpringImports) {
+        if (hasArmeriaImports) {
             return true
         }
         val contents = file.viewProvider.contents
+        if (ArmeriaRouteSupport.referencesArmeriaInText(contents)) {
+            return true
+        }
         val searchWindow = contents.subSequence(0, minOf(contents.length, ArmeriaRouteSupport.ARMERIA_HEADER_SCAN_LIMIT))
         return ArmeriaRouteSupport.SPRING_BOOT_ARMERIA_FILE_INDICATORS.any(searchWindow::contains)
     }
@@ -53,10 +56,11 @@ internal object ArmeriaKotlinSpringBootRouteCollector {
         seenServiceRegistrations: MutableSet<String>,
     ) {
         for (function in file.collectDescendantsOfType<KtNamedFunction>()) {
-            if (!function.hasSpringBeanAnnotation()) {
+            val lightMethods = function.toLightMethods()
+            if (!lightMethods.any { it.hasAnnotation(ArmeriaRouteSupport.SPRING_BEAN_ANNOTATION) }) {
                 continue
             }
-            if (!function.isArmeriaServerBeanReturnType(scope)) {
+            if (!lightMethods.any { ArmeriaRouteSupport.isArmeriaServerBeanReturnType(it, scope) }) {
                 continue
             }
             ArmeriaKotlinRouteCollector.collectServiceRegistrationsInScope(
@@ -66,10 +70,4 @@ internal object ArmeriaKotlinSpringBootRouteCollector {
             )
         }
     }
-
-    private fun KtNamedFunction.hasSpringBeanAnnotation(): Boolean =
-        toLightMethods().any { it.hasAnnotation(ArmeriaRouteSupport.SPRING_BEAN_ANNOTATION) }
-
-    private fun KtNamedFunction.isArmeriaServerBeanReturnType(scope: GlobalSearchScope): Boolean =
-        toLightMethods().any { ArmeriaRouteSupport.isArmeriaServerBeanReturnType(it, scope) }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinSpringBootRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinSpringBootRouteCollector.kt
@@ -30,7 +30,7 @@ internal object ArmeriaKotlinSpringBootRouteCollector {
             }
             fallbackScannedFiles += virtualFile
             ArmeriaRouteCollectionMetrics.current()?.armeriaFiles?.incrementAndGet()
-            collectBeanServerRegistrations(file, routes, seenServiceRegistrations)
+            collectBeanServerRegistrations(file, scope, routes, seenServiceRegistrations)
         }
     }
 
@@ -41,12 +41,14 @@ internal object ArmeriaKotlinSpringBootRouteCollector {
         if (hasSpringImports) {
             return true
         }
-        val searchWindow = file.text.take(ArmeriaRouteSupport.ARMERIA_HEADER_SCAN_LIMIT)
+        val contents = file.viewProvider.contents
+        val searchWindow = contents.subSequence(0, minOf(contents.length, ArmeriaRouteSupport.ARMERIA_HEADER_SCAN_LIMIT))
         return ArmeriaRouteSupport.SPRING_BOOT_ARMERIA_FILE_INDICATORS.any(searchWindow::contains)
     }
 
     private fun collectBeanServerRegistrations(
         file: KtFile,
+        scope: GlobalSearchScope,
         routes: MutableList<ArmeriaRoute>,
         seenServiceRegistrations: MutableSet<String>,
     ) {
@@ -54,8 +56,7 @@ internal object ArmeriaKotlinSpringBootRouteCollector {
             if (!function.hasSpringBeanAnnotation()) {
                 continue
             }
-            val returnType = ArmeriaKotlinRouteCollector.resolveKotlinReturnTypeText(function.typeReference).orEmpty()
-            if (!ArmeriaRouteSupport.isArmeriaServerBeanReturnType(returnType)) {
+            if (!function.isArmeriaServerBeanReturnType(scope)) {
                 continue
             }
             ArmeriaKotlinRouteCollector.collectServiceRegistrationsInScope(
@@ -68,4 +69,7 @@ internal object ArmeriaKotlinSpringBootRouteCollector {
 
     private fun KtNamedFunction.hasSpringBeanAnnotation(): Boolean =
         toLightMethods().any { it.hasAnnotation(ArmeriaRouteSupport.SPRING_BEAN_ANNOTATION) }
+
+    private fun KtNamedFunction.isArmeriaServerBeanReturnType(scope: GlobalSearchScope): Boolean =
+        toLightMethods().any { ArmeriaRouteSupport.isArmeriaServerBeanReturnType(it, scope) }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinSpringBootRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinSpringBootRouteCollector.kt
@@ -35,18 +35,14 @@ internal object ArmeriaKotlinSpringBootRouteCollector {
     }
 
     private fun referencesSpringBootArmeria(file: KtFile): Boolean {
-        val hasArmeriaImports = file.importList?.imports?.any { import ->
-            import.importedFqName?.asString()?.startsWith(ArmeriaRouteSupport.ARMERIA_PACKAGE_PREFIX) == true
-        } ?: false
-        if (hasArmeriaImports) {
+        if (ArmeriaKotlinRouteCollector.referencesArmeriaKotlinContent(file)) {
             return true
         }
         val contents = file.viewProvider.contents
-        if (ArmeriaRouteSupport.referencesArmeriaInText(contents)) {
-            return true
-        }
         val searchWindow = contents.subSequence(0, minOf(contents.length, ArmeriaRouteSupport.ARMERIA_HEADER_SCAN_LIMIT))
-        return ArmeriaRouteSupport.SPRING_BOOT_ARMERIA_FILE_INDICATORS.any(searchWindow::contains)
+        return ArmeriaRouteSupport.SPRING_BOOT_ARMERIA_FILE_INDICATORS.any { indicator ->
+            searchWindow.contains(indicator)
+        }
     }
 
     private fun collectBeanServerRegistrations(

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinSpringBootRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinSpringBootRouteCollector.kt
@@ -1,0 +1,71 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.FileTypeIndex
+import com.intellij.psi.search.GlobalSearchScope
+import org.jetbrains.kotlin.asJava.toLightMethods
+import org.jetbrains.kotlin.idea.KotlinFileType
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+
+internal object ArmeriaKotlinSpringBootRouteCollector {
+    fun collect(
+        project: Project,
+        scope: GlobalSearchScope,
+        routes: MutableList<ArmeriaRoute>,
+        fallbackScannedFiles: MutableSet<VirtualFile>,
+        seenServiceRegistrations: MutableSet<String>,
+    ) {
+        for (virtualFile in FileTypeIndex.getFiles(KotlinFileType.INSTANCE, scope)) {
+            if (virtualFile in fallbackScannedFiles) {
+                continue
+            }
+            ArmeriaRouteCollectionMetrics.current()?.filesScanned?.incrementAndGet()
+            val file = PsiManager.getInstance(project).findFile(virtualFile) as? KtFile ?: continue
+            if (!referencesSpringBootArmeria(file)) {
+                continue
+            }
+            fallbackScannedFiles += virtualFile
+            ArmeriaRouteCollectionMetrics.current()?.armeriaFiles?.incrementAndGet()
+            collectBeanServerRegistrations(file, routes, seenServiceRegistrations)
+        }
+    }
+
+    private fun referencesSpringBootArmeria(file: KtFile): Boolean {
+        val hasSpringImports = file.importList?.imports?.any { import ->
+            import.importedFqName?.asString()?.startsWith(ArmeriaRouteSupport.ARMERIA_SPRING_PACKAGE_PREFIX) == true
+        } ?: false
+        if (hasSpringImports) {
+            return true
+        }
+        val searchWindow = file.text.take(ArmeriaRouteSupport.ARMERIA_HEADER_SCAN_LIMIT)
+        return ArmeriaRouteSupport.SPRING_BOOT_ARMERIA_FILE_INDICATORS.any(searchWindow::contains)
+    }
+
+    private fun collectBeanServerRegistrations(
+        file: KtFile,
+        routes: MutableList<ArmeriaRoute>,
+        seenServiceRegistrations: MutableSet<String>,
+    ) {
+        for (function in file.collectDescendantsOfType<KtNamedFunction>()) {
+            if (!function.hasSpringBeanAnnotation()) {
+                continue
+            }
+            val returnType = ArmeriaKotlinRouteCollector.resolveKotlinReturnTypeText(function.typeReference).orEmpty()
+            if (!ArmeriaRouteSupport.isArmeriaServerBeanReturnType(returnType)) {
+                continue
+            }
+            ArmeriaKotlinRouteCollector.collectServiceRegistrationsInScope(
+                function,
+                routes,
+                seenServiceRegistrations,
+            )
+        }
+    }
+
+    private fun KtNamedFunction.hasSpringBeanAnnotation(): Boolean =
+        toLightMethods().any { it.hasAnnotation(ArmeriaRouteSupport.SPRING_BEAN_ANNOTATION) }
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinSpringBootRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinSpringBootRouteCollector.kt
@@ -25,7 +25,7 @@ internal object ArmeriaKotlinSpringBootRouteCollector {
                 continue
             }
             ArmeriaRouteCollectionMetrics.current()?.filesScanned?.incrementAndGet()
-            val contents = loadVirtualFileText(virtualFile) ?: continue
+            val contents = loadVirtualFileHeaderText(virtualFile) ?: continue
             if (!ArmeriaRouteSupport.mayReferenceSpringBootArmeriaInText(contents)) {
                 continue
             }
@@ -53,9 +53,21 @@ internal object ArmeriaKotlinSpringBootRouteCollector {
         }
     }
 
-    private fun loadVirtualFileText(virtualFile: VirtualFile): CharSequence? =
+    private fun loadVirtualFileHeaderText(virtualFile: VirtualFile): CharSequence? =
         try {
-            String(virtualFile.contentsToByteArray(), virtualFile.charset)
+            val maxBytes = ArmeriaRouteSupport.ARMERIA_HEADER_SCAN_LIMIT * 4
+            val bytesToRead = minOf(virtualFile.length, maxBytes.toLong()).toInt()
+            if (bytesToRead <= 0) {
+                return null
+            }
+            val bytes = ByteArray(bytesToRead)
+            virtualFile.inputStream.use { input ->
+                val read = input.read(bytes)
+                if (read <= 0) {
+                    return null
+                }
+                String(bytes, 0, read, virtualFile.charset)
+            }
         } catch (_: IOException) {
             null
         }
@@ -67,6 +79,9 @@ internal object ArmeriaKotlinSpringBootRouteCollector {
         seenServiceRegistrations: MutableSet<String>,
     ) {
         for (function in file.collectDescendantsOfType<KtNamedFunction>()) {
+            if (!mayHaveSpringBeanAnnotation(function)) {
+                continue
+            }
             val lightMethods = function.toLightMethods()
             if (!lightMethods.any { it.hasAnnotation(ArmeriaRouteSupport.SPRING_BEAN_ANNOTATION) }) {
                 continue
@@ -79,6 +94,16 @@ internal object ArmeriaKotlinSpringBootRouteCollector {
                 routes,
                 seenServiceRegistrations,
             )
+        }
+    }
+
+    private fun mayHaveSpringBeanAnnotation(function: KtNamedFunction): Boolean {
+        if (function.annotationEntries.isEmpty()) {
+            return false
+        }
+        return function.annotationEntries.any { entry ->
+            entry.shortName?.asString() == "Bean" ||
+                entry.text.contains(ArmeriaRouteSupport.SPRING_BEAN_ANNOTATION)
         }
     }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
@@ -80,6 +80,15 @@ object ArmeriaRouteCollector {
                 fallbackScannedFiles,
                 seenServiceRegistrations,
             )
+            if (ArmeriaRouteSupport.isSpringBootArmeriaAvailable(psiFacade, scope)) {
+                ArmeriaKotlinSpringBootRouteCollector.collect(
+                    project,
+                    scope,
+                    routes,
+                    fallbackScannedFiles,
+                    seenServiceRegistrations,
+                )
+            }
         }
         if (ArmeriaRouteSupport.isSpringBootArmeriaAvailable(psiFacade, scope)) {
             ArmeriaSpringBootRouteCollector.collect(

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
@@ -66,6 +66,7 @@ object ArmeriaRouteCollector {
         val seenServiceRegistrations = mutableSetOf<String>()
         val psiFacade = JavaPsiFacade.getInstance(project)
         val serverBuilderOnClasspath = psiFacade.findClass(ArmeriaRouteSupport.SERVER_BUILDER_CLASS, scope) != null
+        val springBootArmeriaAvailable = ArmeriaRouteSupport.isSpringBootArmeriaAvailable(psiFacade, scope)
 
         collectAnnotatedRoutesIndexed(project, scope, routes)
         collectServiceRegistrationsIndexed(project, scope, routes, seenServiceRegistrations)
@@ -80,7 +81,7 @@ object ArmeriaRouteCollector {
                 fallbackScannedFiles,
                 seenServiceRegistrations,
             )
-            if (ArmeriaRouteSupport.isSpringBootArmeriaAvailable(psiFacade, scope)) {
+            if (springBootArmeriaAvailable) {
                 ArmeriaKotlinSpringBootRouteCollector.collect(
                     project,
                     scope,
@@ -90,7 +91,7 @@ object ArmeriaRouteCollector {
                 )
             }
         }
-        if (ArmeriaRouteSupport.isSpringBootArmeriaAvailable(psiFacade, scope)) {
+        if (springBootArmeriaAvailable) {
             ArmeriaSpringBootRouteCollector.collect(
                 project,
                 scope,

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
@@ -34,6 +34,13 @@ object ArmeriaRouteSupport {
     const val ARMERIA_SERVER_CONFIGURATOR_CLASS = "$ARMERIA_SPRING_PACKAGE_PREFIX.ArmeriaServerConfigurator"
     const val SERVER_BUILDER_CLASS = "com.linecorp.armeria.server.ServerBuilder"
     const val SPRING_BEAN_ANNOTATION = "org.springframework.context.annotation.Bean"
+
+    val SPRING_BOOT_ARMERIA_FILE_INDICATORS = setOf(
+        "ArmeriaServerConfigurator",
+        "ArmeriaAutoConfiguration",
+        "spring-boot-starter-armeria",
+    )
+
     const val SERVER_BUILDER_SIMPLE_NAME = "ServerBuilder"
     const val ARMERIA_HEADER_SCAN_LIMIT = 4096
 

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
@@ -294,6 +294,24 @@ object ArmeriaRouteSupport {
         return ARMERIA_REFERENCE_PATTERN.containsMatchIn(searchWindow)
     }
 
+    fun referencesArmeriaKotlinContentInText(contents: CharSequence): Boolean {
+        val header = contents.subSequence(0, minOf(contents.length, ARMERIA_HEADER_SCAN_LIMIT))
+        if (header.contains("import $ARMERIA_PACKAGE_PREFIX")) {
+            return true
+        }
+        return referencesArmeriaInText(contents)
+    }
+
+    fun mayReferenceSpringBootArmeriaInText(contents: CharSequence): Boolean {
+        if (referencesArmeriaKotlinContentInText(contents)) {
+            return true
+        }
+        val header = contents.subSequence(0, minOf(contents.length, ARMERIA_HEADER_SCAN_LIMIT))
+        return SPRING_BOOT_ARMERIA_FILE_INDICATORS.any { indicator ->
+            header.contains(indicator)
+        }
+    }
+
     fun looksLikeServerBuilderReceiverText(text: String): Boolean {
         return SERVER_BUILDER_CALL.containsMatchIn(text) || SERVER_BUILDER_IDENTIFIER.containsMatchIn(text)
     }

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinSpringBootRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinSpringBootRouteCollectorTest.kt
@@ -232,6 +232,49 @@ class ArmeriaKotlinSpringBootRouteCollectorTest : LightJavaCodeInsightFixtureTes
         assertEquals("example.HelloService", directRoutes.single().target)
     }
 
+    fun testKotlinSpringBootCollectorCollectsRoutesWithServerImportOnly() {
+        myFixture.configureByText(
+            "ArmeriaConfig.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+            import org.springframework.context.annotation.Bean
+            import org.springframework.context.annotation.Configuration
+
+            @Configuration
+            class ArmeriaConfig {
+                @Bean
+                fun armeriaServer(): Server =
+                    Server.builder()
+                        .service("/server-import", HelloService())
+                        .build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = mutableListOf<ArmeriaRoute>()
+        ArmeriaKotlinSpringBootRouteCollector.collect(
+            project,
+            GlobalSearchScope.projectScope(project),
+            routes,
+            linkedSetOf(),
+            mutableSetOf(),
+        )
+
+        val serverImportRoutes = routes.filter { it.path == "/server-import" && it.routeMatch == RouteMatch.SERVICE }
+        assertEquals(1, serverImportRoutes.size)
+        assertEquals("example.HelloService", serverImportRoutes.single().target)
+    }
+
     fun testCollectServiceRegistrationFromBeanServerBuilder() {
         myFixture.configureByText(
             "ArmeriaConfig.kt",

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinSpringBootRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinSpringBootRouteCollectorTest.kt
@@ -171,6 +171,7 @@ class ArmeriaKotlinSpringBootRouteCollectorTest : LightJavaCodeInsightFixtureTes
             """
             package example
 
+            import com.linecorp.armeria.spring.ArmeriaServerConfigurator
             import org.springframework.context.annotation.Bean
             import org.springframework.context.annotation.Configuration
 

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinSpringBootRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinSpringBootRouteCollectorTest.kt
@@ -1,5 +1,6 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
+import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
 
 class ArmeriaKotlinSpringBootRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
@@ -186,6 +187,213 @@ class ArmeriaKotlinSpringBootRouteCollectorTest : LightJavaCodeInsightFixtureTes
         val routes = ArmeriaRouteCollector.collect(project)
 
         assertTrue(routes.isEmpty())
+    }
+
+    fun testKotlinSpringBootCollectorCollectsRoutesDirectly() {
+        myFixture.configureByText(
+            "ArmeriaConfig.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.spring.ArmeriaServerConfigurator
+            import org.springframework.context.annotation.Bean
+            import org.springframework.context.annotation.Configuration
+
+            @Configuration
+            class ArmeriaConfig {
+                @Bean
+                fun armeriaServerConfigurator(): ArmeriaServerConfigurator =
+                    ArmeriaServerConfigurator { serverBuilder ->
+                        serverBuilder.service("/direct", HelloService())
+                    }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = mutableListOf<ArmeriaRoute>()
+        ArmeriaKotlinSpringBootRouteCollector.collect(
+            project,
+            GlobalSearchScope.projectScope(project),
+            routes,
+            linkedSetOf(),
+            mutableSetOf(),
+        )
+
+        val directRoutes = routes.filter { it.path == "/direct" && it.routeMatch == RouteMatch.SERVICE }
+        assertEquals(1, directRoutes.size)
+        assertEquals("example.HelloService", directRoutes.single().target)
+    }
+
+    fun testCollectServiceRegistrationFromBeanServerBuilder() {
+        myFixture.configureByText(
+            "ArmeriaConfig.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+            import com.linecorp.armeria.server.ServerBuilder
+            import org.springframework.context.annotation.Bean
+            import org.springframework.context.annotation.Configuration
+
+            @Configuration
+            class ArmeriaConfig {
+                @Bean
+                fun armeriaServerBuilder(): ServerBuilder =
+                    Server.builder()
+                        .service("/builder", HelloService())
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val builderRoutes = routes.filter { it.path == "/builder" && it.routeMatch == RouteMatch.SERVICE }
+        assertEquals(1, builderRoutes.size)
+        assertEquals("example.HelloService", builderRoutes.single().target)
+    }
+
+    fun testCollectInferredReturnTypeFromBeanFunction() {
+        myFixture.configureByText(
+            "ArmeriaConfig.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+            import org.springframework.context.annotation.Bean
+            import org.springframework.context.annotation.Configuration
+
+            @Configuration
+            class ArmeriaConfig {
+                @Bean
+                fun armeriaServer() =
+                    Server.builder()
+                        .service("/inferred", HelloService())
+                        .build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val inferredRoutes = routes.filter { it.path == "/inferred" && it.routeMatch == RouteMatch.SERVICE }
+        assertEquals(1, inferredRoutes.size)
+        assertEquals("example.HelloService", inferredRoutes.single().target)
+    }
+
+    fun testCollectServiceUnderAndAnnotatedServiceFromBeanConfigurator() {
+        myFixture.configureByText(
+            "ArmeriaConfig.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.spring.ArmeriaServerConfigurator
+            import org.springframework.context.annotation.Bean
+            import org.springframework.context.annotation.Configuration
+
+            @Configuration
+            class ArmeriaConfig {
+                @Bean
+                fun armeriaServerConfigurator(): ArmeriaServerConfigurator =
+                    ArmeriaServerConfigurator { serverBuilder ->
+                        serverBuilder.serviceUnder("/api", HelloService())
+                        serverBuilder.annotatedService(AnnotatedService())
+                    }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class AnnotatedService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val serviceUnderRoutes = routes.filter { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE_UNDER }
+        assertEquals(1, serviceUnderRoutes.size)
+        val annotatedRoutes = routes.filter { it.routeMatch == RouteMatch.ANNOTATED_SERVICE }
+        assertEquals(1, annotatedRoutes.size)
+    }
+
+    fun testCollectServiceRegistrationFromConfiguratorSubtype() {
+        myFixture.addClass(
+            """
+            package example;
+
+            import com.linecorp.armeria.server.ServerBuilder;
+            import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
+
+            public final class RoutingConfigurator implements ArmeriaServerConfigurator {
+                @Override
+                public void configure(ServerBuilder serverBuilder) {
+                    serverBuilder.service("/subtype", new HelloService());
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "ArmeriaConfig.kt",
+            """
+            package example
+
+            import org.springframework.context.annotation.Bean
+            import org.springframework.context.annotation.Configuration
+
+            @Configuration
+            class ArmeriaConfig {
+                @Bean
+                fun customConfigurator(): RoutingConfigurator = RoutingConfigurator()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val subtypeRoutes = routes.filter { it.path == "/subtype" && it.routeMatch == RouteMatch.SERVICE }
+        assertEquals(1, subtypeRoutes.size)
     }
 
     private fun registerArmeriaStubs() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Kotlin Spring Boot `@Bean` Server registration discovery to Route Explorer, complementing the Java collector in #170.

## Changes

- `ArmeriaKotlinSpringBootRouteCollector` scans Kotlin files with `com.linecorp.armeria` imports or Spring Boot Armeria indicators
- Finds `@Bean` functions returning `Server`, `ServerBuilder`, or `ArmeriaServerConfigurator` via PSI-based return-type resolution (`toLightMethods()`, inferred types and subtypes)
- Delegates to `ArmeriaKotlinRouteCollector.collectServiceRegistrationsInScope` with shared `seenServiceRegistrations` deduplication
- Extracts shared `SPRING_BOOT_ARMERIA_FILE_INDICATORS` to `ArmeriaRouteSupport`
- Pre-filters Kotlin files via VFS header text before resolving PSI; uses `viewProvider.contents` for indicator scanning
- Broadens Spring Boot Armeria detection to `com.linecorp.armeria.server.*` imports and Armeria references in file text
- Adds direct collector unit tests plus Kotlin parity tests (`ServerBuilder`, inferred return, `serviceUnder`/`annotatedService`, configurator subtype)

## Depends on

- #170

## Test plan

- [x] `./gradlew :plugin:test --tests "com.linecorp.intellij.plugins.armeria.explorer.ArmeriaKotlinSpringBootRouteCollectorTest"`
- [x] `./gradlew :plugin:test --tests "com.linecorp.intellij.plugins.armeria.explorer.ArmeriaSpringBootRouteCollectorTest"`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f287d-8191-797e-94d8-2978ae7702ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f287d-8191-797e-94d8-2978ae7702ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

