### PR TITLE
Configure Cloud Agents to use ManagePullRequest instead of failing on missing gh

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -88,7 +88,7 @@ setup_gh_cli() {
   if ! "${gh_source}" auth status >/dev/null 2>&1; then
     local token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
     if [[ -n "${token}" ]]; then
-      if ! "${gh_source}" auth login --hostname github.com --with-token <<<"${token}"; then
+      if ! "${gh_source}" auth login --hostname github.com --git-protocol https --with-token <<<"${token}"; then
         echo "Warning: gh auth login failed; gh CLI may be unavailable for API calls." >&2
         echo "Use ManagePullRequest for PRs, or set GH_TOKEN in Cursor Cloud Secrets." >&2
       fi

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -66,4 +66,35 @@ ensure_jar() {
 ensure_jar
 ln -sfn "${VERSIONED_JAR_NAME}" "${STABLE_JAR_PATH}"
 
+setup_gh_cli() {
+  local gh_source="/exec-daemon/gh"
+  if [[ ! -x "${gh_source}" ]]; then
+    echo "Warning: ${gh_source} not found; gh CLI will be unavailable in this session." >&2
+    return 0
+  fi
+
+  mkdir -p "${HOME}/.local/bin"
+  ln -sfn "${gh_source}" "${HOME}/.local/bin/gh"
+
+  if [[ -w /usr/local/bin ]]; then
+    ln -sfn "${gh_source}" /usr/local/bin/gh
+  fi
+
+  if ! "${gh_source}" auth status >/dev/null 2>&1; then
+    local token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+    if [[ -n "${token}" ]]; then
+      printf '%s\n' "${token}" | "${gh_source}" auth login --hostname github.com --with-token
+    else
+      echo "Warning: gh is not authenticated and GH_TOKEN/GITHUB_TOKEN is unset." >&2
+      echo "Set GH_TOKEN in Cursor Cloud Secrets, or use the ManagePullRequest tool for PRs." >&2
+    fi
+  fi
+
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "Warning: gh is installed but not on PATH; use /exec-daemon/gh or ~/.local/bin/gh." >&2
+  fi
+}
+
+setup_gh_cli
+
 ./gradlew --no-daemon build

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -73,17 +73,25 @@ setup_gh_cli() {
     return 0
   fi
 
-  mkdir -p "${HOME}/.local/bin"
-  ln -sfn "${gh_source}" "${HOME}/.local/bin/gh"
+  if ! mkdir -p "${HOME}/.local/bin" 2>/dev/null; then
+    echo "Warning: could not create ${HOME}/.local/bin; gh symlink skipped." >&2
+  elif ! ln -sfn "${gh_source}" "${HOME}/.local/bin/gh" 2>/dev/null; then
+    echo "Warning: could not symlink gh to ${HOME}/.local/bin/gh." >&2
+  fi
 
   if [[ -w /usr/local/bin ]]; then
-    ln -sfn "${gh_source}" /usr/local/bin/gh
+    if ! ln -sfn "${gh_source}" /usr/local/bin/gh 2>/dev/null; then
+      echo "Warning: could not symlink gh to /usr/local/bin/gh." >&2
+    fi
   fi
 
   if ! "${gh_source}" auth status >/dev/null 2>&1; then
     local token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
     if [[ -n "${token}" ]]; then
-      printf '%s\n' "${token}" | "${gh_source}" auth login --hostname github.com --with-token
+      if ! "${gh_source}" auth login --hostname github.com --with-token <<<"${token}"; then
+        echo "Warning: gh auth login failed; gh CLI may be unavailable for API calls." >&2
+        echo "Use ManagePullRequest for PRs, or set GH_TOKEN in Cursor Cloud Secrets." >&2
+      fi
     else
       echo "Warning: gh is not authenticated and GH_TOKEN/GITHUB_TOKEN is unset." >&2
       echo "Set GH_TOKEN in Cursor Cloud Secrets, or use the ManagePullRequest tool for PRs." >&2

--- a/.cursor/rules/cloud-github.mdc
+++ b/.cursor/rules/cloud-github.mdc
@@ -1,0 +1,24 @@
+---
+description: GitHub and PR workflows for Cursor Cloud Agents — prefer ManagePullRequest over gh CLI
+alwaysApply: true
+---
+
+# Cloud GitHub operations
+
+In Cursor Cloud, do **not** assume `gh` is on PATH before `.cursor/install.sh` completes.
+
+## Pull requests
+
+- Use the built-in **ManagePullRequest** tool for `create_pr` and `update_pr`.
+- Use **EditPullRequestLabels** for label changes.
+- Do not run `gh pr create` / `gh pr edit` unless ManagePullRequest fails and `gh auth status` succeeds.
+
+## GitHub CLI fallback
+
+When a skill requires `gh` (CI checks, PR comments, API calls):
+
+1. Resolve: `command -v gh` or `/exec-daemon/gh`
+2. Verify: `gh auth status`
+3. If either step fails, stop — do not loop on missing `gh`. Use ManagePullRequest for PRs or `./gradlew build` for local verification.
+
+Do not install `gh` in agent sessions. See `.cursor/skills/cloud-github/SKILL.md`.

--- a/.cursor/skills/cloud-github/SKILL.md
+++ b/.cursor/skills/cloud-github/SKILL.md
@@ -8,8 +8,9 @@ description: >-
 # Cloud GitHub operations
 
 Cursor Cloud Agents in this repository must not fail because `gh` is missing from PATH.
-`.cursor/install.sh` symlinks `/exec-daemon/gh` into `~/.local/bin/gh` and `/usr/local/bin/gh`
-and configures authentication from `GH_TOKEN` or `GITHUB_TOKEN` when needed.
+`.cursor/install.sh` symlinks `/exec-daemon/gh` into `~/.local/bin/gh` and, when
+`/usr/local/bin` is writable, into `/usr/local/bin/gh`. When `gh auth status` is unauthenticated,
+it logs in with `GH_TOKEN` or `GITHUB_TOKEN` if set.
 
 ## PR create / update (preferred)
 

--- a/.cursor/skills/cloud-github/SKILL.md
+++ b/.cursor/skills/cloud-github/SKILL.md
@@ -23,7 +23,7 @@ unless ManagePullRequest fails and `gh auth status` succeeds.
 | Update PR title/body | `ManagePullRequest` with `action: update_pr` |
 | Edit labels | `EditPullRequestLabels` |
 
-Branch naming for agent work: `cursor/<descriptive-name>-c654`.
+Branch naming for agent work: `cursor/<descriptive-name>-<suffix>` (suffix is assigned per agent session).
 
 ## When `gh` is required
 
@@ -53,5 +53,5 @@ Use `gh pr checks` only when you need GitHub-attached check status and `gh auth 
 | Symptom | Fix |
 |---------|-----|
 | `gh: command not found` | Use `/exec-daemon/gh` or re-run `.cursor/install.sh` |
-| `Resource not accessible by integration` | Add `GH_TOKEN` in [Cursor Cloud Secrets](https://cursor.com/dashboard/cloud-agents); reinstall runs `gh auth login --with-token` |
+| `Resource not accessible by integration` | Add `GH_TOKEN` in [Cursor Cloud Secrets](https://cursor.com/dashboard/cloud-agents); reinstall runs `gh auth login --git-protocol https --with-token` |
 | ManagePullRequest fails | Push the branch first, then retry; do not fall back to `gh` unless auth works |

--- a/.cursor/skills/cloud-github/SKILL.md
+++ b/.cursor/skills/cloud-github/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: cloud-github
+description: >-
+  GitHub and pull-request workflows for Cursor Cloud Agents in this repo.
+  Prefer built-in ManagePullRequest over gh CLI; use gh only after install.sh.
+---
+
+# Cloud GitHub operations
+
+Cursor Cloud Agents in this repository must not fail because `gh` is missing from PATH.
+`.cursor/install.sh` symlinks `/exec-daemon/gh` into `~/.local/bin/gh` and `/usr/local/bin/gh`
+and configures authentication from `GH_TOKEN` or `GITHUB_TOKEN` when needed.
+
+## PR create / update (preferred)
+
+Use the built-in **ManagePullRequest** tool. Do not run `gh pr create` or `gh pr edit`
+unless ManagePullRequest fails and `gh auth status` succeeds.
+
+| Task | Tool / action |
+|------|----------------|
+| Open a PR | `ManagePullRequest` with `action: create_pr` |
+| Update PR title/body | `ManagePullRequest` with `action: update_pr` |
+| Edit labels | `EditPullRequestLabels` |
+
+Branch naming for agent work: `cursor/<descriptive-name>-c654`.
+
+## When `gh` is required
+
+Some bundled skills (for example `loop-on-ci`, `fix-ci`) reference `gh pr checks`.
+Before calling `gh`:
+
+1. Confirm install finished: `.cursor/install.sh` runs on every Cloud Agent boot.
+2. Resolve the binary: `command -v gh` → prefer that path; fall back to `/exec-daemon/gh`.
+3. Confirm auth: `gh auth status` (or the resolved path above).
+4. If auth fails, stop retrying `gh` and either use ManagePullRequest for PR work or
+   verify locally with `./gradlew build`.
+
+Do not install `gh` via apt, brew, or curl in agent sessions.
+
+## CI verification in this repo
+
+GitHub Actions runs `./gradlew build` (see `.github/workflows/main.yml`).
+For agent-side verification, prefer:
+
+1. `gradle_run_tasks` with `["build"]` or `[":plugin:test"]` (see `gradle-tapi-mcp` skill)
+2. `./gradlew --no-daemon :plugin:compileKotlin :plugin:test`
+
+Use `gh pr checks` only when you need GitHub-attached check status and `gh auth status` succeeds.
+
+## Authentication troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `gh: command not found` | Use `/exec-daemon/gh` or re-run `.cursor/install.sh` |
+| `Resource not accessible by integration` | Add `GH_TOKEN` in [Cursor Cloud Secrets](https://cursor.com/dashboard/cloud-agents); reinstall runs `gh auth login --with-token` |
+| ManagePullRequest fails | Push the branch first, then retry; do not fall back to `gh` unless auth works |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,23 @@ Prefer token-efficient MCP workflows documented in `.cursor/skills/gradle-tapi-m
 2. `gradle_get_project_overview` for module hierarchy
 3. `gradle_run_tasks` with `["build"]` or targeted `:plugin:test` when verification is needed
 
+### GitHub and pull requests (Cursor Cloud)
+
+Do not rely on bare `gh` commands without checking availability. `.cursor/install.sh` symlinks
+`/exec-daemon/gh` into `~/.local/bin/gh` and `/usr/local/bin/gh`, and logs in with `GH_TOKEN` or
+`GITHUB_TOKEN` when the built-in integration token is missing.
+
+| Goal | Preferred approach |
+|------|-------------------|
+| Create or update a PR | Built-in **ManagePullRequest** tool (`create_pr` / `update_pr`) |
+| Edit PR labels | **EditPullRequestLabels** tool |
+| Verify changes locally | `./gradlew build` or Gradle MCP `gradle_run_tasks` |
+| PR check status / CI logs | `gh` only after `gh auth status` succeeds (see `.cursor/skills/cloud-github/SKILL.md`) |
+
+If `gh` is not found or auth fails, use ManagePullRequest for PR work and Gradle for build
+verification instead of retrying `gh`. Set `GH_TOKEN` in Cursor Cloud Secrets when the GitHub App
+token lacks required scopes.
+
 ### Build, test, lint
 
 | Goal | Command |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,9 @@ Prefer token-efficient MCP workflows documented in `.cursor/skills/gradle-tapi-m
 ### GitHub and pull requests (Cursor Cloud)
 
 Do not rely on bare `gh` commands without checking availability. `.cursor/install.sh` symlinks
-`/exec-daemon/gh` into `~/.local/bin/gh` and `/usr/local/bin/gh`, and logs in with `GH_TOKEN` or
-`GITHUB_TOKEN` when the built-in integration token is missing.
+`/exec-daemon/gh` into `~/.local/bin/gh` and, when `/usr/local/bin` is writable, into
+`/usr/local/bin/gh`. When `gh auth status` is unauthenticated, it logs in with `GH_TOKEN` or
+`GITHUB_TOKEN` if set.
 
 | Goal | Preferred approach |
 |------|-------------------|


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cloud Agents were repeatedly failing when bundled skills invoked `gh` before the CLI was on PATH or authenticated. This change makes GitHub operations reliable in Cursor Cloud.

## Changes

- **`.cursor/install.sh`**: Symlinks `/exec-daemon/gh` into `~/.local/bin/gh` (and `/usr/local/bin/gh` when writable); best-effort token login with `--git-protocol https` when `gh auth status` is unauthenticated. Symlink and auth failures emit warnings instead of aborting the install script.
- **`AGENTS.md`**: Documents the preferred GitHub workflow — ManagePullRequest for PRs, Gradle MCP / `./gradlew build` for verification, `gh` only as an authenticated fallback.
- **`.cursor/skills/cloud-github/SKILL.md`**: Operational guide for PR/CI workflows in Cloud.
- **`.cursor/rules/cloud-github.mdc`**: Always-applied rule so agents stop retrying bare `gh` commands when the CLI is unavailable.

## Agent workflow after this change

| Task | Tool |
|------|------|
| Create/update PR | `ManagePullRequest` |
| Edit labels | `EditPullRequestLabels` |
| Build verification | Gradle MCP or `./gradlew build` |
| PR check status | `gh` only after `gh auth status` succeeds |

## Notes

If `gh` still fails with `Resource not accessible by integration`, add `GH_TOKEN` in [Cursor Cloud Secrets](https://cursor.com/dashboard/cloud-agents).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2abd-099f-7a9a-bd89-584aef39c654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2abd-099f-7a9a-bd89-584aef39c654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

