### PR TITLE
chore: bump gradle-tapi-mcp-server to 0.2.3

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-readonly GRADLE_TAPI_MCP_VERSION="0.2.2"
-readonly GRADLE_TAPI_MCP_SHA256="4eeab95da2e3582df1c9879a48a638bd341a4e0e29113ee01199b7e9b93cdab1"
+readonly GRADLE_TAPI_MCP_VERSION="0.2.3"
+readonly GRADLE_TAPI_MCP_SHA256="01a1e7ce952f926ad2e427eb96386e7c49c8e4bfdf8bae05b5b195c66adc052b"
 readonly INSTALL_DIR="${HOME}/.local/share/gradle-tapi-mcp-server"
 readonly VERSIONED_JAR_NAME="gradle-tapi-mcp-server-${GRADLE_TAPI_MCP_VERSION}.jar"
 readonly VERSIONED_JAR_PATH="${INSTALL_DIR}/${VERSIONED_JAR_NAME}"

--- a/.cursor/skills/gradle-tapi-mcp/SKILL.md
+++ b/.cursor/skills/gradle-tapi-mcp/SKILL.md
@@ -27,7 +27,7 @@ Avoid `includeTasks=true` and heavy model queries unless necessary. `gradle_run_
 | Full verify | `gradle_run_tasks` | `{ "tasks": ["build"] }` |
 | All plugin tests | `gradle_run_tasks` | `{ "tasks": [":plugin:test"] }` |
 | Single test class | `gradle_run_tests` | `{ "testClasses": ["com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteCollectorTest"] }` |
-| Single test method | `gradle_run_tests` | `{ "testMethods": { "com.example.FooTest": ["shouldWork"] } }` |
+| Single test method | `gradle_run_tests` | `{ "testMethods": { "com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteCollectorTest": ["testCollectAnnotatedRoute"] } }` |
 
 Prefer `gradle_run_tests` when iterating on a failing test; use `gradle_run_tasks` for full `:plugin:test` or `build`.
 
@@ -36,7 +36,7 @@ Prefer `gradle_run_tests` when iterating on a failing test; use `gradle_run_task
 This repo uses two JVM roles:
 
 - **Gradle daemon JVM**: Adoptium 25 (`gradle/gradle-daemon-jvm.properties`)
-- **Compile toolchain**: Java 21 JetBrains (`build-logic/.../com.linecorp.intellij.platform-plugin.gradle.kts`)
+- **Compile toolchain**: Java 21 JetBrains (`build-logic/src/main/kotlin/com.linecorp.intellij.platform-plugin.gradle.kts`)
 
 `gradle_get_build_environment` shows the daemon's Java. For all detected JDKs (including toolchain downloads under `~/.gradle/jdks/`), use `gradle_get_java_runtimes`.
 

--- a/.cursor/skills/gradle-tapi-mcp/SKILL.md
+++ b/.cursor/skills/gradle-tapi-mcp/SKILL.md
@@ -7,7 +7,7 @@ description: >-
 
 # Gradle Tooling API MCP
 
-This repository configures [nise-nabe/gradle-tapi-mcp-server](https://github.com/nise-nabe/gradle-tapi-mcp-server) v0.2.2 in `.cursor/mcp.json`. The JAR is installed by `.cursor/install.sh` to `~/.local/share/gradle-tapi-mcp-server/gradle-tapi-mcp-server.jar`. At MCP server launch, `.cursor/mcp.json` sets `GRADLE_PROJECT_DIR=${workspaceFolder}`.
+This repository configures [nise-nabe/gradle-tapi-mcp-server](https://github.com/nise-nabe/gradle-tapi-mcp-server) v0.2.3 in `.cursor/mcp.json`. The JAR is installed by `.cursor/install.sh` to `~/.local/share/gradle-tapi-mcp-server/gradle-tapi-mcp-server.jar`. At MCP server launch, `.cursor/mcp.json` sets `GRADLE_PROJECT_DIR=${workspaceFolder}`.
 
 ## Workflow (token-efficient)
 
@@ -22,5 +22,5 @@ Avoid `includeTasks=true` and heavy model queries unless necessary. `gradle_run_
 
 Full tool reference and advanced workflows live in the upstream repository:
 
-- [README (v0.2.2)](https://github.com/nise-nabe/gradle-tapi-mcp-server/blob/v0.2.2/README.md)
-- [gradle-tapi-mcp skill](https://github.com/nise-nabe/gradle-tapi-mcp-server/tree/v0.2.2/skills/gradle-tapi-mcp)
+- [README (v0.2.3)](https://github.com/nise-nabe/gradle-tapi-mcp-server/blob/v0.2.3/README.md)
+- [gradle-tapi-mcp skill](https://github.com/nise-nabe/gradle-tapi-mcp-server/tree/v0.2.3/skills/gradle-tapi-mcp)

--- a/.cursor/skills/gradle-tapi-mcp/SKILL.md
+++ b/.cursor/skills/gradle-tapi-mcp/SKILL.md
@@ -16,7 +16,39 @@ This repository configures [nise-nabe/gradle-tapi-mcp-server](https://github.com
 3. `gradle_get_project_overview` — module hierarchy (`build-logic`, `plugin`)
 4. `gradle_run_tasks` with `["build"]` or `[":plugin:test"]` when verification is needed
 
-Avoid `includeTasks=true` and heavy model queries unless necessary. `gradle_run_tasks` omits stdout/stderr by default (`includeOutput=false`).
+Avoid `includeTasks=true` and heavy model queries unless necessary. `gradle_run_tasks` omits stdout/stderr by default (`includeOutput=false`). On failure, check `failedTasks` and `buildSummary.failureSummary` before setting `includeOutput=true`.
+
+## Repo-specific tips
+
+### Verification commands
+
+| Goal | MCP tool | Example |
+|------|----------|---------|
+| Full verify | `gradle_run_tasks` | `{ "tasks": ["build"] }` |
+| All plugin tests | `gradle_run_tasks` | `{ "tasks": [":plugin:test"] }` |
+| Single test class | `gradle_run_tests` | `{ "testClasses": ["com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteCollectorTest"] }` |
+| Single test method | `gradle_run_tests` | `{ "testMethods": { "com.example.FooTest": ["shouldWork"] } }` |
+
+Prefer `gradle_run_tests` when iterating on a failing test; use `gradle_run_tasks` for full `:plugin:test` or `build`.
+
+### JDK / toolchain debugging
+
+This repo uses two JVM roles:
+
+- **Gradle daemon JVM**: Adoptium 25 (`gradle/gradle-daemon-jvm.properties`)
+- **Compile toolchain**: Java 21 JetBrains (`build-logic/.../com.linecorp.intellij.platform-plugin.gradle.kts`)
+
+`gradle_get_build_environment` shows the daemon's Java. For all detected JDKs (including toolchain downloads under `~/.gradle/jdks/`), use `gradle_get_java_runtimes`.
+
+### IntelliJ test sandbox corruption
+
+If `:plugin:test` fails with many unrelated test errors and a stack trace mentioning `PersistentEnumerator storage corrupted` under `.intellijPlatform/sandbox/plugin/`, the test sandbox index is stale — not an MCP or code regression.
+
+```bash
+rm -rf .intellijPlatform/sandbox/plugin/IU-*/system-test
+```
+
+Then rerun `:plugin:test` or `build` via MCP or `./gradlew`.
 
 ## Upstream documentation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ IntelliJ Platform plugin for Armeria. Gradle multi-project build (`build-logic` 
 
 ### MCP: Gradle Tooling API
 
-The `gradle` MCP server (`nise-nabe/gradle-tapi-mcp-server` v0.2.2) is configured in `.cursor/mcp.json`. The install script downloads the release JAR to `~/.local/share/gradle-tapi-mcp-server/`, verifies its SHA-256, and exposes it via a stable `gradle-tapi-mcp-server.jar` symlink. `GRADLE_PROJECT_DIR` is set to the workspace root.
+The `gradle` MCP server (`nise-nabe/gradle-tapi-mcp-server` v0.2.3) is configured in `.cursor/mcp.json`. The install script downloads the release JAR to `~/.local/share/gradle-tapi-mcp-server/`, verifies its SHA-256, and exposes it via a stable `gradle-tapi-mcp-server.jar` symlink. `GRADLE_PROJECT_DIR` is set to the workspace root.
 
 Prefer token-efficient MCP workflows documented in `.cursor/skills/gradle-tapi-mcp/SKILL.md`:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the Gradle Tooling API MCP server from v0.2.2 to v0.2.3 and adds repo-specific agent guidance to the gradle-tapi-mcp skill.

## Changes

- `.cursor/install.sh`: version pin and SHA-256 checksum for `gradle-tapi-mcp-server-0.2.3.jar`
- `AGENTS.md`: version reference
- `.cursor/skills/gradle-tapi-mcp/SKILL.md`: version/upstream links plus repo-specific notes for:
  - `gradle_run_tasks` vs `gradle_run_tests`
  - `gradle_get_java_runtimes` for daemon vs toolchain JDK debugging
  - IntelliJ test sandbox index corruption recovery

## Verification

- Downloaded v0.2.3 JAR from the GitHub release and confirmed SHA-256 matches the pinned value
- Ran `ensure_jar` from the install script; symlink points to `gradle-tapi-mcp-server-0.2.3.jar`
- MCP `gradle_run_tasks` → `build` and `:plugin:test` both **SUCCESS** (177 tests)
- MCP `gradle_get_java_runtimes` returns detected JDKs including Adoptium 25 and JetBrains 21
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2b0f-3dba-77d1-9ca8-d89a5a43de97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2b0f-3dba-77d1-9ca8-d89a5a43de97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

