### PR TITLE
docs: improve Gradle MCP guidance from Cloud testing

### DIFF
--- a/.cursor/clean-test-sandbox.sh
+++ b/.cursor/clean-test-sandbox.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Remove stale IntelliJ Platform test sandbox indexes that cause
+# PersistentEnumerator / index corruption failures in :plugin:test.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SANDBOX="${ROOT}/.intellijPlatform/sandbox/plugin"
+
+if [[ ! -d "${SANDBOX}" ]]; then
+  echo "No test sandbox at ${SANDBOX}; nothing to clean."
+  exit 0
+fi
+
+removed=0
+while IFS= read -r -d '' dir; do
+  rm -rf "${dir}"
+  echo "Removed ${dir}"
+  removed=$((removed + 1))
+done < <(find "${SANDBOX}" -mindepth 1 -maxdepth 2 -type d -name system-test -print0 2>/dev/null || true)
+
+if [[ "${removed}" -eq 0 ]]; then
+  echo "No system-test directories found under ${SANDBOX}."
+else
+  echo "Cleaned ${removed} sandbox director(y/ies). Re-run :plugin:test or build."
+fi

--- a/.cursor/skills/cloud-github/SKILL.md
+++ b/.cursor/skills/cloud-github/SKILL.md
@@ -43,8 +43,9 @@ Do not install `gh` via apt, brew, or curl in agent sessions.
 GitHub Actions runs `./gradlew build` (see `.github/workflows/main.yml`).
 For agent-side verification, prefer:
 
-1. `gradle_run_tasks` with `["build"]` or `[":plugin:test"]` (see `gradle-tapi-mcp` skill)
-2. `./gradlew --no-daemon :plugin:compileKotlin :plugin:test`
+1. `./gradlew build` or `./gradlew --no-daemon :plugin:compileKotlin :plugin:test` — matches CI; reliable for long IntelliJ tests
+2. MCP `gradle_run_tasks` with `[":plugin:compileKotlin"]` for fast compile checks (see `gradle-tapi-mcp` skill)
+3. MCP `gradle_run_tasks` / `gradle_run_tests` with `background: true` only when the MCP client stays responsive; fall back to shell on timeout or unresponsive MCP server
 
 Use `gh pr checks` only when you need GitHub-attached check status and `gh auth status` succeeds.
 

--- a/.cursor/skills/gradle-tapi-mcp/SKILL.md
+++ b/.cursor/skills/gradle-tapi-mcp/SKILL.md
@@ -14,9 +14,90 @@ This repository configures [nise-nabe/gradle-tapi-mcp-server](https://github.com
 1. `gradle_connection_status` — confirm connected
 2. `gradle_get_build_environment` — resolved Gradle/Java versions
 3. `gradle_get_project_overview` — module hierarchy (`build-logic`, `plugin`)
-4. `gradle_run_tasks` with `["build"]` or `[":plugin:test"]` when verification is needed
+4. `gradle_run_tasks` with `["build"]` or `[":plugin:compileKotlin"]` when verification is needed
 
 Avoid `includeTasks=true` and heavy model queries unless necessary. `gradle_run_tasks` omits stdout/stderr by default (`includeOutput=false`). On failure, check `failedTasks` and `buildSummary.failureSummary` before setting `includeOutput=true`.
+
+### Task discovery (root vs `:plugin`)
+
+The workspace root is a thin aggregator; most runnable tasks live on `:plugin` or in the `build-logic` composite build.
+
+| Goal | Prefer |
+|------|--------|
+| Module tree / composite builds | `gradle_get_project_overview` or `gradle_get_gradle_build` |
+| List verification tasks on `:plugin` | `gradle_get_project_model` with `projectPath: ":plugin"` and `taskGroup: "verification"` |
+| Find compile/test tasks | Use `:plugin:` task paths (e.g. `:plugin:compileKotlin`, `:plugin:test`) |
+
+`gradle_get_build_invocations` at the root with `taskNamePrefix: "compile"` often returns `[]`. Query `:plugin` via `projectPath` or use `gradle_get_project_model` instead.
+
+## When to use MCP vs shell
+
+| Scenario | Prefer |
+|----------|--------|
+| Compile check (`:plugin:compileKotlin`) | MCP `gradle_run_tasks` — fast (~15s), clean JSON |
+| Full `build` or `:plugin:test` in Cloud | **Shell** `./gradlew` — IntelliJ tests are long-running and MCP clients often time out (~60s) |
+| Single test class iteration (local, responsive MCP) | MCP `gradle_run_tests` with `background: true` + polling (see below) |
+| MCP server unresponsive / all tools timeout | **Shell** `./gradlew`; Gradle daemon may still be IDLE while MCP is stuck |
+| PR / CI parity check | `./gradlew build` or `./gradlew --no-daemon :plugin:compileKotlin :plugin:test` |
+
+Do **not** start a second MCP `gradle_run_tasks` or `gradle_run_tests` while one is still running. Overlapping runs cause `InterruptedException`, can leave the IntelliJ test sandbox corrupted, and may wedge the MCP server until it is restarted.
+
+## Long-running IntelliJ tests (`:plugin:test`, `gradle_run_tests`)
+
+IntelliJ Platform plugin tests spin up IDE sandboxes and routinely exceed MCP client timeouts, even for a single test class.
+
+### Recommended pattern (when MCP is responsive)
+
+1. Start with `background: true`:
+
+```json
+{
+  "tasks": [":plugin:test"],
+  "background": true
+}
+```
+
+Or for a single class:
+
+```json
+{
+  "testClasses": ["com.linecorp.intellij.plugins.armeria.explorer.ArmeriaClientCollectorTest"],
+  "background": true
+}
+```
+
+2. Poll `gradle_get_build_status` with the returned `buildId` until `status` is `succeeded`, `failed`, or `cancelled`.
+
+3. Read `outcome` and `buildSummary` from the poll response. Set `includeOutput: true` only if you need truncated logs.
+
+**Cursor Cloud caveat:** `background: true` should return a `buildId` immediately, but MCP clients may still time out before the first response. If that happens, fall back to shell (below).
+
+### Shell fallback (reliable in Cloud)
+
+```bash
+./gradlew :plugin:test
+# or a single class:
+./gradlew :plugin:test --tests 'com.linecorp.intellij.plugins.armeria.explorer.ArmeriaClientCollectorTest'
+```
+
+Use `./gradlew build` for full verification (same as CI).
+
+### Disk recovery when MCP is stuck
+
+Build records persist under `.gradle/mcp-builds/<buildId>/` even when the MCP server stops responding.
+
+| File | Use |
+|------|-----|
+| `mcp-result.json` | Terminal MCP outcome when Gradle finished but MCP cannot answer |
+| `gradle-result.json` | Authoritative Gradle init-script result when present |
+| `stdout.log` / `stderr.log` | Full captured output after the build ends |
+| `events.ndjson` | Task/test progress events |
+
+If every MCP call times out but `./gradlew` still works:
+
+1. List recent builds: `gradle_list_builds` (if MCP responds) or `ls .gradle/mcp-builds/`
+2. Read `.gradle/mcp-builds/<buildId>/mcp-result.json` for `status`, `outcome`, and `buildSummary`
+3. Avoid starting new MCP test runs until the environment recovers (restart the MCP server / agent session if needed)
 
 ## Repo-specific tips
 
@@ -24,31 +105,35 @@ Avoid `includeTasks=true` and heavy model queries unless necessary. `gradle_run_
 
 | Goal | MCP tool | Example |
 |------|----------|---------|
-| Full verify | `gradle_run_tasks` | `{ "tasks": ["build"] }` |
-| All plugin tests | `gradle_run_tasks` | `{ "tasks": [":plugin:test"] }` |
-| Single test class | `gradle_run_tests` | `{ "testClasses": ["com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteCollectorTest"] }` |
-| Single test method | `gradle_run_tests` | `{ "testMethods": { "com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteCollectorTest": ["testCollectAnnotatedRoute"] } }` |
+| Full verify | `gradle_run_tasks` or shell | `{ "tasks": ["build"] }` — prefer `./gradlew build` in Cloud |
+| All plugin tests | shell (preferred) or MCP background | `./gradlew :plugin:test` |
+| Single test class | `gradle_run_tests` + background, or shell | See long-running section above |
+| Fast compile gate | `gradle_run_tasks` | `{ "tasks": [":plugin:compileKotlin"] }` |
 
-Prefer `gradle_run_tests` when iterating on a failing test; use `gradle_run_tasks` for full `:plugin:test` or `build`.
+Prefer shell for `:plugin:test` and `build` in Cursor Cloud. Use MCP for lightweight queries and compile checks.
 
 ### JDK / toolchain debugging
 
 This repo uses two JVM roles:
 
-- **Gradle daemon JVM**: Adoptium 25 (`gradle/gradle-daemon-jvm.properties`)
+- **Gradle daemon JVM (pinned)**: Adoptium 25 in `gradle/gradle-daemon-jvm.properties` (Foojay resolver downloads it on first use)
 - **Compile toolchain**: Java 21 JetBrains (`build-logic/src/main/kotlin/com.linecorp.intellij.platform-plugin.gradle.kts`)
 
-`gradle_get_build_environment` shows the daemon's Java. For all detected JDKs (including toolchain downloads under `~/.gradle/jdks/`), use `gradle_get_java_runtimes`.
+`gradle_get_build_environment` reports the **running daemon's** Java, which may differ from the pin until the daemon restarts and picks up Adoptium 25 (e.g. an existing daemon on Java 21 OpenJDK in Cloud). Do not treat a Java 21 daemon reading as a misconfiguration by itself — check whether a restart or `./gradlew --stop` is needed to apply the pin.
+
+For all detected JDKs (including toolchain downloads under `~/.gradle/jdks/`), use `gradle_get_java_runtimes`.
 
 ### IntelliJ test sandbox corruption
 
-If `:plugin:test` fails with many unrelated test errors and a stack trace mentioning `PersistentEnumerator storage corrupted` under `.intellijPlatform/sandbox/plugin/`, the test sandbox index is stale — not an MCP or code regression.
+If `:plugin:test` fails with many unrelated test errors and a stack trace mentioning `PersistentEnumerator storage corrupted` under `.intellijPlatform/sandbox/plugin/`, the test sandbox index is stale — not an MCP or code regression. This often follows an interrupted MCP test run.
 
 ```bash
+.cursor/clean-test-sandbox.sh
+# equivalent:
 rm -rf .intellijPlatform/sandbox/plugin/IU-*/system-test
 ```
 
-Then rerun `:plugin:test` or `build` via MCP or `./gradlew`.
+Then rerun `:plugin:test` or `build` via shell or MCP (background + polling).
 
 ## Upstream documentation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ IntelliJ Platform plugin for Armeria. Gradle multi-project build (`build-logic` 
 
 ### Prerequisites
 
-- **Gradle daemon JVM**: Adoptium 25 (pinned in `gradle/gradle-daemon-jvm.properties`; Foojay resolver downloads it).
+- **Gradle daemon JVM**: Adoptium 25 (pinned in `gradle/gradle-daemon-jvm.properties`; Foojay resolver downloads it). The running daemon may report a different Java until it restarts and applies the pin — see `gradle_get_build_environment`.
 - **Compile toolchain**: Java 21 JetBrains (configured in `build-logic/src/main/kotlin/com.linecorp.intellij.platform-plugin.gradle.kts` and inherited by `plugin/`).
 - Gradle wrapper (`./gradlew`) downloads the distribution and dependencies on first use.
 
@@ -18,7 +18,9 @@ Prefer token-efficient MCP workflows documented in `.cursor/skills/gradle-tapi-m
 
 1. `gradle_get_build_environment` for resolved Gradle/Java versions
 2. `gradle_get_project_overview` for module hierarchy
-3. `gradle_run_tasks` with `["build"]` or targeted `:plugin:test` when verification is needed
+3. `gradle_run_tasks` with `[":plugin:compileKotlin"]` for fast compile checks
+
+For **`:plugin:test` and `build`**, prefer `./gradlew` in Cursor Cloud — IntelliJ tests are long-running and MCP clients often time out. When using MCP for tests, pass `background: true` and poll `gradle_get_build_status`; never overlap concurrent MCP test runs. If MCP stops responding, read `.gradle/mcp-builds/<buildId>/mcp-result.json` and fall back to shell. Task discovery: query `:plugin` (root `gradle_get_build_invocations` returns few tasks).
 
 ### GitHub and pull requests (Cursor Cloud)
 
@@ -31,7 +33,7 @@ Do not rely on bare `gh` commands without checking availability. `.cursor/instal
 |------|-------------------|
 | Create or update a PR | Built-in **ManagePullRequest** tool (`create_pr` / `update_pr`) |
 | Edit PR labels | **EditPullRequestLabels** tool |
-| Verify changes locally | `./gradlew build` or Gradle MCP `gradle_run_tasks` |
+| Verify changes locally | `./gradlew build` (preferred for tests); MCP for compile checks — see `gradle-tapi-mcp` skill |
 | PR check status / CI logs | `gh` only after `gh auth status` succeeds (see `.cursor/skills/cloud-github/SKILL.md`) |
 
 If `gh` is not found or auth fails, use ManagePullRequest for PR work and Gradle for build
@@ -47,6 +49,7 @@ token lacks required scopes.
 | Unit tests | `./gradlew :plugin:test` |
 | Run IDE sandbox | `./gradlew :plugin:runIde` |
 | Fast CI-style check | `./gradlew --no-daemon :plugin:compileKotlin :plugin:test` |
+| Fix stale test sandbox | `.cursor/clean-test-sandbox.sh` |
 
 There is no separate lint task; `./gradlew build` is the compile/test gate.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents Gradle MCP (v0.2.3) usage patterns and pitfalls discovered during hands-on testing in Cursor Cloud on this IntelliJ Platform plugin repo.

## Changes

- **`.cursor/skills/gradle-tapi-mcp/SKILL.md`**: Long-running test workflow (`background` + polling), disk recovery via `.gradle/mcp-builds/`, task discovery on `:plugin`, overlap warnings, MCP vs shell guidance, daemon JVM clarification
- **`AGENTS.md`**: Cross-links to updated MCP workflow and sandbox cleanup script
- **`.cursor/skills/cloud-github/SKILL.md`**: Prefer shell for full test verification when MCP may timeout
- **`.cursor/clean-test-sandbox.sh`**: Helper to remove stale IntelliJ test sandbox indexes

## Context

Upstream issues filed on `nise-nabe/gradle-tapi-mcp-server` for MCP server unresponsiveness, `background=true` timeouts, and `InterruptedException` on client timeout (#79–#82).

## Test plan

- [x] Documentation-only change; no code behavior change
- [x] `clean-test-sandbox.sh` is idempotent when sandbox is absent
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2b1d-49c0-7b60-891b-8aea942942a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2b1d-49c0-7b60-891b-8aea942942a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

