### PR TITLE
chore: update gradle-tapi-mcp-server to v0.3.0

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-readonly GRADLE_TAPI_MCP_VERSION="0.2.3"
-readonly GRADLE_TAPI_MCP_SHA256="01a1e7ce952f926ad2e427eb96386e7c49c8e4bfdf8bae05b5b195c66adc052b"
+readonly GRADLE_TAPI_MCP_VERSION="0.3.0"
+readonly GRADLE_TAPI_MCP_SHA256="1899fb2730146b68280097a6f34dcedcc80cdc682f0887dd2ab6f2d0af8dc71d"
 readonly INSTALL_DIR="${HOME}/.local/share/gradle-tapi-mcp-server"
 readonly VERSIONED_JAR_NAME="gradle-tapi-mcp-server-${GRADLE_TAPI_MCP_VERSION}.jar"
 readonly VERSIONED_JAR_PATH="${INSTALL_DIR}/${VERSIONED_JAR_NAME}"

--- a/.cursor/skills/gradle-tapi-mcp/SKILL.md
+++ b/.cursor/skills/gradle-tapi-mcp/SKILL.md
@@ -7,7 +7,7 @@ description: >-
 
 # Gradle Tooling API MCP
 
-This repository configures [nise-nabe/gradle-tapi-mcp-server](https://github.com/nise-nabe/gradle-tapi-mcp-server) v0.2.3 in `.cursor/mcp.json`. The JAR is installed by `.cursor/install.sh` to `~/.local/share/gradle-tapi-mcp-server/gradle-tapi-mcp-server.jar`. At MCP server launch, `.cursor/mcp.json` sets `GRADLE_PROJECT_DIR=${workspaceFolder}`.
+This repository configures [nise-nabe/gradle-tapi-mcp-server](https://github.com/nise-nabe/gradle-tapi-mcp-server) v0.3.0 in `.cursor/mcp.json`. The JAR is installed by `.cursor/install.sh` to `~/.local/share/gradle-tapi-mcp-server/gradle-tapi-mcp-server.jar`. At MCP server launch, `.cursor/mcp.json` sets `GRADLE_PROJECT_DIR=${workspaceFolder}`.
 
 ## Workflow (token-efficient)
 
@@ -139,5 +139,5 @@ Then rerun `:plugin:test` or `build` via shell or MCP (background + polling).
 
 Full tool reference and advanced workflows live in the upstream repository:
 
-- [README (v0.2.3)](https://github.com/nise-nabe/gradle-tapi-mcp-server/blob/v0.2.3/README.md)
-- [gradle-tapi-mcp skill](https://github.com/nise-nabe/gradle-tapi-mcp-server/tree/v0.2.3/skills/gradle-tapi-mcp)
+- [README (v0.3.0)](https://github.com/nise-nabe/gradle-tapi-mcp-server/blob/v0.3.0/README.md)
+- [gradle-tapi-mcp skill](https://github.com/nise-nabe/gradle-tapi-mcp-server/tree/v0.3.0/skills/gradle-tapi-mcp)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ IntelliJ Platform plugin for Armeria. Gradle multi-project build (`build-logic` 
 
 ### MCP: Gradle Tooling API
 
-The `gradle` MCP server (`nise-nabe/gradle-tapi-mcp-server` v0.2.3) is configured in `.cursor/mcp.json`. The install script downloads the release JAR to `~/.local/share/gradle-tapi-mcp-server/`, verifies its SHA-256, and exposes it via a stable `gradle-tapi-mcp-server.jar` symlink. `GRADLE_PROJECT_DIR` is set to the workspace root.
+The `gradle` MCP server (`nise-nabe/gradle-tapi-mcp-server` v0.3.0) is configured in `.cursor/mcp.json`. The install script downloads the release JAR to `~/.local/share/gradle-tapi-mcp-server/`, verifies its SHA-256, and exposes it via a stable `gradle-tapi-mcp-server.jar` symlink. `GRADLE_PROJECT_DIR` is set to the workspace root.
 
 Prefer token-efficient MCP workflows documented in `.cursor/skills/gradle-tapi-mcp/SKILL.md`:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the Gradle Tooling API MCP server from v0.2.3 to [v0.3.0](https://github.com/nise-nabe/gradle-tapi-mcp-server/releases/tag/v0.3.0).

## Changes

- `.cursor/install.sh` — bump version and SHA-256 for the release JAR
- `AGENTS.md` — version reference
- `.cursor/skills/gradle-tapi-mcp/SKILL.md` — version and upstream doc links

## v0.3.0 highlights (upstream)

- Kotlin MCP SDK migration with kotlinx.serialization
- Improved MCP responsiveness during long builds and client timeouts
- `gradle_get_build_invocations` now aggregates subproject tasks

## Test plan

- [x] Verified SHA-256 of downloaded `gradle-tapi-mcp-server-0.3.0.jar`
- [ ] Cloud agent session picks up the new JAR via `.cursor/install.sh` on next run
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2bf8-80b7-744b-bb56-255d69349ead"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2bf8-80b7-744b-bb56-255d69349ead"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

