### PR TITLE
chore: stop running Gradle build during Cloud install

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -104,5 +104,3 @@ setup_gh_cli() {
 }
 
 setup_gh_cli
-
-./gradlew --no-daemon build


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remove `./gradlew --no-daemon build` from `.cursor/install.sh`.

The Cloud install hook should only provision environment tooling:
- Gradle MCP server JAR download + SHA verification
- `gh` CLI symlink and optional auth

A full `build` on every agent boot is unnecessary for that setup, takes several minutes for this IntelliJ plugin, and can fail on stale Kotlin/Gradle caches during startup. Project verification remains in GitHub Actions (`./gradlew build`).

## Test plan

- [x] Install script still ends after `setup_gh_cli` (no Gradle invocation)
- [ ] Cloud agent boot completes install hook without cache-related failures

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2c55-eb6a-7ce6-ad9b-88aedd13b772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2c55-eb6a-7ce6-ad9b-88aedd13b772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

