### PR TITLE
docs: require feature-style PR descriptions for Cloud Agents

### DIFF
--- a/.cursor/rules/cloud-github.mdc
+++ b/.cursor/rules/cloud-github.mdc
@@ -12,6 +12,7 @@ In Cursor Cloud, do **not** assume `gh` is on PATH before `.cursor/install.sh` c
 - Use the built-in **ManagePullRequest** tool for `create_pr` and `update_pr`.
 - Use **EditPullRequestLabels** for label changes.
 - Do not run `gh pr create` / `gh pr edit` unless ManagePullRequest fails and `gh auth status` succeeds.
+- PR bodies must follow `.cursor/rules/pr-description-format.mdc` (feature PR format; no review-response sections).
 
 ## GitHub CLI fallback
 

--- a/.cursor/rules/pr-description-format.mdc
+++ b/.cursor/rules/pr-description-format.mdc
@@ -1,0 +1,61 @@
+---
+description: PR descriptions must read like feature PRs, not review-response documents
+alwaysApply: true
+---
+
+# Pull request description format
+
+Write PR bodies as **normal feature pull requests**. Do not frame the description as a response to code review.
+
+## Required structure
+
+Use these sections only:
+
+1. **Summary** — what the PR does and why (1–3 short paragraphs or bullets)
+2. **Changes** — concrete behavior, files, or capabilities added/changed
+3. **Depends on** — optional, only when there is a real dependency
+4. **Test plan** — verification checklist
+
+## Do not use review-response framing
+
+Never add sections or prose such as:
+
+- "Thermos review fixes" / "Thermo-nuclear review fixes"
+- "Copilot review fixes" / "Review feedback addressed"
+- "Fixes in this update" / "Follow-up fixes" / "Latest review fixes"
+- "Addresses review findings" / "This revision addresses …"
+- "P1 (addressed in …)" / "P2 (addressed in …)"
+- "Rebase notes" as a standalone review section
+- Verdicts like "Ship — no remaining P0/P1 findings"
+
+Also avoid opening lines like "After thermo-nuclear review, this PR addresses …".
+
+## After review-driven code changes
+
+When fixing review comments, **update the existing Summary and Changes** so the PR reads as one coherent feature description.
+
+- Fold review-driven edits into **Changes** as ordinary bullets (what changed, not who asked)
+- Do not append a new section that lists review items or commit SHAs for each finding
+- Put review thread replies in **PR comments**, not in the PR body
+
+## Good vs bad
+
+**Bad**
+
+```markdown
+## Thermos review fixes
+- Fixed Kotlin URI extraction (was showing callee text)
+- Added regression tests per review
+```
+
+**Good**
+
+```markdown
+## Changes
+- Kotlin client collector resolves URI strings/constants instead of showing callee text
+- Regression tests for Java/Kotlin client collectors
+```
+
+## When updating an existing PR
+
+Use `ManagePullRequest` `update_pr` to refresh Summary/Changes/Test plan as a whole. Do not grow the body with stacked "review fix" sections across iterations.

--- a/.cursor/skills/cloud-github/SKILL.md
+++ b/.cursor/skills/cloud-github/SKILL.md
@@ -25,6 +25,15 @@ unless ManagePullRequest fails and `gh auth status` succeeds.
 
 Branch naming for agent work: `cursor/<descriptive-name>-<suffix>` (suffix is assigned per agent session).
 
+## PR description format
+
+PR bodies must read like **feature pull requests**, not review-response documents. See
+`.cursor/rules/pr-description-format.mdc`.
+
+- Use **Summary**, **Changes**, optional **Depends on**, and **Test plan** only
+- Never add sections such as "Thermos review fixes", "Fixes in this update", or "Review feedback addressed"
+- After addressing review comments, fold edits into **Changes**; reply in PR comments, not as new body sections
+
 ## When `gh` is required
 
 Some bundled skills (for example `loop-on-ci`, `fix-ci`) reference `gh pr checks`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Do not rely on bare `gh` commands without checking availability. `.cursor/instal
 
 | Goal | Preferred approach |
 |------|-------------------|
-| Create or update a PR | Built-in **ManagePullRequest** tool (`create_pr` / `update_pr`) |
+| Create or update a PR | Built-in **ManagePullRequest** tool (`create_pr` / `update_pr`); body format in `.cursor/rules/pr-description-format.mdc` |
 | Edit PR labels | **EditPullRequestLabels** tool |
 | Verify changes locally | `./gradlew build` (preferred for tests); MCP for compile checks — see `gradle-tapi-mcp` skill |
 | PR check status / CI logs | `gh` only after `gh auth status` succeeds (see `.cursor/skills/cloud-github/SKILL.md`) |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds repository rules so Cloud Agents write pull request descriptions as normal feature PRs instead of review-response documents.

## Changes

- Add `.cursor/rules/pr-description-format.mdc` (always applied) with required sections and forbidden review-response headings
- Document the format in `.cursor/skills/cloud-github/SKILL.md`
- Reference the rule from `.cursor/rules/cloud-github.mdc` and `AGENTS.md`

## Test plan

- [x] Rule file uses `alwaysApply: true`
- [x] cloud-github skill and AGENTS.md link to the new rule
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2c83-4972-7323-a236-d8a955b79942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2c83-4972-7323-a236-d8a955b79942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

