### PR TITLE
build: enable Gradle configuration cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,5 +6,7 @@ pluginVersion=0.1.0-SNAPSHOT
 org.gradle.jvmargs=-Xmx1g
 org.gradle.parallel=true
 org.gradle.caching=true
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
 org.gradle.warning.mode=all
 org.gradle.vfs.watch=true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enables Gradle Configuration Cache in the root `gradle.properties`, matching the settings already recommended in the Armeria project template and flagged on every build during performance analysis.

## Motivation

Repeated `./gradlew build` runs spent ~180ms (warm) to ~1.6s (cold daemon) in the configuration phase, mostly resolving IntelliJ Platform dependencies for `:plugin`. Gradle also printed a recommendation to enable configuration cache on every invocation.

With configuration cache enabled locally:

- First build: configuration cache entry stored
- Second build: **685ms** total, `Configuration cache entry reused`

## Changes

- `org.gradle.configuration-cache=true`
- `org.gradle.configuration-cache.parallel=true`

## Verification

```bash
./gradlew build --configuration-cache
./gradlew build --configuration-cache  # entry reused
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2c83-faca-745d-882b-4d052a08e234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2c83-faca-745d-882b-4d052a08e234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

