### PR TITLE
build: replace deprecated testing suite delegate syntax

### DIFF
--- a/build-logic/src/main/kotlin/com.linecorp.intellij.platform-plugin.gradle.kts
+++ b/build-logic/src/main/kotlin/com.linecorp.intellij.platform-plugin.gradle.kts
@@ -26,7 +26,7 @@ intellijPlatform {
 
 testing {
     suites {
-        val test by getting(JvmTestSuite::class) {
+        getByName<JvmTestSuite>("test") {
             targets.all {
                 testTask.configure {
                     failOnNoDiscoveredTests = false

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
 
 testing {
     suites {
-        val test by getting(JvmTestSuite::class) {
+        getByName<JvmTestSuite>("test") {
             dependencies {
                 implementation(libs.velocity.engine.core)
                 implementation(libs.junit4)

--- a/plugin/src/main/resources/fileTemplates/j2ee/armeria-build.gradle.kts.ft
+++ b/plugin/src/main/resources/fileTemplates/j2ee/armeria-build.gradle.kts.ft
@@ -165,7 +165,7 @@ tasks.withType<JavaCompile>().configureEach {
 testing {
     @Suppress("UnstableApiUsage", "unused")
     suites {
-        val test by getting(JvmTestSuite::class) {
+        getByName<JvmTestSuite>("test") {
             useJUnitJupiter()
         }
     }

--- a/plugin/src/main/resources/fileTemplates/j2ee/armeria-build.gradle.kts.ft
+++ b/plugin/src/main/resources/fileTemplates/j2ee/armeria-build.gradle.kts.ft
@@ -163,7 +163,7 @@ tasks.withType<JavaCompile>().configureEach {
 }
 #if ($context.testRunnerId == "junit5")
 testing {
-    @Suppress("UnstableApiUsage", "unused")
+    @Suppress("UnstableApiUsage")
     suites {
         getByName<JvmTestSuite>("test") {
             useJUnitJupiter()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the deprecated `val test by getting(JvmTestSuite::class)` testing-suite delegate with `getByName<JvmTestSuite>("test")` as required by Gradle 9.6, so configuration no longer emits deprecation warnings on every build and stays compatible with Gradle 10.

## Changes

- `build-logic/src/main/kotlin/com.linecorp.intellij.platform-plugin.gradle.kts` — configure the `test` suite via `getByName`
- `plugin/build.gradle.kts` — same non-deprecated suite lookup for plugin test dependencies
- `plugin/src/main/resources/fileTemplates/j2ee/armeria-build.gradle.kts.ft` — align wizard-generated projects; drop obsolete `@Suppress("unused")` on the `testing` block

## Test plan

- [x] `./gradlew build --console=plain` — no `val name by getting(Type::class)` deprecation warnings in build output
- [x] Wizard template `testing` block keeps only `@Suppress("UnstableApiUsage")`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2c83-faca-745d-882b-4d052a08e234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2c83-faca-745d-882b-4d052a08e234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

