### PR TITLE
build: increase Gradle daemon heap to 2g

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ kotlin.code.style=official
 
 pluginVersion=0.1.0-SNAPSHOT
 
-org.gradle.jvmargs=-Xmx1g
+org.gradle.jvmargs=-Xmx2g
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.warning.mode=all


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Increases the Gradle daemon maximum heap from 1g to 2g in `gradle.properties`.

## Motivation

Build performance analysis noted that IntelliJ Platform plugin builds resolve large classpaths during configuration and `:plugin:test` sandbox startup. The current 1g limit can increase GC pressure during full rebuilds, especially alongside Kotlin compilation and bytecode instrumentation.

## Changes

- `org.gradle.jvmargs=-Xmx2g` (was `-Xmx1g`)

## Verification

```bash
./gradlew --stop
./gradlew build
```

Build succeeds with the new daemon JVM settings.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2c83-faca-745d-882b-4d052a08e234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2c83-faca-745d-882b-4d052a08e234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

