### PR TITLE
chore: release 0.1.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # suppress inspection "UnusedProperty" for whole file
 kotlin.code.style=official
 
-pluginVersion=0.1.0-SNAPSHOT
+pluginVersion=0.1.0
 
 org.gradle.jvmargs=-Xmx2g
 org.gradle.parallel=true

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
-## [Unreleased]
+## Unreleased
+
+## 0.1.0 - 2026-07-04
+
 ### Added
+
 - Implemented Armeria run configuration with module classpath and main class selection.
 - Added project-wide duplicate route registration inspection for ServerBuilder and annotated routes, with module-scoped caching and cross-registration conflict detection.
 - Added programmatic `ServerBuilder.decorator()` detection in Route Explorer.
@@ -20,13 +24,8 @@
 - Added a duplicate annotated route inspection for Armeria HTTP services.
 - Added DocService URL detection in console output.
 
-### Changed
-
-### Deprecated
-
-### Removed
-
 ### Fixed
+
 - Fixed Armeria Clients explorer listing no-arg `builder()` calls and non-Armeria `WebClient` false positives in Kotlin fallback resolution.
 - Fixed Kotlin client URI extraction, `GrpcClients`/`ThriftClients.newClient` discovery, and async PSI collection in Armeria Clients explorer.
 - Fixed duplicate Kotlin annotated routes and false-positive service registrations in Route Explorer.
@@ -40,5 +39,3 @@
 - Aligned Kotlin service registration discovery with the Java collector via shared PSI delegation.
 - New Project Wizard: emit `armeria-tomcat8` in Gradle and Maven templates when selected.
 - New Project Wizard: align Scala optional dependencies and Scala build setup in Gradle (Groovy) and Maven templates with Gradle (Kotlin DSL).
-
-### Security


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prepares the 0.1.0 release by bumping `pluginVersion` and patching `CHANGELOG.md` with accumulated changes since v0.0.5.

## Changes

- Set `pluginVersion` to `0.1.0` in `gradle.properties`
- Move `[Unreleased]` changelog entries into `0.1.0 - 2026-07-04`

## Test plan

- [x] `./gradlew build :plugin:buildPlugin` passes
- [ ] Tag `v0.1.0` and publish GitHub Release with plugin ZIP after merge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2cbf-7e52-7177-b424-c68d92ff0716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2cbf-7e52-7177-b424-c68d92ff0716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

