### PR TITLE
fix: preserve bracket format in CHANGELOG headers

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## Unreleased
+## [Unreleased]
 
-## 0.1.0 - 2026-07-04
+## [0.1.0] - 2026-07-04
 
 ### Added
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.changelog.Changelog
+import org.jetbrains.changelog.date
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 
 plugins {
@@ -27,6 +28,14 @@ testing {
             }
         }
     }
+}
+
+changelog {
+    version.set(providers.gradleProperty("pluginVersion"))
+    path.set(file("CHANGELOG.md").canonicalPath)
+    header.set(provider { "[${version.get()}] - ${date()}" })
+    unreleasedTerm.set("[Unreleased]")
+    keepUnreleasedSection.set(true)
 }
 
 intellijPlatform {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restores Keep a Changelog bracket headers that `patchChangelog` stripped during the 0.1.0 release, and configures the changelog Gradle plugin to preserve `[]` in future patches.

## Changes

- Restore `## [Unreleased]` and `## [0.1.0] - 2026-07-04` in `plugin/CHANGELOG.md`
- Configure `changelog` block in `plugin/build.gradle.kts` with `unreleasedTerm = "[Unreleased]"` and `header = "[${version}] - ${date()}"`

## Test plan

- [x] `./gradlew :plugin:compileKotlin` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2cbf-7e52-7177-b424-c68d92ff0716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2cbf-7e52-7177-b424-c68d92ff0716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

