### PR TITLE
fix: restore Unreleased changelog section templates

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
 
 ## [0.1.0] - 2026-07-04
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -36,6 +36,7 @@ changelog {
     header.set(provider { "[${version.get()}] - ${date()}" })
     unreleasedTerm.set("[Unreleased]")
     keepUnreleasedSection.set(true)
+    groups.set(listOf("Added", "Changed", "Deprecated", "Removed", "Fixed", "Security"))
 }
 
 intellijPlatform {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restores the empty Keep a Changelog subsection templates under `[Unreleased]` and configures the changelog Gradle plugin to recreate them after future `patchChangelog` runs.

## Changes

- Add `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, and `Security` templates under `## [Unreleased]` in `plugin/CHANGELOG.md`
- Set `changelog.groups` in `plugin/build.gradle.kts` to the same section list

## Test plan

- [x] `./gradlew :plugin:getChangelog --unreleased` shows all six template sections
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2cbf-7e52-7177-b424-c68d92ff0716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2cbf-7e52-7177-b424-c68d92ff0716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

