### PR TITLE
chore: bump gradle-tapi-mcp-server to v0.3.2

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-readonly GRADLE_TAPI_MCP_VERSION="0.3.0"
-readonly GRADLE_TAPI_MCP_SHA256="1899fb2730146b68280097a6f34dcedcc80cdc682f0887dd2ab6f2d0af8dc71d"
+readonly GRADLE_TAPI_MCP_VERSION="0.3.2"
+readonly GRADLE_TAPI_MCP_SHA256="270076019fd4150653427023bbe9d7839c0958a58ea9cafb023daa01b833a5d2"
 readonly INSTALL_DIR="${HOME}/.local/share/gradle-tapi-mcp-server"
 readonly VERSIONED_JAR_NAME="gradle-tapi-mcp-server-${GRADLE_TAPI_MCP_VERSION}.jar"
 readonly VERSIONED_JAR_PATH="${INSTALL_DIR}/${VERSIONED_JAR_NAME}"

--- a/.cursor/skills/gradle-tapi-mcp/SKILL.md
+++ b/.cursor/skills/gradle-tapi-mcp/SKILL.md
@@ -7,7 +7,7 @@ description: >-
 
 # Gradle Tooling API MCP
 
-This repository configures [nise-nabe/gradle-tapi-mcp-server](https://github.com/nise-nabe/gradle-tapi-mcp-server) v0.3.0 in `.cursor/mcp.json`. The JAR is installed by `.cursor/install.sh` to `~/.local/share/gradle-tapi-mcp-server/gradle-tapi-mcp-server.jar`. At MCP server launch, `.cursor/mcp.json` sets `GRADLE_PROJECT_DIR=${workspaceFolder}`.
+This repository configures [nise-nabe/gradle-tapi-mcp-server](https://github.com/nise-nabe/gradle-tapi-mcp-server) v0.3.2 in `.cursor/mcp.json`. The JAR is installed by `.cursor/install.sh` to `~/.local/share/gradle-tapi-mcp-server/gradle-tapi-mcp-server.jar`. At MCP server launch, `.cursor/mcp.json` sets `GRADLE_PROJECT_DIR=${workspaceFolder}`.
 
 The MCP server may report `loading` for a few seconds on first use; call `gradle_connection_status` before other tools.
 
@@ -157,5 +157,5 @@ Then rerun `:plugin:test` or `build` via shell or MCP (background + polling).
 
 Full tool reference and advanced workflows live in the upstream repository:
 
-- [README (v0.3.0)](https://github.com/nise-nabe/gradle-tapi-mcp-server/blob/v0.3.0/README.md)
-- [gradle-tapi-mcp skill](https://github.com/nise-nabe/gradle-tapi-mcp-server/tree/v0.3.0/skills/gradle-tapi-mcp)
+- [README (v0.3.2)](https://github.com/nise-nabe/gradle-tapi-mcp-server/blob/v0.3.2/README.md)
+- [gradle-tapi-mcp skill](https://github.com/nise-nabe/gradle-tapi-mcp-server/tree/v0.3.2/skills/gradle-tapi-mcp)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ IntelliJ Platform plugin for Armeria. Gradle multi-project build (`build-logic` 
 
 ### MCP: Gradle Tooling API
 
-The `gradle` MCP server (`nise-nabe/gradle-tapi-mcp-server` v0.3.0) is configured in `.cursor/mcp.json`. The install script downloads the release JAR to `~/.local/share/gradle-tapi-mcp-server/`, verifies its SHA-256, and exposes it via a stable `gradle-tapi-mcp-server.jar` symlink. `GRADLE_PROJECT_DIR` is set to the workspace root.
+The `gradle` MCP server (`nise-nabe/gradle-tapi-mcp-server` v0.3.2) is configured in `.cursor/mcp.json`. The install script downloads the release JAR to `~/.local/share/gradle-tapi-mcp-server/`, verifies its SHA-256, and exposes it via a stable `gradle-tapi-mcp-server.jar` symlink. `GRADLE_PROJECT_DIR` is set to the workspace root.
 
 Prefer token-efficient MCP workflows documented in `.cursor/skills/gradle-tapi-mcp/SKILL.md`:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the pinned [gradle-tapi-mcp-server](https://github.com/nise-nabe/gradle-tapi-mcp-server) release from v0.3.0 to v0.3.2. v0.3.2 includes slimmer MCP tool schemas for `tools/list` token budget (from v0.3.2 release notes).

## Changes

- `.cursor/install.sh`: version `0.3.2` and SHA-256 pin for the release JAR
- `AGENTS.md`: version reference updated to v0.3.2
- `.cursor/skills/gradle-tapi-mcp/SKILL.md`: version and upstream doc links updated to v0.3.2

## Test plan

- [x] Run `.cursor/install.sh` — downloads `gradle-tapi-mcp-server-0.3.2.jar` and symlinks `gradle-tapi-mcp-server.jar`
- [x] SHA-256 of downloaded JAR matches the pin in `install.sh`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2f66-ffb9-7ed4-bd9d-b2a05ddfb85d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2f66-ffb9-7ed4-bd9d-b2a05ddfb85d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

