### PR TITLE
feat: extend HTTP Request generation for more route types

### DIFF
--- a/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGeneratorTest.kt
+++ b/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGeneratorTest.kt
@@ -126,13 +126,6 @@ class ArmeriaHttpRequestGeneratorTest {
     }
 
     @Test
-    fun supports_rejectsAnnotatedServiceWithPathPrefix() {
-        val route = route(routeMatch = RouteMatch.ANNOTATED_SERVICE, annotatedServiceHasPathPrefix = true, path = "/api")
-
-        assertFalse(ArmeriaHttpRequestGenerator.supports(route))
-    }
-
-    @Test
     fun supports_rejectsGrpcRegistrationMount() {
         val route = route(protocol = "gRPC", path = "/grpc", routeMatch = RouteMatch.NON_HTTP)
 
@@ -189,12 +182,49 @@ class ArmeriaHttpRequestGeneratorTest {
         assertTrue(ArmeriaHttpRequestGenerator.requestText(route).contains("/users/1"))
     }
 
+    @Test
+    fun requestText_substitutesConstrainedPathVariablesWithWhitespace() {
+        val route = route(httpMethod = "GET", path = "/users/{id :\\d+}")
+
+        assertTrue(ArmeriaHttpRequestGenerator.requestText(route).contains("/users/1"))
+    }
+
+    @Test
+    fun httpMethod_errorsForUnsupportedNonHttpRoute() {
+        val route = route(protocol = "Thrift", routeMatch = RouteMatch.NON_HTTP)
+
+        val error = runCatching { ArmeriaHttpRequestGenerator.httpMethod(route) }.exceptionOrNull()
+
+        assertTrue(error is IllegalStateException)
+        assertTrue(error!!.message!!.contains("NON_HTTP"))
+    }
+
+    @Test
+    fun requestText_grpcProtoRouteNormalizesTrailingSlashBaseUrl() {
+        val route = route(
+            protocol = "gRPC",
+            path = "/example.EchoService/Echo",
+            target = "example.EchoService.Echo",
+            routeMatch = RouteMatch.NON_HTTP,
+        )
+
+        assertEquals(
+            """
+            ### gRPC example.EchoService.Echo
+            GRPC http://localhost:8080/example.EchoService/Echo
+
+            # Invoke via DocService: http://localhost:8080/docs
+
+            """.trimIndent() + "\n",
+            ArmeriaHttpRequestGenerator.requestText(route, "http://localhost:8080/"),
+        )
+    }
+
     private fun route(
         httpMethod: String = "GET",
         path: String = "/api",
         protocol: String = "HTTP",
         routeMatch: RouteMatch = RouteMatch.ANNOTATED_HTTP,
-        annotatedServiceHasPathPrefix: Boolean = false,
         pathType: PathType = PathType.EXACT,
         target: String = "Handler",
     ): ArmeriaRoute {
@@ -207,7 +237,6 @@ class ArmeriaHttpRequestGeneratorTest {
             moduleName = "app",
             targetUnresolved = false,
             isDocService = false,
-            annotatedServiceHasPathPrefix = annotatedServiceHasPathPrefix,
             pathType = pathType,
             decorators = emptyList(),
             exceptionHandlers = emptyList(),

--- a/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGeneratorTest.kt
+++ b/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGeneratorTest.kt
@@ -126,10 +126,17 @@ class ArmeriaHttpRequestGeneratorTest {
     }
 
     @Test
-    fun supports_annotatedServiceWithPathPrefix() {
+    fun supports_rejectsAnnotatedServiceWithPathPrefix() {
         val route = route(routeMatch = RouteMatch.ANNOTATED_SERVICE, annotatedServiceHasPathPrefix = true, path = "/api")
 
-        assertTrue(ArmeriaHttpRequestGenerator.supports(route))
+        assertFalse(ArmeriaHttpRequestGenerator.supports(route))
+    }
+
+    @Test
+    fun supports_rejectsGrpcRegistrationMount() {
+        val route = route(protocol = "gRPC", path = "/grpc", routeMatch = RouteMatch.NON_HTTP)
+
+        assertFalse(ArmeriaHttpRequestGenerator.supports(route))
     }
 
     @Test
@@ -147,23 +154,61 @@ class ArmeriaHttpRequestGeneratorTest {
         assertEquals("armeria-grpc-example.EchoService-Echo.http", ArmeriaHttpRequestGenerator.fileName(route))
     }
 
+    @Test
+    fun requestText_grpcProtoRoute() {
+        val route = route(
+            protocol = "gRPC",
+            path = "/example.EchoService/Echo",
+            target = "example.EchoService.Echo",
+            routeMatch = RouteMatch.NON_HTTP,
+        )
+
+        assertEquals(
+            """
+            ### gRPC example.EchoService.Echo
+            GRPC http://localhost:8080/example.EchoService/Echo
+
+            # Invoke via DocService: http://localhost:8080/docs
+
+            """.trimIndent() + "\n",
+            ArmeriaHttpRequestGenerator.requestText(route),
+        )
+    }
+
+    @Test
+    fun requestText_preservesRegexPath() {
+        val route = route(httpMethod = "GET", path = """\d{2,3}""", pathType = PathType.REGEX)
+
+        assertTrue(ArmeriaHttpRequestGenerator.requestText(route).contains("""http://localhost:8080\d{2,3}"""))
+    }
+
+    @Test
+    fun requestText_substitutesConstrainedPathVariables() {
+        val route = route(httpMethod = "GET", path = "/users/{id:\\d+}")
+
+        assertTrue(ArmeriaHttpRequestGenerator.requestText(route).contains("/users/1"))
+    }
+
     private fun route(
         httpMethod: String = "GET",
         path: String = "/api",
         protocol: String = "HTTP",
         routeMatch: RouteMatch = RouteMatch.ANNOTATED_HTTP,
         annotatedServiceHasPathPrefix: Boolean = false,
+        pathType: PathType = PathType.EXACT,
+        target: String = "Handler",
     ): ArmeriaRoute {
         return ArmeriaRoute(
             protocol = protocol,
             httpMethod = httpMethod,
             path = path,
-            target = "Handler",
+            target = target,
             routeMatch = routeMatch,
             moduleName = "app",
             targetUnresolved = false,
             isDocService = false,
             annotatedServiceHasPathPrefix = annotatedServiceHasPathPrefix,
+            pathType = pathType,
             decorators = emptyList(),
             exceptionHandlers = emptyList(),
             pointer = TestPsiPointer,

--- a/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGeneratorTest.kt
+++ b/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGeneratorTest.kt
@@ -148,6 +148,19 @@ class ArmeriaHttpRequestGeneratorTest {
     }
 
     @Test
+    fun supports_grpcRouteWithoutPackage() {
+        val route = route(
+            protocol = "gRPC",
+            path = "/Greeter/Ping",
+            target = "Greeter.Ping",
+            routeMatch = RouteMatch.NON_HTTP,
+        )
+
+        assertTrue(ArmeriaHttpRequestGenerator.supports(route))
+        assertEquals("armeria-grpc-Greeter-Ping.http", ArmeriaHttpRequestGenerator.fileName(route))
+    }
+
+    @Test
     fun requestText_grpcProtoRoute() {
         val route = route(
             protocol = "gRPC",
@@ -187,6 +200,35 @@ class ArmeriaHttpRequestGeneratorTest {
         val route = route(httpMethod = "GET", path = "/users/{id :\\d+}")
 
         assertTrue(ArmeriaHttpRequestGenerator.requestText(route).contains("/users/1"))
+    }
+
+    @Test
+    fun requestText_substitutesConstrainedPathVariablesWithQuantifierBraces() {
+        val route = route(httpMethod = "GET", path = "/users/{id:\\d{2,3}}")
+
+        assertTrue(ArmeriaHttpRequestGenerator.requestText(route).contains("/users/1"))
+        assertFalse(ArmeriaHttpRequestGenerator.requestText(route).contains("/users/1}"))
+    }
+
+    @Test
+    fun requestText_grpcProtoRouteWithoutPackage() {
+        val route = route(
+            protocol = "gRPC",
+            path = "/Greeter/Ping",
+            target = "Greeter.Ping",
+            routeMatch = RouteMatch.NON_HTTP,
+        )
+
+        assertEquals(
+            """
+            ### gRPC Greeter.Ping
+            GRPC http://localhost:8080/Greeter/Ping
+
+            # Invoke via DocService: http://localhost:8080/docs
+
+            """.trimIndent() + "\n",
+            ArmeriaHttpRequestGenerator.requestText(route),
+        )
     }
 
     @Test

--- a/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGeneratorTest.kt
+++ b/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGeneratorTest.kt
@@ -144,7 +144,7 @@ class ArmeriaHttpRequestGeneratorTest {
         val route = route(protocol = "gRPC", path = "/example.EchoService/Echo", routeMatch = RouteMatch.NON_HTTP)
 
         assertTrue(ArmeriaHttpRequestGenerator.supports(route))
-        assertEquals("armeria-grpc-example.EchoService-Echo.grpc", ArmeriaHttpRequestGenerator.fileName(route))
+        assertEquals("armeria-grpc-example.EchoService-Echo.http", ArmeriaHttpRequestGenerator.fileName(route))
     }
 
     private fun route(

--- a/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGeneratorTest.kt
+++ b/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGeneratorTest.kt
@@ -66,7 +66,7 @@ class ArmeriaHttpRequestGeneratorTest {
         assertFalse(ArmeriaHttpRequestGenerator.supports(route(routeMatch = RouteMatch.ANNOTATED_SERVICE)))
         assertFalse(
             ArmeriaHttpRequestGenerator.supports(
-                route(protocol = "gRPC", routeMatch = RouteMatch.NON_HTTP),
+                route(protocol = "Thrift", routeMatch = RouteMatch.NON_HTTP),
             ),
         )
     }
@@ -118,11 +118,41 @@ class ArmeriaHttpRequestGeneratorTest {
         )
     }
 
+    @Test
+    fun requestText_substitutesPathVariables() {
+        val route = route(httpMethod = "GET", path = "/users/{id}")
+
+        assertTrue(ArmeriaHttpRequestGenerator.requestText(route).contains("/users/1"))
+    }
+
+    @Test
+    fun supports_annotatedServiceWithPathPrefix() {
+        val route = route(routeMatch = RouteMatch.ANNOTATED_SERVICE, annotatedServiceHasPathPrefix = true, path = "/api")
+
+        assertTrue(ArmeriaHttpRequestGenerator.supports(route))
+    }
+
+    @Test
+    fun requestText_substitutesColonStylePathVariables() {
+        val route = route(httpMethod = "GET", path = "/hello/:name")
+
+        assertTrue(ArmeriaHttpRequestGenerator.requestText(route).contains("/hello/example"))
+    }
+
+    @Test
+    fun supports_grpcRoute() {
+        val route = route(protocol = "gRPC", path = "/example.EchoService/Echo", routeMatch = RouteMatch.NON_HTTP)
+
+        assertTrue(ArmeriaHttpRequestGenerator.supports(route))
+        assertEquals("armeria-grpc-example.EchoService-Echo.grpc", ArmeriaHttpRequestGenerator.fileName(route))
+    }
+
     private fun route(
         httpMethod: String = "GET",
         path: String = "/api",
         protocol: String = "HTTP",
         routeMatch: RouteMatch = RouteMatch.ANNOTATED_HTTP,
+        annotatedServiceHasPathPrefix: Boolean = false,
     ): ArmeriaRoute {
         return ArmeriaRoute(
             protocol = protocol,
@@ -133,6 +163,7 @@ class ArmeriaHttpRequestGeneratorTest {
             moduleName = "app",
             targetUnresolved = false,
             isDocService = false,
+            annotatedServiceHasPathPrefix = annotatedServiceHasPathPrefix,
             decorators = emptyList(),
             exceptionHandlers = emptyList(),
             pointer = TestPsiPointer,

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGenerator.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGenerator.kt
@@ -27,7 +27,13 @@ object ArmeriaHttpRequestGenerator {
             RouteMatch.ANNOTATED_HTTP, RouteMatch.RUNTIME -> route.httpMethod
             RouteMatch.SERVICE, RouteMatch.SERVICE_UNDER, RouteMatch.HEALTH_CHECK, RouteMatch.ROUTE_FLUENT ->
                 route.httpMethod.ifBlank { "GET" }
-            RouteMatch.NON_HTTP -> "POST"
+            RouteMatch.NON_HTTP -> {
+                if (isGrpcRoute(route)) {
+                    "POST"
+                } else {
+                    error("Unsupported route match: ${route.routeMatch}")
+                }
+            }
             RouteMatch.ANNOTATED_SERVICE, RouteMatch.FILE_SERVICE, RouteMatch.VIRTUAL_HOST,
             RouteMatch.ROUTE_DECORATOR, RouteMatch.DECORATOR_UNDER,
             -> error("Unsupported route match: ${route.routeMatch}")
@@ -44,14 +50,15 @@ object ArmeriaHttpRequestGenerator {
     }
 
     fun requestText(route: ArmeriaRoute, baseUrl: String = DEFAULT_BASE_URL): String {
+        val normalizedBaseUrl = normalizeBaseUrl(baseUrl)
         if (isGrpcRoute(route)) {
-            return grpcRequestText(route, baseUrl)
+            return grpcRequestText(route, normalizedBaseUrl)
         }
         val method = httpMethod(route)
         val resolvedPath = pathWithPlaceholders(route.path, route.pathType)
         return buildString {
             appendLine("### ${route.path}")
-            appendLine("$method $baseUrl$resolvedPath")
+            appendLine("$method $normalizedBaseUrl$resolvedPath")
             appendLine("Accept: application/json")
             appendLine()
         }
@@ -68,14 +75,17 @@ object ArmeriaHttpRequestGenerator {
     }
 
     private fun grpcRequestText(route: ArmeriaRoute, baseUrl: String): String {
+        val grpcPath = route.path.trim('/')
         return buildString {
             appendLine("### gRPC ${route.target}")
-            appendLine("GRPC $baseUrl/${route.path.trim('/')}")
+            appendLine("GRPC $baseUrl/$grpcPath")
             appendLine()
-            appendLine("# Invoke via DocService: ${baseUrl}/docs")
+            appendLine("# Invoke via DocService: $baseUrl/docs")
             appendLine()
         }
     }
+
+    private fun normalizeBaseUrl(baseUrl: String): String = baseUrl.trimEnd('/')
 
     private fun pathWithPlaceholders(path: String, pathType: PathType): String {
         if (pathType == PathType.REGEX || pathType == PathType.GLOB) {
@@ -89,8 +99,9 @@ object ArmeriaHttpRequestGenerator {
     }
 
     private fun braceVariableName(capture: String): String {
-        val colonIndex = capture.indexOf(':')
-        return if (colonIndex < 0) capture else capture.substring(0, colonIndex)
+        val trimmed = capture.trim()
+        val colonIndex = trimmed.indexOf(':')
+        return if (colonIndex < 0) trimmed else trimmed.substring(0, colonIndex).trim()
     }
 
     private fun sampleValue(name: String): String = when {

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGenerator.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGenerator.kt
@@ -36,7 +36,7 @@ object ArmeriaHttpRequestGenerator {
     fun fileName(route: ArmeriaRoute): String {
         if (route.routeMatch == RouteMatch.NON_HTTP) {
             val slug = pathSlug(route.path)
-            return "armeria-grpc-$slug.grpc"
+            return "armeria-grpc-$slug.http"
         }
         val method = httpMethod(route).lowercase(Locale.ROOT)
         return "armeria-$method-${pathSlug(route.path)}.http"

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGenerator.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGenerator.kt
@@ -6,44 +6,77 @@ object ArmeriaHttpRequestGenerator {
     const val DEFAULT_BASE_URL = "http://localhost:8080"
 
     private val NON_SLUG_CHARACTERS = Regex("[^a-zA-Z0-9._-]")
+    private val BRACE_PATH_VARIABLE = Regex("""\{([^}]+)}""")
+    private val COLON_PATH_VARIABLE = Regex(""":([A-Za-z_][A-Za-z0-9_]*)""")
 
     fun supports(route: ArmeriaRoute): Boolean {
         return when (route.routeMatch) {
             RouteMatch.ANNOTATED_HTTP -> route.httpMethod.isNotBlank()
             RouteMatch.SERVICE, RouteMatch.SERVICE_UNDER, RouteMatch.HEALTH_CHECK, RouteMatch.ROUTE_FLUENT -> true
             RouteMatch.RUNTIME -> route.httpMethod.isNotBlank()
-            RouteMatch.ANNOTATED_SERVICE, RouteMatch.NON_HTTP,
-            RouteMatch.FILE_SERVICE, RouteMatch.VIRTUAL_HOST, RouteMatch.ROUTE_DECORATOR, RouteMatch.DECORATOR_UNDER,
-            -> false
+            RouteMatch.ANNOTATED_SERVICE -> route.annotatedServiceHasPathPrefix
+            RouteMatch.NON_HTTP -> route.protocol.equals("gRPC", ignoreCase = true)
+            RouteMatch.FILE_SERVICE, RouteMatch.VIRTUAL_HOST, RouteMatch.ROUTE_DECORATOR, RouteMatch.DECORATOR_UNDER ->
+                false
         }
     }
 
     fun httpMethod(route: ArmeriaRoute): String {
         return when (route.routeMatch) {
             RouteMatch.ANNOTATED_HTTP, RouteMatch.RUNTIME -> route.httpMethod
-            RouteMatch.SERVICE, RouteMatch.SERVICE_UNDER, RouteMatch.HEALTH_CHECK, RouteMatch.ROUTE_FLUENT -> {
-                route.httpMethod.ifBlank { "GET" }
-            }
-            RouteMatch.ANNOTATED_SERVICE, RouteMatch.NON_HTTP,
-            RouteMatch.FILE_SERVICE, RouteMatch.VIRTUAL_HOST, RouteMatch.ROUTE_DECORATOR, RouteMatch.DECORATOR_UNDER,
-            ->
+            RouteMatch.SERVICE, RouteMatch.SERVICE_UNDER, RouteMatch.HEALTH_CHECK,
+            RouteMatch.ANNOTATED_SERVICE, RouteMatch.ROUTE_FLUENT,
+            -> route.httpMethod.ifBlank { "GET" }
+            RouteMatch.NON_HTTP -> "POST"
+            RouteMatch.FILE_SERVICE, RouteMatch.VIRTUAL_HOST, RouteMatch.ROUTE_DECORATOR, RouteMatch.DECORATOR_UNDER ->
                 error("Unsupported route match: ${route.routeMatch}")
         }
     }
 
     fun fileName(route: ArmeriaRoute): String {
+        if (route.routeMatch == RouteMatch.NON_HTTP) {
+            val slug = pathSlug(route.path)
+            return "armeria-grpc-$slug.grpc"
+        }
         val method = httpMethod(route).lowercase(Locale.ROOT)
         return "armeria-$method-${pathSlug(route.path)}.http"
     }
 
     fun requestText(route: ArmeriaRoute, baseUrl: String = DEFAULT_BASE_URL): String {
+        if (route.routeMatch == RouteMatch.NON_HTTP) {
+            return grpcRequestText(route, baseUrl)
+        }
         val method = httpMethod(route)
+        val resolvedPath = pathWithPlaceholders(route.path)
         return buildString {
             appendLine("### ${route.path}")
-            appendLine("$method $baseUrl${route.path}")
+            appendLine("$method $baseUrl$resolvedPath")
             appendLine("Accept: application/json")
             appendLine()
         }
+    }
+
+    private fun grpcRequestText(route: ArmeriaRoute, baseUrl: String): String {
+        return buildString {
+            appendLine("### gRPC ${route.target}")
+            appendLine("GRPC $baseUrl/${route.path.trim('/')}")
+            appendLine()
+            appendLine("# Invoke via DocService: ${baseUrl}/docs")
+            appendLine()
+        }
+    }
+
+    fun pathWithPlaceholders(path: String): String {
+        var resolved = BRACE_PATH_VARIABLE.replace(path) { match -> sampleValue(match.groupValues[1]) }
+        resolved = COLON_PATH_VARIABLE.replace(resolved) { match -> sampleValue(match.groupValues[1]) }
+        return resolved
+    }
+
+    private fun sampleValue(name: String): String = when {
+        name.equals("id", ignoreCase = true) -> "1"
+        name.equals("name", ignoreCase = true) -> "example"
+        name.all { it.isDigit() } -> "sample"
+        else -> name.lowercase(Locale.ROOT)
     }
 
     private fun pathSlug(path: String): String {

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGenerator.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGenerator.kt
@@ -8,33 +8,34 @@ object ArmeriaHttpRequestGenerator {
     private val NON_SLUG_CHARACTERS = Regex("[^a-zA-Z0-9._-]")
     private val BRACE_PATH_VARIABLE = Regex("""\{([^}]+)}""")
     private val COLON_PATH_VARIABLE = Regex(""":([A-Za-z_][A-Za-z0-9_]*)""")
+    private val GRPC_METHOD_PATH = Regex("""^/[^/]+\.[^/]+/[^/]+$""")
 
     fun supports(route: ArmeriaRoute): Boolean {
         return when (route.routeMatch) {
             RouteMatch.ANNOTATED_HTTP -> route.httpMethod.isNotBlank()
             RouteMatch.SERVICE, RouteMatch.SERVICE_UNDER, RouteMatch.HEALTH_CHECK, RouteMatch.ROUTE_FLUENT -> true
             RouteMatch.RUNTIME -> route.httpMethod.isNotBlank()
-            RouteMatch.ANNOTATED_SERVICE -> route.annotatedServiceHasPathPrefix
-            RouteMatch.NON_HTTP -> route.protocol.equals("gRPC", ignoreCase = true)
-            RouteMatch.FILE_SERVICE, RouteMatch.VIRTUAL_HOST, RouteMatch.ROUTE_DECORATOR, RouteMatch.DECORATOR_UNDER ->
-                false
+            RouteMatch.NON_HTTP -> isGrpcRoute(route)
+            RouteMatch.ANNOTATED_SERVICE, RouteMatch.FILE_SERVICE, RouteMatch.VIRTUAL_HOST,
+            RouteMatch.ROUTE_DECORATOR, RouteMatch.DECORATOR_UNDER,
+            -> false
         }
     }
 
     fun httpMethod(route: ArmeriaRoute): String {
         return when (route.routeMatch) {
             RouteMatch.ANNOTATED_HTTP, RouteMatch.RUNTIME -> route.httpMethod
-            RouteMatch.SERVICE, RouteMatch.SERVICE_UNDER, RouteMatch.HEALTH_CHECK,
-            RouteMatch.ANNOTATED_SERVICE, RouteMatch.ROUTE_FLUENT,
-            -> route.httpMethod.ifBlank { "GET" }
+            RouteMatch.SERVICE, RouteMatch.SERVICE_UNDER, RouteMatch.HEALTH_CHECK, RouteMatch.ROUTE_FLUENT ->
+                route.httpMethod.ifBlank { "GET" }
             RouteMatch.NON_HTTP -> "POST"
-            RouteMatch.FILE_SERVICE, RouteMatch.VIRTUAL_HOST, RouteMatch.ROUTE_DECORATOR, RouteMatch.DECORATOR_UNDER ->
-                error("Unsupported route match: ${route.routeMatch}")
+            RouteMatch.ANNOTATED_SERVICE, RouteMatch.FILE_SERVICE, RouteMatch.VIRTUAL_HOST,
+            RouteMatch.ROUTE_DECORATOR, RouteMatch.DECORATOR_UNDER,
+            -> error("Unsupported route match: ${route.routeMatch}")
         }
     }
 
     fun fileName(route: ArmeriaRoute): String {
-        if (route.routeMatch == RouteMatch.NON_HTTP) {
+        if (isGrpcRoute(route)) {
             val slug = pathSlug(route.path)
             return "armeria-grpc-$slug.http"
         }
@@ -43,17 +44,27 @@ object ArmeriaHttpRequestGenerator {
     }
 
     fun requestText(route: ArmeriaRoute, baseUrl: String = DEFAULT_BASE_URL): String {
-        if (route.routeMatch == RouteMatch.NON_HTTP) {
+        if (isGrpcRoute(route)) {
             return grpcRequestText(route, baseUrl)
         }
         val method = httpMethod(route)
-        val resolvedPath = pathWithPlaceholders(route.path)
+        val resolvedPath = pathWithPlaceholders(route.path, route.pathType)
         return buildString {
             appendLine("### ${route.path}")
             appendLine("$method $baseUrl$resolvedPath")
             appendLine("Accept: application/json")
             appendLine()
         }
+    }
+
+    private fun isGrpcRoute(route: ArmeriaRoute): Boolean {
+        if (route.routeMatch != RouteMatch.NON_HTTP) {
+            return false
+        }
+        if (!route.protocol.equals(RouteProtocol.GRPC.presentableName(), ignoreCase = true)) {
+            return false
+        }
+        return GRPC_METHOD_PATH.matches(route.path)
     }
 
     private fun grpcRequestText(route: ArmeriaRoute, baseUrl: String): String {
@@ -66,10 +77,20 @@ object ArmeriaHttpRequestGenerator {
         }
     }
 
-    fun pathWithPlaceholders(path: String): String {
-        var resolved = BRACE_PATH_VARIABLE.replace(path) { match -> sampleValue(match.groupValues[1]) }
+    private fun pathWithPlaceholders(path: String, pathType: PathType): String {
+        if (pathType == PathType.REGEX || pathType == PathType.GLOB) {
+            return path
+        }
+        var resolved = BRACE_PATH_VARIABLE.replace(path) { match ->
+            sampleValue(braceVariableName(match.groupValues[1]))
+        }
         resolved = COLON_PATH_VARIABLE.replace(resolved) { match -> sampleValue(match.groupValues[1]) }
         return resolved
+    }
+
+    private fun braceVariableName(capture: String): String {
+        val colonIndex = capture.indexOf(':')
+        return if (colonIndex < 0) capture else capture.substring(0, colonIndex)
     }
 
     private fun sampleValue(name: String): String = when {

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGenerator.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGenerator.kt
@@ -6,9 +6,8 @@ object ArmeriaHttpRequestGenerator {
     const val DEFAULT_BASE_URL = "http://localhost:8080"
 
     private val NON_SLUG_CHARACTERS = Regex("[^a-zA-Z0-9._-]")
-    private val BRACE_PATH_VARIABLE = Regex("""\{([^}]+)}""")
     private val COLON_PATH_VARIABLE = Regex(""":([A-Za-z_][A-Za-z0-9_]*)""")
-    private val GRPC_METHOD_PATH = Regex("""^/[^/]+\.[^/]+/[^/]+$""")
+    private val GRPC_METHOD_PATH = Regex("""^/[^/]+/[^/]+$""")
 
     fun supports(route: ArmeriaRoute): Boolean {
         return when (route.routeMatch) {
@@ -91,11 +90,50 @@ object ArmeriaHttpRequestGenerator {
         if (pathType == PathType.REGEX || pathType == PathType.GLOB) {
             return path
         }
-        var resolved = BRACE_PATH_VARIABLE.replace(path) { match ->
-            sampleValue(braceVariableName(match.groupValues[1]))
-        }
+        var resolved = replaceBracePathVariables(path)
         resolved = COLON_PATH_VARIABLE.replace(resolved) { match -> sampleValue(match.groupValues[1]) }
         return resolved
+    }
+
+    private fun replaceBracePathVariables(path: String): String {
+        val result = StringBuilder()
+        var index = 0
+        while (index < path.length) {
+            if (path[index] == '{') {
+                val end = findMatchingBrace(path, index)
+                if (end < 0) {
+                    result.append(path[index])
+                    index++
+                    continue
+                }
+                val capture = path.substring(index + 1, end)
+                result.append(sampleValue(braceVariableName(capture)))
+                index = end + 1
+            } else {
+                result.append(path[index])
+                index++
+            }
+        }
+        return result.toString()
+    }
+
+    private fun findMatchingBrace(path: String, start: Int): Int {
+        if (start >= path.length || path[start] != '{') {
+            return -1
+        }
+        var depth = 0
+        for (index in start until path.length) {
+            when (path[index]) {
+                '{' -> depth++
+                '}' -> {
+                    depth--
+                    if (depth == 0) {
+                        return index
+                    }
+                }
+            }
+        }
+        return -1
     }
 
     private fun braceVariableName(capture: String): String {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends HTTP Request file generation to cover more Armeria route types discovered by Route Explorer, with guards against invalid gRPC mounts and regex path corruption.

## Changes

- Substitute `{name}` and `:name` path variable placeholders in generated URLs (skip `REGEX` / `GLOB` paths)
- Strip brace constraints (`{id:\d+}`) before sample-value substitution, including whitespace around variable names and quantifiers with nested braces (`{id:\d{2,3}}`)
- Support gRPC DocService templates for proto-style method paths (`/package.Service/Method` and package-less `/Service/Method`) via centralized `isGrpcRoute()`
- Reject gRPC registration mounts (`/grpc`) and annotated-service prefix-only mounts that are not directly callable
- Fail fast in `httpMethod()` for unsupported `NON_HTTP` routes instead of silently returning `POST`
- Normalize `baseUrl` to avoid double slashes in generated gRPC and HTTP request URLs
- Add regression tests for gRPC proto output (with and without package), registration mounts, regex paths, constrained variables, and edge cases

## Depends on

- #202

## Test plan

- [x] `:plugin-route-analysis:fastTest` — `ArmeriaHttpRequestGeneratorTest`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2f83-3c3e-7f3f-b835-be2c90fec8ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2f83-3c3e-7f3f-b835-be2c90fec8ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

