### PR TITLE
feat: add Go to Related navigation between handlers and registrations

### DIFF
--- a/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupportPathFormattingTest.kt
+++ b/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupportPathFormattingTest.kt
@@ -29,4 +29,12 @@ class ArmeriaRouteSupportPathFormattingTest {
             ArmeriaRouteSupport.formatAnnotatedHandlerPath("regex:^/api", "/hello"),
         )
     }
+
+    @Test
+    fun formatAnnotatedHandlerPath_usesRegexDisplayTypeWhenRegexPrefixCombinesWithPrefixHandler() {
+        assertEquals(
+            "regex:^/api/hello",
+            ArmeriaRouteSupport.formatAnnotatedHandlerPath("regex:^/api", "prefix:/hello"),
+        )
+    }
 }

--- a/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupportPathFormattingTest.kt
+++ b/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupportPathFormattingTest.kt
@@ -37,4 +37,12 @@ class ArmeriaRouteSupportPathFormattingTest {
             ArmeriaRouteSupport.formatAnnotatedHandlerPath("regex:^/api", "prefix:/hello"),
         )
     }
+
+    @Test
+    fun formatAnnotatedHandlerPath_preservesRegexStartAnchorWhenExactPrefixCombinesWithRegexHandler() {
+        assertEquals(
+            "regex:^/api/hello$",
+            ArmeriaRouteSupport.formatAnnotatedHandlerPath("/api", "regex:^/hello$"),
+        )
+    }
 }

--- a/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupportPathFormattingTest.kt
+++ b/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupportPathFormattingTest.kt
@@ -1,0 +1,32 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ArmeriaRouteSupportPathFormattingTest {
+    @Test
+    fun formatAnnotatedHandlerPath_combinesExactPaths() {
+        assertEquals("/api/hello", ArmeriaRouteSupport.formatAnnotatedHandlerPath("/api", "/hello"))
+    }
+
+    @Test
+    fun formatAnnotatedHandlerPath_preservesPrefixType() {
+        assertEquals("prefix:/api/hello", ArmeriaRouteSupport.formatAnnotatedHandlerPath("/api", "prefix:/hello"))
+    }
+
+    @Test
+    fun formatAnnotatedHandlerPath_preservesRegexTypeWithoutNormalizingPatterns() {
+        assertEquals(
+            "regex:^/api/hello$",
+            ArmeriaRouteSupport.formatAnnotatedHandlerPath("regex:^/api", "regex:^/hello$"),
+        )
+    }
+
+    @Test
+    fun formatAnnotatedHandlerPath_preservesRegexClassPrefixWithExactHandler() {
+        assertEquals(
+            "regex:^/api/hello",
+            ArmeriaRouteSupport.formatAnnotatedHandlerPath("regex:^/api", "/hello"),
+        )
+    }
+}

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
@@ -258,9 +258,16 @@ object ArmeriaRouteSupport {
     }
 
     private fun joinRegexPathBodies(prefix: String, handler: String): String {
-        val normalizedPrefix = prefix.trim().removeSuffix("$")
-        val normalizedHandler = handler.trim().removePrefix("^")
-        return normalizedPrefix + normalizedHandler
+        val prefixBody = prefix.trim().removeSuffix("$")
+        val trimmedHandler = handler.trim()
+        val handlerHadStartAnchor = trimmedHandler.startsWith("^")
+        val handlerBody = trimmedHandler.removePrefix("^")
+        val combined = prefixBody + handlerBody
+        return if (handlerHadStartAnchor && !prefixBody.startsWith("^")) {
+            "^$combined"
+        } else {
+            combined
+        }
     }
 
     fun extractPathAnnotations(method: PsiMethod): List<String> {

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
@@ -214,14 +214,43 @@ object ArmeriaRouteSupport {
     }
 
     fun formatAnnotatedHandlerPath(classPrefix: String, rawPath: String): String {
-        val (pathType, normalizedPath) = parsePathType(rawPath.ifBlank { "/" })
-        val combined = combinePaths(classPrefix, normalizedPath)
-        return when (pathType) {
-            PathType.EXACT -> combined
-            PathType.PREFIX -> "prefix:$combined"
-            PathType.REGEX -> "regex:$combined"
-            PathType.GLOB -> "glob:$combined"
+        val (handlerPathType, handlerPath) = parsePathType(rawPath.ifBlank { "/" })
+        val (prefixPathType, prefixPath) = parsePathType(classPrefix.ifBlank { "/" })
+        val combinedBody = combineAnnotatedPathBodies(prefixPathType, prefixPath, handlerPathType, handlerPath)
+        val displayType = if (handlerPathType != PathType.EXACT) handlerPathType else prefixPathType
+        return when (displayType) {
+            PathType.EXACT -> combinedBody
+            PathType.PREFIX -> "prefix:$combinedBody"
+            PathType.REGEX -> "regex:$combinedBody"
+            PathType.GLOB -> "glob:$combinedBody"
         }
+    }
+
+    private fun combineAnnotatedPathBodies(
+        prefixPathType: PathType,
+        prefixPath: String,
+        handlerPathType: PathType,
+        handlerPath: String,
+    ): String {
+        if (prefixPath == "/" || prefixPath.isBlank()) {
+            return handlerPath
+        }
+        if (handlerPath == "/" || handlerPath.isBlank()) {
+            return prefixPath
+        }
+        if (prefixPathType == PathType.EXACT && handlerPathType == PathType.EXACT) {
+            return combinePaths(prefixPath, handlerPath)
+        }
+        if (prefixPathType == PathType.REGEX || handlerPathType == PathType.REGEX) {
+            return joinRegexPathBodies(prefixPath, handlerPath)
+        }
+        return combinePaths(prefixPath, handlerPath)
+    }
+
+    private fun joinRegexPathBodies(prefix: String, handler: String): String {
+        val normalizedPrefix = prefix.trim().removeSuffix("$")
+        val normalizedHandler = handler.trim().removePrefix("^")
+        return normalizedPrefix + normalizedHandler
     }
 
     fun extractPathAnnotations(method: PsiMethod): List<String> {

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
@@ -213,6 +213,17 @@ object ArmeriaRouteSupport {
         }
     }
 
+    fun formatAnnotatedHandlerPath(classPrefix: String, rawPath: String): String {
+        val (pathType, normalizedPath) = parsePathType(rawPath.ifBlank { "/" })
+        val combined = combinePaths(classPrefix, normalizedPath)
+        return when (pathType) {
+            PathType.EXACT -> combined
+            PathType.PREFIX -> "prefix:$combined"
+            PathType.REGEX -> "regex:$combined"
+            PathType.GLOB -> "glob:$combined"
+        }
+    }
+
     fun extractPathAnnotations(method: PsiMethod): List<String> {
         return method.annotations
             .filter { it.qualifiedName == PATH_ANNOTATION }

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
@@ -217,13 +217,23 @@ object ArmeriaRouteSupport {
         val (handlerPathType, handlerPath) = parsePathType(rawPath.ifBlank { "/" })
         val (prefixPathType, prefixPath) = parsePathType(classPrefix.ifBlank { "/" })
         val combinedBody = combineAnnotatedPathBodies(prefixPathType, prefixPath, handlerPathType, handlerPath)
-        val displayType = if (handlerPathType != PathType.EXACT) handlerPathType else prefixPathType
+        val displayType = annotatedPathDisplayType(prefixPathType, handlerPathType)
         return when (displayType) {
             PathType.EXACT -> combinedBody
             PathType.PREFIX -> "prefix:$combinedBody"
             PathType.REGEX -> "regex:$combinedBody"
             PathType.GLOB -> "glob:$combinedBody"
         }
+    }
+
+    private fun annotatedPathDisplayType(prefixPathType: PathType, handlerPathType: PathType): PathType {
+        if (prefixPathType == PathType.REGEX || handlerPathType == PathType.REGEX) {
+            return PathType.REGEX
+        }
+        if (handlerPathType != PathType.EXACT) {
+            return handlerPathType
+        }
+        return prefixPathType
     }
 
     private fun combineAnnotatedPathBodies(

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteTargetExtractor.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteTargetExtractor.kt
@@ -138,3 +138,6 @@ internal object ArmeriaRouteTargetExtractor {
         }
     }
 }
+
+fun extractArmeriaRouteTarget(expression: PsiExpression): String =
+    ArmeriaRouteTargetExtractor.extractTarget(expression)

--- a/plugin-shared/src/main/resources/messages/ArmeriaBundle.properties
+++ b/plugin-shared/src/main/resources/messages/ArmeriaBundle.properties
@@ -125,6 +125,7 @@ marker.route.annotated={0} {1}
 marker.route.registration={0}("{1}")
 
 editor.route.gotoRelated.handler={0} {1}
+editor.route.gotoRelated.handlers=Annotated handlers
 editor.route.gotoRelated.registration=Service registration
 
 client.explorer.empty=No Armeria clients discovered

--- a/plugin-shared/src/main/resources/messages/ArmeriaBundle.properties
+++ b/plugin-shared/src/main/resources/messages/ArmeriaBundle.properties
@@ -124,6 +124,9 @@ marker.route.title=Armeria route
 marker.route.annotated={0} {1}
 marker.route.registration={0}("{1}")
 
+editor.route.gotoRelated.handler={0} {1}
+editor.route.gotoRelated.registration=Service registration
+
 client.explorer.empty=No Armeria clients discovered
 client.explorer.name=Armeria Clients
 client.explorer.action.refresh=Refresh

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaKotlinRouteNavigationSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaKotlinRouteNavigationSupport.kt
@@ -145,7 +145,7 @@ internal object ArmeriaKotlinRouteNavigationSupport {
         val implementation = kotlinServiceImplementationExpression(call) ?: return null
         resolveServiceClassFromImplementation(implementation)?.let { return it }
         return (implementation as? PsiExpression)?.let { psiExpression ->
-            ArmeriaRouteNavigationSupport.findClassByFqn(call.project, extractArmeriaRouteTarget(psiExpression))
+            ArmeriaRouteNavigationSupport.findClassByTarget(call.project, extractArmeriaRouteTarget(psiExpression))
         }
     }
 
@@ -166,7 +166,7 @@ internal object ArmeriaKotlinRouteNavigationSupport {
             classFromResolved(reference?.references?.firstOrNull()?.resolve())?.let { return it }
         }
         return (initializer as? PsiExpression)?.let { expression ->
-            ArmeriaRouteNavigationSupport.findClassByFqn(property.project, extractArmeriaRouteTarget(expression))
+            ArmeriaRouteNavigationSupport.findClassByTarget(property.project, extractArmeriaRouteTarget(expression))
         }
     }
 

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaKotlinRouteNavigationSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaKotlinRouteNavigationSupport.kt
@@ -2,13 +2,11 @@ package com.linecorp.intellij.plugins.armeria.editor
 
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiVariable
 import com.intellij.psi.util.PsiTreeUtil
 import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaKotlinRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.ServiceRegistrationMethod
-import com.linecorp.intellij.plugins.armeria.explorer.extractArmeriaRouteTarget
 import com.linecorp.intellij.plugins.armeria.inspection.ArmeriaKotlinMethodRoute
 import org.jetbrains.kotlin.asJava.toLightClass
 import org.jetbrains.kotlin.psi.KtCallExpression
@@ -144,9 +142,10 @@ internal object ArmeriaKotlinRouteNavigationSupport {
     private fun resolveServiceClassFromKotlinCall(call: KtCallExpression): PsiClass? {
         val implementation = kotlinServiceImplementationExpression(call) ?: return null
         resolveServiceClassFromImplementation(implementation)?.let { return it }
-        return (implementation as? PsiExpression)?.let { psiExpression ->
-            ArmeriaRouteNavigationSupport.findClassByTarget(call.project, extractArmeriaRouteTarget(psiExpression))
-        }
+        return ArmeriaRouteNavigationSupport.findClassByTarget(
+            call.project,
+            extractKotlinRouteTarget(implementation),
+        )
     }
 
     private fun classFromKotlinProperty(property: KtProperty): PsiClass? {
@@ -165,8 +164,25 @@ internal object ArmeriaKotlinRouteNavigationSupport {
             }
             classFromResolved(reference?.references?.firstOrNull()?.resolve())?.let { return it }
         }
-        return (initializer as? PsiExpression)?.let { expression ->
-            ArmeriaRouteNavigationSupport.findClassByTarget(property.project, extractArmeriaRouteTarget(expression))
+        return ArmeriaRouteNavigationSupport.findClassByTarget(
+            property.project,
+            extractKotlinRouteTarget(initializer),
+        )
+    }
+
+    private fun extractKotlinRouteTarget(expression: KtExpression): String {
+        return when (expression) {
+            is KtCallExpression -> {
+                val callee = expression.calleeExpression
+                val reference = when (callee) {
+                    is KtNameReferenceExpression -> callee
+                    is KtDotQualifiedExpression -> callee.selectorExpression as? KtNameReferenceExpression
+                    else -> null
+                }
+                reference?.getReferencedName() ?: expression.text.trim()
+            }
+            is KtNameReferenceExpression -> expression.getReferencedName()
+            else -> expression.text.trim()
         }
     }
 

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaKotlinRouteNavigationSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaKotlinRouteNavigationSupport.kt
@@ -1,0 +1,211 @@
+package com.linecorp.intellij.plugins.armeria.editor
+
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiVariable
+import com.intellij.psi.util.PsiTreeUtil
+import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaKotlinRouteCollector
+import com.linecorp.intellij.plugins.armeria.explorer.ServiceRegistrationMethod
+import com.linecorp.intellij.plugins.armeria.explorer.extractArmeriaRouteTarget
+import com.linecorp.intellij.plugins.armeria.inspection.ArmeriaKotlinMethodRoute
+import org.jetbrains.kotlin.asJava.toLightClass
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtConstructor
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtValueArgument
+
+internal object ArmeriaKotlinRouteNavigationSupport {
+    fun annotatedRouteHandler(element: PsiElement): PsiElement? =
+        annotatedKotlinRouteFunction(element)
+
+    fun annotatedKotlinRouteFunction(element: PsiElement): PsiElement? {
+        val function = kotlinFunctionFromElement(element) ?: return null
+        return function.takeIf { ArmeriaKotlinMethodRoute.from(it) != null }
+    }
+
+    fun httpMethod(handler: PsiElement): String? =
+        (handler as? KtNamedFunction)?.let { ArmeriaKotlinMethodRoute.from(it)?.httpMethod }
+
+    fun routePath(handler: PsiElement): String =
+        (handler as? KtNamedFunction)?.let { ArmeriaKotlinMethodRoute.from(it)?.paths?.joinToString(", ") }.orEmpty()
+
+    fun relatedRegistrations(handler: PsiElement): List<PsiElement> {
+        val function = handler as? KtNamedFunction ?: return emptyList()
+        val serviceClass = PsiTreeUtil.getParentOfType(function, KtClass::class.java)?.toLightClass() ?: return emptyList()
+        return ArmeriaRouteNavigationSupport.findRegistrationsForServiceClass(serviceClass, function.project)
+    }
+
+    fun relatedHandlers(context: PsiElement): List<PsiElement> {
+        val call = kotlinRegistrationCallFromContext(context) ?: return emptyList()
+        val serviceClass = resolveServiceClassFromKotlinCall(call) ?: return emptyList()
+        return ArmeriaRouteNavigationSupport.annotatedHandlersInClass(serviceClass)
+    }
+
+    fun collectRegistrationFromReference(
+        element: PsiElement,
+        serviceClass: PsiClass,
+        registrations: MutableSet<PsiElement>,
+    ) {
+        val kotlinCall = kotlinRegistrationCallFromReference(element) ?: return
+        val resolvedClass = resolveServiceClassFromKotlinCall(kotlinCall) ?: return
+        if (ArmeriaRouteNavigationSupport.serviceTypesMatch(serviceClass, resolvedClass)) {
+            registrations += kotlinCall
+        }
+    }
+
+    fun annotatedHandlerFromMethod(method: PsiMethod): PsiElement? {
+        val kotlinFunction = method.originalElement as? KtNamedFunction ?: return null
+        return kotlinFunction.takeIf { ArmeriaKotlinMethodRoute.from(it) != null }
+    }
+
+    fun resolvedClassFromReference(expression: PsiElement): PsiClass? = when (expression) {
+        is KtNameReferenceExpression -> classFromResolved(expression.references.firstOrNull()?.resolve())
+        else -> null
+    }
+
+    fun classFromResolved(resolved: PsiElement?): PsiClass? = when (resolved) {
+        is PsiClass -> resolved
+        is PsiMethod -> resolved.takeIf { it.isConstructor }?.containingClass
+        is PsiVariable -> (resolved.type as? com.intellij.psi.PsiClassType)?.resolve()
+        is KtClass -> resolved.toLightClass()
+        is KtConstructor<*> -> resolved.getContainingClassOrObject().toLightClass()
+        is KtProperty -> classFromKotlinProperty(resolved)
+        else -> null
+    }
+
+    fun resolveServiceClassFromImplementation(expression: PsiElement): PsiClass? {
+        resolvedClassFromReference(expression)?.let { return it }
+        when (expression) {
+            is KtCallExpression -> {
+                val reference = when (val callee = expression.calleeExpression) {
+                    is KtNameReferenceExpression -> callee
+                    is KtDotQualifiedExpression -> callee.selectorExpression as? KtNameReferenceExpression
+                    else -> null
+                }
+                classFromResolved(reference?.references?.firstOrNull()?.resolve())?.let { return it }
+            }
+            is KtProperty -> return classFromKotlinProperty(expression)
+        }
+        return null
+    }
+
+    fun isKotlinServiceRegistrationCall(call: PsiElement): Boolean {
+        val kotlinCall = call as? KtCallExpression ?: return false
+        val methodName = kotlinCallName(kotlinCall) ?: return false
+        if (methodName !in ArmeriaRouteNavigationSupport.serviceRegistrationMethodNames) {
+            return false
+        }
+        return ArmeriaKotlinRouteCollector.looksLikeArmeriaBuilderCall(kotlinCall)
+    }
+
+    fun registrationNavigationElement(registration: PsiElement): PsiElement {
+        val call = registration as? KtCallExpression ?: return registration
+        return kotlinCallReferenceNameElement(call) ?: registration
+    }
+
+    fun handlerNavigationElement(handler: PsiElement): PsiElement {
+        val function = handler as? KtNamedFunction ?: return handler
+        return function.nameIdentifier ?: handler
+    }
+
+    private fun kotlinFunctionFromElement(element: PsiElement): KtNamedFunction? = when (element) {
+        is KtNamedFunction -> element
+        else -> PsiTreeUtil.getParentOfType(element, KtNamedFunction::class.java, false)
+    }
+
+    private fun kotlinRegistrationCallFromReference(start: PsiElement): KtCallExpression? {
+        var current: PsiElement? = start
+        while (current != null) {
+            val call = PsiTreeUtil.getParentOfType(current, KtCallExpression::class.java, false)
+                ?: break
+            if (isKotlinServiceRegistrationCall(call)) {
+                return call
+            }
+            current = call.parent
+        }
+        return null
+    }
+
+    private fun kotlinRegistrationCallFromContext(context: PsiElement): KtCallExpression? {
+        if (context is KtCallExpression && isKotlinServiceRegistrationCall(context)) {
+            return context
+        }
+        return PsiTreeUtil.getParentOfType(context, KtCallExpression::class.java)
+            ?.takeIf(::isKotlinServiceRegistrationCall)
+    }
+
+    private fun resolveServiceClassFromKotlinCall(call: KtCallExpression): PsiClass? {
+        val implementation = kotlinServiceImplementationExpression(call) ?: return null
+        resolveServiceClassFromImplementation(implementation)?.let { return it }
+        return (implementation as? PsiExpression)?.let { psiExpression ->
+            ArmeriaRouteNavigationSupport.findClassByFqn(call.project, extractArmeriaRouteTarget(psiExpression))
+        }
+    }
+
+    private fun classFromKotlinProperty(property: KtProperty): PsiClass? {
+        property.typeReference?.references?.firstOrNull()?.resolve()?.let { typeResolved ->
+            when (typeResolved) {
+                is PsiClass -> return typeResolved
+                is KtClass -> return typeResolved.toLightClass()
+            }
+        }
+        val initializer = property.initializer ?: return null
+        if (initializer is KtCallExpression) {
+            val reference = when (val callee = initializer.calleeExpression) {
+                is KtNameReferenceExpression -> callee
+                is KtDotQualifiedExpression -> callee.selectorExpression as? KtNameReferenceExpression
+                else -> null
+            }
+            classFromResolved(reference?.references?.firstOrNull()?.resolve())?.let { return it }
+        }
+        return (initializer as? PsiExpression)?.let { expression ->
+            ArmeriaRouteNavigationSupport.findClassByFqn(property.project, extractArmeriaRouteTarget(expression))
+        }
+    }
+
+    private fun kotlinServiceImplementationExpression(call: KtCallExpression): KtExpression? {
+        val arguments = call.valueArguments
+        return when (ServiceRegistrationMethod.fromMethodName(kotlinCallName(call) ?: return null)) {
+            ServiceRegistrationMethod.ANNOTATED_SERVICE ->
+                findKotlinArgumentExpression(arguments, "service", 1)
+                    ?: findKotlinArgumentExpression(arguments, "service", 0)
+            ServiceRegistrationMethod.SERVICE, ServiceRegistrationMethod.SERVICE_UNDER ->
+                findKotlinArgumentExpression(arguments, "service", 1)
+            else -> null
+        }
+    }
+
+    private fun findKotlinArgumentExpression(
+        arguments: List<KtValueArgument>,
+        parameterName: String,
+        positionalIndex: Int,
+    ): KtExpression? {
+        arguments.firstOrNull { it.getArgumentName()?.asName?.identifier == parameterName }
+            ?.getArgumentExpression()
+            ?.let { return it }
+        return arguments.getOrNull(positionalIndex)?.getArgumentExpression()
+    }
+
+    private fun kotlinCallName(call: KtCallExpression): String? {
+        return when (val callee = call.calleeExpression) {
+            is KtDotQualifiedExpression -> callee.selectorExpression?.text
+            is KtNameReferenceExpression -> callee.text
+            else -> callee?.text
+        }
+    }
+
+    private fun kotlinCallReferenceNameElement(call: KtCallExpression): PsiElement? {
+        return when (val callee = call.calleeExpression) {
+            is KtDotQualifiedExpression -> callee.selectorExpression
+            is KtNameReferenceExpression -> callee
+            else -> null
+        }
+    }
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaKotlinRouteNavigationSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaKotlinRouteNavigationSupport.kt
@@ -10,7 +10,7 @@ import com.linecorp.intellij.plugins.armeria.explorer.ServiceRegistrationMethod
 import com.linecorp.intellij.plugins.armeria.inspection.ArmeriaKotlinMethodRoute
 import org.jetbrains.kotlin.asJava.toLightClass
 import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtConstructor
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtExpression
@@ -36,7 +36,8 @@ internal object ArmeriaKotlinRouteNavigationSupport {
 
     fun relatedRegistrations(handler: PsiElement): List<PsiElement> {
         val function = handler as? KtNamedFunction ?: return emptyList()
-        val serviceClass = PsiTreeUtil.getParentOfType(function, KtClass::class.java)?.toLightClass() ?: return emptyList()
+        val serviceClass = PsiTreeUtil.getParentOfType(function, KtClassOrObject::class.java)?.toLightClass()
+            ?: return emptyList()
         return ArmeriaRouteNavigationSupport.findRegistrationsForServiceClass(serviceClass, function.project)
     }
 
@@ -72,7 +73,7 @@ internal object ArmeriaKotlinRouteNavigationSupport {
         is PsiClass -> resolved
         is PsiMethod -> resolved.takeIf { it.isConstructor }?.containingClass
         is PsiVariable -> (resolved.type as? com.intellij.psi.PsiClassType)?.resolve()
-        is KtClass -> resolved.toLightClass()
+        is KtClassOrObject -> resolved.toLightClass()
         is KtConstructor<*> -> resolved.getContainingClassOrObject().toLightClass()
         is KtProperty -> classFromKotlinProperty(resolved)
         else -> null
@@ -152,7 +153,7 @@ internal object ArmeriaKotlinRouteNavigationSupport {
         property.typeReference?.references?.firstOrNull()?.resolve()?.let { typeResolved ->
             when (typeResolved) {
                 is PsiClass -> return typeResolved
-                is KtClass -> return typeResolved.toLightClass()
+                is KtClassOrObject -> return typeResolved.toLightClass()
             }
         }
         val initializer = property.initializer ?: return null

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteGotoRelatedProvider.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteGotoRelatedProvider.kt
@@ -6,7 +6,7 @@ import com.intellij.psi.PsiElement
 
 class ArmeriaRouteGotoRelatedProvider : GotoRelatedProvider() {
     override fun getItems(context: PsiElement): List<GotoRelatedItem> {
-        ArmeriaRouteNavigationSupport.annotatedRouteMethod(context)?.let { return ArmeriaRouteNavigationSupport.relatedGotoItems(it) }
+        ArmeriaRouteNavigationSupport.annotatedRouteHandler(context)?.let { return ArmeriaRouteNavigationSupport.relatedGotoItems(it) }
         return ArmeriaRouteNavigationSupport.relatedHandlerGotoItems(context)
     }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteGotoRelatedProvider.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteGotoRelatedProvider.kt
@@ -1,0 +1,12 @@
+package com.linecorp.intellij.plugins.armeria.editor
+
+import com.intellij.navigation.GotoRelatedItem
+import com.intellij.navigation.GotoRelatedProvider
+import com.intellij.psi.PsiElement
+
+class ArmeriaRouteGotoRelatedProvider : GotoRelatedProvider() {
+    override fun getItems(context: PsiElement): List<GotoRelatedItem> {
+        ArmeriaRouteNavigationSupport.annotatedRouteMethod(context)?.let { return ArmeriaRouteNavigationSupport.relatedGotoItems(it) }
+        return ArmeriaRouteNavigationSupport.relatedHandlerGotoItems(context)
+    }
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupport.kt
@@ -1,0 +1,109 @@
+package com.linecorp.intellij.plugins.armeria.editor
+
+import com.intellij.navigation.GotoRelatedItem
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiIdentifier
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.psi.PsiNewExpression
+import com.intellij.psi.PsiReferenceExpression
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.searches.ReferencesSearch
+import com.intellij.psi.util.PsiTreeUtil
+import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteSupport
+import com.linecorp.intellij.plugins.armeria.explorer.ServiceRegistrationMethod
+import com.linecorp.intellij.plugins.armeria.message
+
+internal object ArmeriaRouteNavigationSupport {
+    fun annotatedRouteMethod(element: PsiElement): PsiMethod? {
+        val method = methodFromElement(element) ?: return null
+        return method.takeIf { ArmeriaRouteSupport.findRouteAnnotation(it) != null }
+    }
+
+    fun httpMethod(method: PsiMethod): String? = ArmeriaRouteSupport.findRouteAnnotation(method)?.second
+
+    fun routePath(method: PsiMethod): String {
+        val annotation = ArmeriaRouteSupport.findRouteAnnotation(method) ?: return ""
+        val classPrefix = ArmeriaRouteSupport.extractPrimaryPath(
+            method.containingClass?.getAnnotation(ArmeriaRouteSupport.PATH_PREFIX_ANNOTATION),
+        )
+        val path = ArmeriaRouteSupport.extractPaths(annotation.first).firstOrNull().orEmpty().ifBlank { "/" }
+        return ArmeriaRouteSupport.combinePaths(classPrefix, ArmeriaRouteSupport.normalizePath(path))
+    }
+
+    fun relatedRegistrations(method: PsiMethod): List<PsiMethodCallExpression> {
+        val serviceClass = method.containingClass ?: return emptyList()
+        return findRegistrationsForServiceClass(serviceClass, method.project)
+    }
+
+    fun relatedHandlers(context: PsiElement): List<PsiMethod> {
+        val registration = registrationCallFromContext(context) ?: return emptyList()
+        val serviceClass = resolveServiceClass(registration) ?: return emptyList()
+        return serviceClass.methods.filter { ArmeriaRouteSupport.findRouteAnnotation(it) != null }
+    }
+
+    fun relatedGotoItems(method: PsiMethod): List<GotoRelatedItem> =
+        relatedRegistrations(method).map { GotoRelatedItem(it.methodExpression, message("editor.route.gotoRelated.registration")) }
+
+    fun relatedHandlerGotoItems(context: PsiElement): List<GotoRelatedItem> =
+        relatedHandlers(context).map { handler ->
+            GotoRelatedItem(handler.nameIdentifier ?: handler, message("editor.route.gotoRelated.handler", httpMethod(handler).orEmpty(), routePath(handler)))
+        }
+
+    private fun methodFromElement(element: PsiElement): PsiMethod? = when (element) {
+        is PsiMethod -> element
+        is PsiIdentifier -> element.parent as? PsiMethod
+        else -> PsiTreeUtil.getParentOfType(element, PsiMethod::class.java)
+    }
+
+    private fun findRegistrationsForServiceClass(serviceClass: PsiClass, project: Project): List<PsiMethodCallExpression> {
+        val registrations = linkedSetOf<PsiMethodCallExpression>()
+        ReferencesSearch.search(serviceClass, GlobalSearchScope.projectScope(project)).forEach { reference ->
+            val call = PsiTreeUtil.getParentOfType(reference.element, PsiMethodCallExpression::class.java) ?: return@forEach
+            if (!isServiceRegistrationCall(call)) return@forEach
+            val resolvedClass = resolveServiceClass(call) ?: return@forEach
+            if (resolvedClass == serviceClass || serviceClass.isInheritor(resolvedClass, true)) registrations += call
+        }
+        return registrations.toList()
+    }
+
+    private fun registrationCallFromContext(context: PsiElement): PsiMethodCallExpression? {
+        if (context is PsiMethodCallExpression && isServiceRegistrationCall(context)) {
+            return context
+        }
+        return PsiTreeUtil.getParentOfType(context, PsiMethodCallExpression::class.java)
+            ?.takeIf(::isServiceRegistrationCall)
+    }
+
+    private fun isServiceRegistrationCall(call: PsiMethodCallExpression): Boolean =
+        call.methodExpression.referenceName in SERVICE_REGISTRATION_METHOD_NAMES
+
+    private fun resolveServiceClass(call: PsiMethodCallExpression): PsiClass? {
+        val args = call.argumentList.expressions
+        val expr = when (ServiceRegistrationMethod.fromMethodName(call.methodExpression.referenceName ?: return null)) {
+            ServiceRegistrationMethod.ANNOTATED_SERVICE -> args.getOrNull(1) ?: args.getOrNull(0)
+            ServiceRegistrationMethod.SERVICE, ServiceRegistrationMethod.SERVICE_UNDER -> args.getOrNull(1)
+            else -> null
+        } ?: return null
+        return when (expr) {
+            is PsiNewExpression -> expr.classReference?.resolve() as? PsiClass
+            is PsiReferenceExpression -> when (val resolved = expr.resolve()) {
+                is PsiClass -> resolved
+                is PsiMethod -> resolved.containingClass
+                else -> null
+            }
+            is PsiExpression -> (expr.type as? PsiClassType)?.resolve()
+            else -> null
+        }
+    }
+
+    private val SERVICE_REGISTRATION_METHOD_NAMES = setOf(
+        ServiceRegistrationMethod.SERVICE.methodName,
+        ServiceRegistrationMethod.SERVICE_UNDER.methodName,
+        ServiceRegistrationMethod.ANNOTATED_SERVICE.methodName,
+    )
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupport.kt
@@ -2,31 +2,97 @@ package com.linecorp.intellij.plugins.armeria.editor
 
 import com.intellij.navigation.GotoRelatedItem
 import com.intellij.openapi.project.Project
+import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiClass
-import com.intellij.psi.PsiClassType
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiIdentifier
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiMethodCallExpression
-import com.intellij.psi.PsiNewExpression
-import com.intellij.psi.PsiReferenceExpression
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.PsiTreeUtil
+import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaKotlinRouteCollector
+import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteSupport
+import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteTargetExtractor
 import com.linecorp.intellij.plugins.armeria.explorer.ServiceRegistrationMethod
+import com.linecorp.intellij.plugins.armeria.inspection.ArmeriaKotlinMethodRoute
 import com.linecorp.intellij.plugins.armeria.message
+import org.jetbrains.kotlin.asJava.toLightClass
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtConstructor
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtValueArgument
 
 internal object ArmeriaRouteNavigationSupport {
+    fun annotatedRouteHandler(element: PsiElement): PsiElement? {
+        annotatedRouteMethod(element)?.let { return it }
+        annotatedKotlinRouteFunction(element)?.let { return it }
+        return null
+    }
+
     fun annotatedRouteMethod(element: PsiElement): PsiMethod? {
         val method = methodFromElement(element) ?: return null
         return method.takeIf { ArmeriaRouteSupport.findRouteAnnotation(it) != null }
     }
 
-    fun httpMethod(method: PsiMethod): String? = ArmeriaRouteSupport.findRouteAnnotation(method)?.second
+    fun annotatedKotlinRouteFunction(element: PsiElement): KtNamedFunction? {
+        val function = kotlinFunctionFromElement(element) ?: return null
+        return function.takeIf { ArmeriaKotlinMethodRoute.from(it) != null }
+    }
 
-    fun routePath(method: PsiMethod): String {
+    fun httpMethod(handler: PsiElement): String? = when (handler) {
+        is PsiMethod -> ArmeriaRouteSupport.findRouteAnnotation(handler)?.second
+        is KtNamedFunction -> ArmeriaKotlinMethodRoute.from(handler)?.httpMethod
+        else -> null
+    }
+
+    fun routePath(handler: PsiElement): String = when (handler) {
+        is PsiMethod -> routePathForJavaMethod(handler)
+        is KtNamedFunction -> ArmeriaKotlinMethodRoute.from(handler)?.paths?.firstOrNull().orEmpty()
+        else -> ""
+    }
+
+    fun relatedRegistrations(handler: PsiElement): List<PsiElement> = when (handler) {
+        is PsiMethod -> findRegistrationsForServiceClass(handler.containingClass ?: return emptyList(), handler.project)
+        is KtNamedFunction -> {
+            val serviceClass = PsiTreeUtil.getParentOfType(handler, KtClass::class.java)?.toLightClass() ?: return emptyList()
+            findRegistrationsForServiceClass(serviceClass, handler.project)
+        }
+        else -> emptyList()
+    }
+
+    fun relatedHandlers(context: PsiElement): List<PsiElement> {
+        javaRegistrationCallFromContext(context)?.let { call ->
+            val serviceClass = resolveServiceClassFromJavaCall(call) ?: return emptyList()
+            return annotatedHandlersInClass(serviceClass)
+        }
+        kotlinRegistrationCallFromContext(context)?.let { call ->
+            val serviceClass = resolveServiceClassFromKotlinCall(call) ?: return emptyList()
+            return annotatedHandlersInClass(serviceClass)
+        }
+        return emptyList()
+    }
+
+    fun relatedGotoItems(handler: PsiElement): List<GotoRelatedItem> =
+        relatedRegistrations(handler).map { registration ->
+            GotoRelatedItem(registrationNavigationElement(registration), message("editor.route.gotoRelated.registration"))
+        }
+
+    fun relatedHandlerGotoItems(context: PsiElement): List<GotoRelatedItem> =
+        relatedHandlers(context).map { handler ->
+            GotoRelatedItem(
+                handlerNavigationElement(handler),
+                message("editor.route.gotoRelated.handler", httpMethod(handler).orEmpty(), routePath(handler)),
+            )
+        }
+
+    private fun routePathForJavaMethod(method: PsiMethod): String {
         val annotation = ArmeriaRouteSupport.findRouteAnnotation(method) ?: return ""
         val classPrefix = ArmeriaRouteSupport.extractPrimaryPath(
             method.containingClass?.getAnnotation(ArmeriaRouteSupport.PATH_PREFIX_ANNOTATION),
@@ -35,75 +101,239 @@ internal object ArmeriaRouteNavigationSupport {
         return ArmeriaRouteSupport.combinePaths(classPrefix, ArmeriaRouteSupport.normalizePath(path))
     }
 
-    fun relatedRegistrations(method: PsiMethod): List<PsiMethodCallExpression> {
-        val serviceClass = method.containingClass ?: return emptyList()
-        return findRegistrationsForServiceClass(serviceClass, method.project)
-    }
-
-    fun relatedHandlers(context: PsiElement): List<PsiMethod> {
-        val registration = registrationCallFromContext(context) ?: return emptyList()
-        val serviceClass = resolveServiceClass(registration) ?: return emptyList()
-        return serviceClass.methods.filter { ArmeriaRouteSupport.findRouteAnnotation(it) != null }
-    }
-
-    fun relatedGotoItems(method: PsiMethod): List<GotoRelatedItem> =
-        relatedRegistrations(method).map { GotoRelatedItem(it.methodExpression, message("editor.route.gotoRelated.registration")) }
-
-    fun relatedHandlerGotoItems(context: PsiElement): List<GotoRelatedItem> =
-        relatedHandlers(context).map { handler ->
-            GotoRelatedItem(handler.nameIdentifier ?: handler, message("editor.route.gotoRelated.handler", httpMethod(handler).orEmpty(), routePath(handler)))
-        }
-
     private fun methodFromElement(element: PsiElement): PsiMethod? = when (element) {
         is PsiMethod -> element
         is PsiIdentifier -> element.parent as? PsiMethod
         else -> PsiTreeUtil.getParentOfType(element, PsiMethod::class.java)
     }
 
-    private fun findRegistrationsForServiceClass(serviceClass: PsiClass, project: Project): List<PsiMethodCallExpression> {
-        val registrations = linkedSetOf<PsiMethodCallExpression>()
-        ReferencesSearch.search(serviceClass, GlobalSearchScope.projectScope(project)).forEach { reference ->
-            val call = PsiTreeUtil.getParentOfType(reference.element, PsiMethodCallExpression::class.java) ?: return@forEach
-            if (!isServiceRegistrationCall(call)) return@forEach
-            val resolvedClass = resolveServiceClass(call) ?: return@forEach
-            if (resolvedClass == serviceClass || serviceClass.isInheritor(resolvedClass, true)) registrations += call
+    private fun kotlinFunctionFromElement(element: PsiElement): KtNamedFunction? = when (element) {
+        is KtNamedFunction -> element
+        else -> PsiTreeUtil.getParentOfType(element, KtNamedFunction::class.java, false)
+    }
+
+    private fun findRegistrationsForServiceClass(serviceClass: PsiClass, project: Project): List<PsiElement> {
+        val registrations = linkedSetOf<PsiElement>()
+        val scope = GlobalSearchScope.projectScope(project)
+        val searchTargets = mutableListOf<PsiElement>()
+        searchTargets += serviceClass
+        val ktClass = serviceClass.originalElement as? KtClass
+        if (ktClass != null) {
+            searchTargets += ktClass
+            ktClass.primaryConstructor?.let { searchTargets += it }
+        }
+        for (target in searchTargets) {
+            collectRegistrationsFromReferences(target, serviceClass, registrations)
         }
         return registrations.toList()
     }
 
-    private fun registrationCallFromContext(context: PsiElement): PsiMethodCallExpression? {
-        if (context is PsiMethodCallExpression && isServiceRegistrationCall(context)) {
+    private fun collectRegistrationsFromReferences(
+        target: PsiElement,
+        serviceClass: PsiClass,
+        registrations: MutableSet<PsiElement>,
+    ) {
+        ReferencesSearch.search(target, GlobalSearchScope.projectScope(target.project)).forEach { reference ->
+            val javaCall = PsiTreeUtil.getParentOfType(reference.element, PsiMethodCallExpression::class.java)
+            if (javaCall != null && isJavaServiceRegistrationCall(javaCall)) {
+                val resolvedClass = resolveServiceClassFromJavaCall(javaCall) ?: return@forEach
+                if (serviceTypesMatch(serviceClass, resolvedClass)) {
+                    registrations += javaCall
+                }
+                return@forEach
+            }
+            val kotlinCall = kotlinRegistrationCallFromReference(reference.element)
+            if (kotlinCall != null) {
+                val resolvedClass = resolveServiceClassFromKotlinCall(kotlinCall) ?: return@forEach
+                if (serviceTypesMatch(serviceClass, resolvedClass)) {
+                    registrations += kotlinCall
+                }
+            }
+        }
+    }
+
+    private fun kotlinRegistrationCallFromReference(start: PsiElement): KtCallExpression? {
+        var current: PsiElement? = start
+        while (current != null) {
+            val call = PsiTreeUtil.getParentOfType(current, KtCallExpression::class.java, false)
+                ?: break
+            if (isKotlinServiceRegistrationCall(call)) {
+                return call
+            }
+            current = call.parent
+        }
+        return null
+    }
+
+    private fun javaRegistrationCallFromContext(context: PsiElement): PsiMethodCallExpression? {
+        if (context is PsiMethodCallExpression && isJavaServiceRegistrationCall(context)) {
             return context
         }
         return PsiTreeUtil.getParentOfType(context, PsiMethodCallExpression::class.java)
-            ?.takeIf(::isServiceRegistrationCall)
+            ?.takeIf(::isJavaServiceRegistrationCall)
     }
 
-    private fun isServiceRegistrationCall(call: PsiMethodCallExpression): Boolean =
-        call.methodExpression.referenceName in SERVICE_REGISTRATION_METHOD_NAMES
+    private fun kotlinRegistrationCallFromContext(context: PsiElement): KtCallExpression? {
+        if (context is KtCallExpression && isKotlinServiceRegistrationCall(context)) {
+            return context
+        }
+        return PsiTreeUtil.getParentOfType(context, KtCallExpression::class.java)
+            ?.takeIf(::isKotlinServiceRegistrationCall)
+    }
 
-    private fun resolveServiceClass(call: PsiMethodCallExpression): PsiClass? {
+    private fun isJavaServiceRegistrationCall(call: PsiMethodCallExpression): Boolean {
+        val methodName = call.methodExpression.referenceName ?: return false
+        if (methodName !in SERVICE_REGISTRATION_METHOD_NAMES) {
+            return false
+        }
+        return ArmeriaRouteCollector.looksLikeArmeriaBuilderCall(call)
+    }
+
+    private fun isKotlinServiceRegistrationCall(call: KtCallExpression): Boolean {
+        val methodName = kotlinCallName(call) ?: return false
+        if (methodName !in SERVICE_REGISTRATION_METHOD_NAMES) {
+            return false
+        }
+        return ArmeriaKotlinRouteCollector.looksLikeArmeriaBuilderCall(call)
+    }
+
+    private fun resolveServiceClassFromJavaCall(call: PsiMethodCallExpression): PsiClass? {
+        val implementation = javaServiceImplementationExpression(call) ?: return null
+        return resolveServiceClassFromImplementation(implementation, call.project)
+    }
+
+    private fun resolveServiceClassFromKotlinCall(call: KtCallExpression): PsiClass? {
+        val implementation = kotlinServiceImplementationExpression(call) ?: return null
+        return resolveServiceClassFromImplementation(implementation, call.project)
+    }
+
+    private fun resolveServiceClassFromImplementation(expression: PsiElement, project: Project): PsiClass? {
+        if (expression is PsiExpression) {
+            val target = ArmeriaRouteTargetExtractor.extractTarget(expression)
+            return findClassByTarget(project, target)
+        }
+        if (expression is KtExpression) {
+            return resolveKotlinImplementationClass(expression, project)
+        }
+        return null
+    }
+
+    private fun resolveKotlinImplementationClass(expression: KtExpression, project: Project): PsiClass? {
+        when (expression) {
+            is KtCallExpression -> {
+                val reference = when (val callee = expression.calleeExpression) {
+                    is KtNameReferenceExpression -> callee
+                    is KtDotQualifiedExpression -> callee.selectorExpression as? KtNameReferenceExpression
+                    else -> null
+                }
+                classFromResolved(reference?.references?.firstOrNull()?.resolve(), project)?.let { return it }
+            }
+            is KtNameReferenceExpression -> {
+                classFromResolved(expression.references.firstOrNull()?.resolve(), project)?.let { return it }
+            }
+        }
+        return (expression as? PsiExpression)?.let {
+            findClassByTarget(project, ArmeriaRouteTargetExtractor.extractTarget(it))
+        }
+    }
+
+    private fun classFromResolved(resolved: PsiElement?, project: Project): PsiClass? = when (resolved) {
+        is PsiClass -> resolved
+        is PsiMethod -> resolved.takeIf { it.isConstructor }?.containingClass
+        is KtClass -> resolved.toLightClass()
+        is KtConstructor<*> -> resolved.getContainingClassOrObject().toLightClass()
+        else -> null
+    }
+
+    private fun findClassByTarget(project: Project, target: String): PsiClass? {
+        val facade = JavaPsiFacade.getInstance(project)
+        val scope = GlobalSearchScope.projectScope(project)
+        facade.findClass(target, scope)?.let { return it }
+        if (!target.contains('.')) {
+            return facade.findClass("example.$target", scope)
+        }
+        return null
+    }
+
+    private fun annotatedHandlersInClass(serviceClass: PsiClass): List<PsiElement> {
+        val handlers = linkedSetOf<PsiElement>()
+        var current: PsiClass? = serviceClass
+        while (current != null) {
+            for (method in current.allMethods) {
+                when {
+                    ArmeriaRouteSupport.findRouteAnnotation(method) != null -> handlers += method
+                    else -> (method.originalElement as? KtNamedFunction)
+                        ?.takeIf { ArmeriaKotlinMethodRoute.from(it) != null }
+                        ?.let { handlers += it }
+                }
+            }
+            current = current.superClass
+        }
+        return handlers.toList()
+    }
+
+    private fun serviceTypesMatch(first: PsiClass, second: PsiClass): Boolean =
+        first == second || first.isInheritor(second, true) || second.isInheritor(first, true)
+
+    private fun javaServiceImplementationExpression(call: PsiMethodCallExpression): PsiExpression? {
         val args = call.argumentList.expressions
-        val expr = when (ServiceRegistrationMethod.fromMethodName(call.methodExpression.referenceName ?: return null)) {
+        return when (ServiceRegistrationMethod.fromMethodName(call.methodExpression.referenceName ?: return null)) {
             ServiceRegistrationMethod.ANNOTATED_SERVICE -> args.getOrNull(1) ?: args.getOrNull(0)
             ServiceRegistrationMethod.SERVICE, ServiceRegistrationMethod.SERVICE_UNDER -> args.getOrNull(1)
-            else -> null
-        } ?: return null
-        return when (expr) {
-            is PsiNewExpression -> expr.classReference?.resolve() as? PsiClass
-            is PsiReferenceExpression -> when (val resolved = expr.resolve()) {
-                is PsiClass -> resolved
-                is PsiMethod -> resolved.containingClass
-                else -> null
-            }
-            is PsiExpression -> (expr.type as? PsiClassType)?.resolve()
             else -> null
         }
     }
 
-    private val SERVICE_REGISTRATION_METHOD_NAMES = setOf(
-        ServiceRegistrationMethod.SERVICE.methodName,
-        ServiceRegistrationMethod.SERVICE_UNDER.methodName,
-        ServiceRegistrationMethod.ANNOTATED_SERVICE.methodName,
-    )
+    private fun kotlinServiceImplementationExpression(call: KtCallExpression): KtExpression? {
+        val arguments = call.valueArguments
+        return when (ServiceRegistrationMethod.fromMethodName(kotlinCallName(call) ?: return null)) {
+            ServiceRegistrationMethod.ANNOTATED_SERVICE ->
+                findKotlinArgumentExpression(arguments, "service", 1)
+                    ?: findKotlinArgumentExpression(arguments, "service", 0)
+            ServiceRegistrationMethod.SERVICE, ServiceRegistrationMethod.SERVICE_UNDER ->
+                findKotlinArgumentExpression(arguments, "service", 1)
+            else -> null
+        }
+    }
+
+    private fun findKotlinArgumentExpression(
+        arguments: List<KtValueArgument>,
+        parameterName: String,
+        positionalIndex: Int,
+    ): KtExpression? {
+        arguments.firstOrNull { it.getArgumentName()?.asName?.identifier == parameterName }
+            ?.getArgumentExpression()
+            ?.let { return it }
+        return arguments.getOrNull(positionalIndex)?.getArgumentExpression()
+    }
+
+    private fun kotlinCallName(call: KtCallExpression): String? {
+        return when (val callee = call.calleeExpression) {
+            is KtDotQualifiedExpression -> callee.selectorExpression?.text
+            is KtNameReferenceExpression -> callee.text
+            else -> callee?.text
+        }
+    }
+
+    private fun registrationNavigationElement(registration: PsiElement): PsiElement = when (registration) {
+        is PsiMethodCallExpression -> registration.methodExpression
+        is KtCallExpression -> kotlinCallReferenceNameElement(registration) ?: registration
+        else -> registration
+    }
+
+    private fun handlerNavigationElement(handler: PsiElement): PsiElement = when (handler) {
+        is PsiMethod -> handler.nameIdentifier ?: handler
+        is KtNamedFunction -> handler.nameIdentifier ?: handler
+        else -> handler
+    }
+
+    private fun kotlinCallReferenceNameElement(call: KtCallExpression): PsiElement? {
+        return when (val callee = call.calleeExpression) {
+            is KtDotQualifiedExpression -> callee.selectorExpression
+            is KtNameReferenceExpression -> callee
+            else -> null
+        }
+    }
+
+    private val SERVICE_REGISTRATION_METHOD_NAMES = ServiceRegistrationMethod.METHOD_NAMES
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupport.kt
@@ -1,6 +1,10 @@
 package com.linecorp.intellij.plugins.armeria.editor
 
+import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.navigation.GotoRelatedItem
+import com.intellij.openapi.extensions.PluginId
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.IndexNotReadyException
 import com.intellij.openapi.project.Project
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiClass
@@ -15,28 +19,22 @@ import com.intellij.psi.PsiVariable
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.PsiTreeUtil
-import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaKotlinRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteSupport
 import com.linecorp.intellij.plugins.armeria.explorer.extractArmeriaRouteTarget
 import com.linecorp.intellij.plugins.armeria.explorer.ServiceRegistrationMethod
-import com.linecorp.intellij.plugins.armeria.inspection.ArmeriaKotlinMethodRoute
 import com.linecorp.intellij.plugins.armeria.message
-import org.jetbrains.kotlin.asJava.toLightClass
-import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.psi.KtClass
-import org.jetbrains.kotlin.psi.KtConstructor
-import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
-import org.jetbrains.kotlin.psi.KtExpression
-import org.jetbrains.kotlin.psi.KtNameReferenceExpression
-import org.jetbrains.kotlin.psi.KtNamedFunction
-import org.jetbrains.kotlin.psi.KtProperty
-import org.jetbrains.kotlin.psi.KtValueArgument
 
 internal object ArmeriaRouteNavigationSupport {
+    private val KOTLIN_PLUGIN_ID = PluginId.getId("org.jetbrains.kotlin")
+
+    val serviceRegistrationMethodNames: Set<String> = ServiceRegistrationMethod.CORE_METHOD_NAMES
+
     fun annotatedRouteHandler(element: PsiElement): PsiElement? {
         annotatedRouteMethod(element)?.let { return it }
-        annotatedKotlinRouteFunction(element)?.let { return it }
+        if (isKotlinPluginAvailable()) {
+            return ArmeriaKotlinRouteNavigationSupport.annotatedRouteHandler(element)
+        }
         return null
     }
 
@@ -45,47 +43,57 @@ internal object ArmeriaRouteNavigationSupport {
         return method.takeIf { ArmeriaRouteSupport.findRouteAnnotation(it) != null }
     }
 
-    fun annotatedKotlinRouteFunction(element: PsiElement): KtNamedFunction? {
-        val function = kotlinFunctionFromElement(element) ?: return null
-        return function.takeIf { ArmeriaKotlinMethodRoute.from(it) != null }
+    fun annotatedKotlinRouteFunction(element: PsiElement): PsiElement? {
+        if (!isKotlinPluginAvailable()) {
+            return null
+        }
+        return ArmeriaKotlinRouteNavigationSupport.annotatedKotlinRouteFunction(element)
     }
 
     fun httpMethod(handler: PsiElement): String? = when (handler) {
         is PsiMethod -> ArmeriaRouteSupport.findRouteAnnotation(handler)?.second
-        is KtNamedFunction -> ArmeriaKotlinMethodRoute.from(handler)?.httpMethod
-        else -> null
+        else -> if (isKotlinPluginAvailable()) ArmeriaKotlinRouteNavigationSupport.httpMethod(handler) else null
     }
 
     fun routePath(handler: PsiElement): String = when (handler) {
         is PsiMethod -> routePathsForJavaMethod(handler).joinToString(", ")
-        is KtNamedFunction -> ArmeriaKotlinMethodRoute.from(handler)?.paths?.joinToString(", ").orEmpty()
-        else -> ""
+        else -> if (isKotlinPluginAvailable()) ArmeriaKotlinRouteNavigationSupport.routePath(handler) else ""
     }
 
-    fun relatedRegistrations(handler: PsiElement): List<PsiElement> = when (handler) {
-        is PsiMethod -> findRegistrationsForServiceClass(handler.containingClass ?: return emptyList(), handler.project)
-        is KtNamedFunction -> {
-            val serviceClass = PsiTreeUtil.getParentOfType(handler, KtClass::class.java)?.toLightClass() ?: return emptyList()
-            findRegistrationsForServiceClass(serviceClass, handler.project)
+    fun relatedRegistrations(handler: PsiElement): List<PsiElement> {
+        if (isIndexUnavailable(handler.project)) {
+            return emptyList()
         }
-        else -> emptyList()
+        return when (handler) {
+            is PsiMethod -> findRegistrationsForServiceClass(handler.containingClass ?: return emptyList(), handler.project)
+            else -> if (isKotlinPluginAvailable()) {
+                ArmeriaKotlinRouteNavigationSupport.relatedRegistrations(handler)
+            } else {
+                emptyList()
+            }
+        }
     }
 
     fun relatedHandlers(context: PsiElement): List<PsiElement> {
+        if (isIndexUnavailable(context.project)) {
+            return emptyList()
+        }
         javaRegistrationCallFromContext(context)?.let { call ->
             val serviceClass = resolveServiceClassFromJavaCall(call) ?: return emptyList()
             return annotatedHandlersInClass(serviceClass)
         }
-        kotlinRegistrationCallFromContext(context)?.let { call ->
-            val serviceClass = resolveServiceClassFromKotlinCall(call) ?: return emptyList()
-            return annotatedHandlersInClass(serviceClass)
+        if (isKotlinPluginAvailable()) {
+            return ArmeriaKotlinRouteNavigationSupport.relatedHandlers(context)
         }
         return emptyList()
     }
 
     fun relatedGotoItems(handler: PsiElement): List<GotoRelatedItem> =
         relatedRegistrations(handler).map { registration ->
-            GotoRelatedItem(registrationNavigationElement(registration), message("editor.route.gotoRelated.registration"))
+            GotoRelatedItem(
+                registrationNavigationElement(registration),
+                message("editor.route.gotoRelated.registration"),
+            )
         }
 
     fun relatedHandlerGotoItems(context: PsiElement): List<GotoRelatedItem> =
@@ -95,6 +103,59 @@ internal object ArmeriaRouteNavigationSupport {
                 message("editor.route.gotoRelated.handler", httpMethod(handler).orEmpty(), routePath(handler)),
             )
         }
+
+    fun findRegistrationsForServiceClass(serviceClass: PsiClass, project: Project): List<PsiElement> {
+        if (isIndexUnavailable(project)) {
+            return emptyList()
+        }
+        val registrations = linkedSetOf<PsiElement>()
+        val scope = GlobalSearchScope.projectScope(project)
+        val builderClass = JavaPsiFacade.getInstance(project)
+            .findClass(ArmeriaRouteSupport.SERVER_BUILDER_CLASS, scope)
+            ?: return emptyList()
+        try {
+            for (methodName in INDEXED_REGISTRATION_METHOD_NAMES) {
+                for (method in builderClass.findMethodsByName(methodName, false)) {
+                    ReferencesSearch.search(method, scope).forEach { reference ->
+                        collectRegistrationFromReference(reference.element, serviceClass, registrations)
+                    }
+                }
+            }
+        } catch (_: IndexNotReadyException) {
+            return emptyList()
+        }
+        return registrations.toList()
+    }
+
+    fun annotatedHandlersInClass(serviceClass: PsiClass): List<PsiElement> {
+        val handlers = linkedSetOf<PsiElement>()
+        var current: PsiClass? = serviceClass
+        while (current != null) {
+            for (method in current.methods) {
+                if (isKotlinPluginAvailable()) {
+                    ArmeriaKotlinRouteNavigationSupport.annotatedHandlerFromMethod(method)?.let {
+                        handlers += it
+                        continue
+                    }
+                }
+                if (ArmeriaRouteSupport.findRouteAnnotation(method) != null) {
+                    handlers += method
+                }
+            }
+            current = current.superClass
+        }
+        return handlers.toList()
+    }
+
+    fun serviceTypesMatch(first: PsiClass, second: PsiClass): Boolean =
+        first == second || first.isInheritor(second, true) || second.isInheritor(first, true)
+
+    fun findClassByFqn(project: Project, target: String): PsiClass? {
+        if (target.isBlank() || !target.contains('.')) {
+            return null
+        }
+        return JavaPsiFacade.getInstance(project).findClass(target, GlobalSearchScope.projectScope(project))
+    }
 
     private fun routePathsForJavaMethod(method: PsiMethod): List<String> {
         val annotation = ArmeriaRouteSupport.findRouteAnnotation(method) ?: return emptyList()
@@ -115,27 +176,6 @@ internal object ArmeriaRouteNavigationSupport {
         else -> PsiTreeUtil.getParentOfType(element, PsiMethod::class.java)
     }
 
-    private fun kotlinFunctionFromElement(element: PsiElement): KtNamedFunction? = when (element) {
-        is KtNamedFunction -> element
-        else -> PsiTreeUtil.getParentOfType(element, KtNamedFunction::class.java, false)
-    }
-
-    private fun findRegistrationsForServiceClass(serviceClass: PsiClass, project: Project): List<PsiElement> {
-        val registrations = linkedSetOf<PsiElement>()
-        val scope = GlobalSearchScope.projectScope(project)
-        val builderClass = JavaPsiFacade.getInstance(project)
-            .findClass(ArmeriaRouteSupport.SERVER_BUILDER_CLASS, scope)
-            ?: return emptyList()
-        for (methodName in INDEXED_REGISTRATION_METHOD_NAMES) {
-            for (method in builderClass.findMethodsByName(methodName, false)) {
-                ReferencesSearch.search(method, scope).forEach { reference ->
-                    collectRegistrationFromReference(reference.element, serviceClass, registrations)
-                }
-            }
-        }
-        return registrations.toList()
-    }
-
     private fun collectRegistrationFromReference(
         element: PsiElement,
         serviceClass: PsiClass,
@@ -149,26 +189,9 @@ internal object ArmeriaRouteNavigationSupport {
             }
             return
         }
-        val kotlinCall = kotlinRegistrationCallFromReference(element)
-        if (kotlinCall != null) {
-            val resolvedClass = resolveServiceClassFromKotlinCall(kotlinCall) ?: return
-            if (serviceTypesMatch(serviceClass, resolvedClass)) {
-                registrations += kotlinCall
-            }
+        if (isKotlinPluginAvailable()) {
+            ArmeriaKotlinRouteNavigationSupport.collectRegistrationFromReference(element, serviceClass, registrations)
         }
-    }
-
-    private fun kotlinRegistrationCallFromReference(start: PsiElement): KtCallExpression? {
-        var current: PsiElement? = start
-        while (current != null) {
-            val call = PsiTreeUtil.getParentOfType(current, KtCallExpression::class.java, false)
-                ?: break
-            if (isKotlinServiceRegistrationCall(call)) {
-                return call
-            }
-            current = call.parent
-        }
-        return null
     }
 
     private fun javaRegistrationCallFromContext(context: PsiElement): PsiMethodCallExpression? {
@@ -179,28 +202,12 @@ internal object ArmeriaRouteNavigationSupport {
             ?.takeIf(::isJavaServiceRegistrationCall)
     }
 
-    private fun kotlinRegistrationCallFromContext(context: PsiElement): KtCallExpression? {
-        if (context is KtCallExpression && isKotlinServiceRegistrationCall(context)) {
-            return context
-        }
-        return PsiTreeUtil.getParentOfType(context, KtCallExpression::class.java)
-            ?.takeIf(::isKotlinServiceRegistrationCall)
-    }
-
     private fun isJavaServiceRegistrationCall(call: PsiMethodCallExpression): Boolean {
         val methodName = call.methodExpression.referenceName ?: return false
-        if (methodName !in SERVICE_REGISTRATION_METHOD_NAMES) {
+        if (methodName !in serviceRegistrationMethodNames) {
             return false
         }
         return ArmeriaRouteCollector.looksLikeArmeriaBuilderCall(call)
-    }
-
-    private fun isKotlinServiceRegistrationCall(call: KtCallExpression): Boolean {
-        val methodName = kotlinCallName(call) ?: return false
-        if (methodName !in SERVICE_REGISTRATION_METHOD_NAMES) {
-            return false
-        }
-        return ArmeriaKotlinRouteCollector.looksLikeArmeriaBuilderCall(call)
     }
 
     private fun resolveServiceClassFromJavaCall(call: PsiMethodCallExpression): PsiClass? {
@@ -208,92 +215,37 @@ internal object ArmeriaRouteNavigationSupport {
         return resolveServiceClassFromImplementation(implementation, call.project)
     }
 
-    private fun resolveServiceClassFromKotlinCall(call: KtCallExpression): PsiClass? {
-        val implementation = kotlinServiceImplementationExpression(call) ?: return null
-        return resolveServiceClassFromImplementation(implementation, call.project)
-    }
-
     private fun resolveServiceClassFromImplementation(expression: PsiElement, project: Project): PsiClass? {
         resolvedClassFromReference(expression)?.let { return it }
-        when (expression) {
-            is KtCallExpression -> {
-                val reference = when (val callee = expression.calleeExpression) {
-                    is KtNameReferenceExpression -> callee
-                    is KtDotQualifiedExpression -> callee.selectorExpression as? KtNameReferenceExpression
-                    else -> null
-                }
-                classFromResolved(reference?.references?.firstOrNull()?.resolve())?.let { return it }
-            }
+        if (isKotlinPluginAvailable()) {
+            ArmeriaKotlinRouteNavigationSupport.resolveServiceClassFromImplementation(expression)?.let { return it }
         }
         return (expression as? PsiExpression)?.let { psiExpression ->
             findClassByFqn(project, extractArmeriaRouteTarget(psiExpression))
         }
     }
 
-    private fun resolvedClassFromReference(expression: PsiElement): PsiClass? = when (expression) {
-        is PsiReferenceExpression -> classFromResolved(expression.resolve())
-        is KtNameReferenceExpression -> classFromResolved(expression.references.firstOrNull()?.resolve())
-        else -> null
+    private fun resolvedClassFromReference(expression: PsiElement): PsiClass? {
+        when (expression) {
+            is PsiReferenceExpression -> return classFromResolved(expression.resolve())
+        }
+        if (isKotlinPluginAvailable()) {
+            return ArmeriaKotlinRouteNavigationSupport.resolvedClassFromReference(expression)
+        }
+        return null
     }
 
-    private fun classFromResolved(resolved: PsiElement?): PsiClass? = when (resolved) {
-        is PsiClass -> resolved
-        is PsiMethod -> resolved.takeIf { it.isConstructor }?.containingClass
-        is PsiVariable -> (resolved.type as? PsiClassType)?.resolve()
-        is KtClass -> resolved.toLightClass()
-        is KtConstructor<*> -> resolved.getContainingClassOrObject().toLightClass()
-        is KtProperty -> classFromKotlinProperty(resolved)
-        else -> null
+    private fun classFromResolved(resolved: PsiElement?): PsiClass? {
+        when (resolved) {
+            is PsiClass -> return resolved
+            is PsiMethod -> return resolved.takeIf { it.isConstructor }?.containingClass
+            is PsiVariable -> return (resolved.type as? PsiClassType)?.resolve()
+        }
+        if (isKotlinPluginAvailable()) {
+            return ArmeriaKotlinRouteNavigationSupport.classFromResolved(resolved)
+        }
+        return null
     }
-
-    private fun classFromKotlinProperty(property: KtProperty): PsiClass? {
-        property.typeReference?.references?.firstOrNull()?.resolve()?.let { typeResolved ->
-            when (typeResolved) {
-                is PsiClass -> return typeResolved
-                is KtClass -> return typeResolved.toLightClass()
-            }
-        }
-        val initializer = property.initializer ?: return null
-        if (initializer is KtCallExpression) {
-            val reference = when (val callee = initializer.calleeExpression) {
-                is KtNameReferenceExpression -> callee
-                is KtDotQualifiedExpression -> callee.selectorExpression as? KtNameReferenceExpression
-                else -> null
-            }
-            classFromResolved(reference?.references?.firstOrNull()?.resolve())?.let { return it }
-        }
-        return (initializer as? PsiExpression)?.let { expression ->
-            findClassByFqn(property.project, extractArmeriaRouteTarget(expression))
-        }
-    }
-
-    private fun findClassByFqn(project: Project, target: String): PsiClass? {
-        if (target.isBlank() || !target.contains('.')) {
-            return null
-        }
-        return JavaPsiFacade.getInstance(project).findClass(target, GlobalSearchScope.projectScope(project))
-    }
-
-    private fun annotatedHandlersInClass(serviceClass: PsiClass): List<PsiElement> {
-        val handlers = linkedSetOf<PsiElement>()
-        var current: PsiClass? = serviceClass
-        while (current != null) {
-            for (method in current.allMethods) {
-                val kotlinFunction = method.originalElement as? KtNamedFunction
-                when {
-                    kotlinFunction != null && ArmeriaKotlinMethodRoute.from(kotlinFunction) != null ->
-                        handlers += kotlinFunction
-                    ArmeriaRouteSupport.findRouteAnnotation(method) != null ->
-                        handlers += method
-                }
-            }
-            current = current.superClass
-        }
-        return handlers.toList()
-    }
-
-    private fun serviceTypesMatch(first: PsiClass, second: PsiClass): Boolean =
-        first == second || first.isInheritor(second, true) || second.isInheritor(first, true)
 
     private fun javaServiceImplementationExpression(call: PsiMethodCallExpression): PsiExpression? {
         val args = call.argumentList.expressions
@@ -304,58 +256,27 @@ internal object ArmeriaRouteNavigationSupport {
         }
     }
 
-    private fun kotlinServiceImplementationExpression(call: KtCallExpression): KtExpression? {
-        val arguments = call.valueArguments
-        return when (ServiceRegistrationMethod.fromMethodName(kotlinCallName(call) ?: return null)) {
-            ServiceRegistrationMethod.ANNOTATED_SERVICE ->
-                findKotlinArgumentExpression(arguments, "service", 1)
-                    ?: findKotlinArgumentExpression(arguments, "service", 0)
-            ServiceRegistrationMethod.SERVICE, ServiceRegistrationMethod.SERVICE_UNDER ->
-                findKotlinArgumentExpression(arguments, "service", 1)
-            else -> null
-        }
-    }
-
-    private fun findKotlinArgumentExpression(
-        arguments: List<KtValueArgument>,
-        parameterName: String,
-        positionalIndex: Int,
-    ): KtExpression? {
-        arguments.firstOrNull { it.getArgumentName()?.asName?.identifier == parameterName }
-            ?.getArgumentExpression()
-            ?.let { return it }
-        return arguments.getOrNull(positionalIndex)?.getArgumentExpression()
-    }
-
-    private fun kotlinCallName(call: KtCallExpression): String? {
-        return when (val callee = call.calleeExpression) {
-            is KtDotQualifiedExpression -> callee.selectorExpression?.text
-            is KtNameReferenceExpression -> callee.text
-            else -> callee?.text
-        }
-    }
-
     private fun registrationNavigationElement(registration: PsiElement): PsiElement = when (registration) {
         is PsiMethodCallExpression -> registration.methodExpression
-        is KtCallExpression -> kotlinCallReferenceNameElement(registration) ?: registration
-        else -> registration
+        else -> if (isKotlinPluginAvailable()) {
+            ArmeriaKotlinRouteNavigationSupport.registrationNavigationElement(registration)
+        } else {
+            registration
+        }
     }
 
     private fun handlerNavigationElement(handler: PsiElement): PsiElement = when (handler) {
         is PsiMethod -> handler.nameIdentifier ?: handler
-        is KtNamedFunction -> handler.nameIdentifier ?: handler
-        else -> handler
-    }
-
-    private fun kotlinCallReferenceNameElement(call: KtCallExpression): PsiElement? {
-        return when (val callee = call.calleeExpression) {
-            is KtDotQualifiedExpression -> callee.selectorExpression
-            is KtNameReferenceExpression -> callee
-            else -> null
+        else -> if (isKotlinPluginAvailable()) {
+            ArmeriaKotlinRouteNavigationSupport.handlerNavigationElement(handler)
+        } else {
+            handler
         }
     }
 
-    private val SERVICE_REGISTRATION_METHOD_NAMES = ServiceRegistrationMethod.CORE_METHOD_NAMES
+    private fun isKotlinPluginAvailable(): Boolean = PluginManagerCore.isLoaded(KOTLIN_PLUGIN_ID)
+
+    private fun isIndexUnavailable(project: Project): Boolean = DumbService.isDumb(project)
 
     private val INDEXED_REGISTRATION_METHOD_NAMES = setOf(
         ServiceRegistrationMethod.ANNOTATED_SERVICE.methodName,

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupport.kt
@@ -15,7 +15,7 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaKotlinRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteSupport
-import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteTargetExtractor
+import com.linecorp.intellij.plugins.armeria.explorer.extractArmeriaRouteTarget
 import com.linecorp.intellij.plugins.armeria.explorer.ServiceRegistrationMethod
 import com.linecorp.intellij.plugins.armeria.inspection.ArmeriaKotlinMethodRoute
 import com.linecorp.intellij.plugins.armeria.message
@@ -209,7 +209,7 @@ internal object ArmeriaRouteNavigationSupport {
 
     private fun resolveServiceClassFromImplementation(expression: PsiElement, project: Project): PsiClass? {
         if (expression is PsiExpression) {
-            val target = ArmeriaRouteTargetExtractor.extractTarget(expression)
+            val target = extractArmeriaRouteTarget(expression)
             return findClassByTarget(project, target)
         }
         if (expression is KtExpression) {
@@ -233,7 +233,7 @@ internal object ArmeriaRouteNavigationSupport {
             }
         }
         return (expression as? PsiExpression)?.let {
-            findClassByTarget(project, ArmeriaRouteTargetExtractor.extractTarget(it))
+            findClassByTarget(project, extractArmeriaRouteTarget(it))
         }
     }
 

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupport.kt
@@ -14,7 +14,10 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiIdentifier
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.psi.PsiNewExpression
+import com.intellij.psi.PsiParenthesizedExpression
 import com.intellij.psi.PsiReferenceExpression
+import com.intellij.psi.PsiTypeCastExpression
 import com.intellij.psi.PsiVariable
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.PsiShortNamesCache
@@ -232,8 +235,20 @@ internal object ArmeriaRouteNavigationSupport {
         if (isKotlinPluginAvailable()) {
             ArmeriaKotlinRouteNavigationSupport.resolveServiceClassFromImplementation(expression)?.let { return it }
         }
-        return (expression as? PsiExpression)?.let { psiExpression ->
-            findClassByTarget(project, extractArmeriaRouteTarget(psiExpression))
+        val psiExpression = expression as? PsiExpression ?: return null
+        classFromNewExpression(psiExpression)?.let { return it }
+        return findClassByTarget(project, extractArmeriaRouteTarget(psiExpression))
+    }
+
+    private fun classFromNewExpression(expression: PsiExpression): PsiClass? {
+        var current: PsiExpression = expression
+        while (true) {
+            when (current) {
+                is PsiNewExpression -> return classFromResolved(current.classReference?.resolve())
+                is PsiTypeCastExpression -> current = current.operand ?: return null
+                is PsiParenthesizedExpression -> current = current.expression ?: return null
+                else -> return null
+            }
         }
     }
 

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupport.kt
@@ -164,10 +164,7 @@ internal object ArmeriaRouteNavigationSupport {
         )
         return ArmeriaRouteSupport.extractPaths(annotation.first)
             .ifEmpty { listOf("/") }
-            .map { path ->
-                val normalized = path.ifBlank { "/" }
-                ArmeriaRouteSupport.combinePaths(classPrefix, ArmeriaRouteSupport.normalizePath(normalized))
-            }
+            .map { path -> ArmeriaRouteSupport.formatAnnotatedHandlerPath(classPrefix, path) }
     }
 
     private fun methodFromElement(element: PsiElement): PsiMethod? = when (element) {

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupport.kt
@@ -17,6 +17,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import com.intellij.psi.PsiReferenceExpression
 import com.intellij.psi.PsiVariable
 import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.PsiShortNamesCache
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.PsiTreeUtil
 import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteCollector
@@ -157,6 +158,17 @@ internal object ArmeriaRouteNavigationSupport {
         return JavaPsiFacade.getInstance(project).findClass(target, GlobalSearchScope.projectScope(project))
     }
 
+    fun findClassByTarget(project: Project, target: String): PsiClass? {
+        if (target.isBlank()) {
+            return null
+        }
+        if (target.contains('.')) {
+            return findClassByFqn(project, target)
+        }
+        val scope = GlobalSearchScope.projectScope(project)
+        return PsiShortNamesCache.getInstance(project).getClassesByName(target, scope).singleOrNull()
+    }
+
     private fun routePathsForJavaMethod(method: PsiMethod): List<String> {
         val annotation = ArmeriaRouteSupport.findRouteAnnotation(method) ?: return emptyList()
         val classPrefix = ArmeriaRouteSupport.extractPrimaryPath(
@@ -221,7 +233,7 @@ internal object ArmeriaRouteNavigationSupport {
             ArmeriaKotlinRouteNavigationSupport.resolveServiceClassFromImplementation(expression)?.let { return it }
         }
         return (expression as? PsiExpression)?.let { psiExpression ->
-            findClassByFqn(project, extractArmeriaRouteTarget(psiExpression))
+            findClassByTarget(project, extractArmeriaRouteTarget(psiExpression))
         }
     }
 

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupport.kt
@@ -68,13 +68,20 @@ internal object ArmeriaRouteNavigationSupport {
         if (isIndexUnavailable(handler.project)) {
             return emptyList()
         }
-        return when (handler) {
-            is PsiMethod -> findRegistrationsForServiceClass(handler.containingClass ?: return emptyList(), handler.project)
-            else -> if (isKotlinPluginAvailable()) {
-                ArmeriaKotlinRouteNavigationSupport.relatedRegistrations(handler)
-            } else {
-                emptyList()
+        return try {
+            when (handler) {
+                is PsiMethod -> findRegistrationsForServiceClass(
+                    handler.containingClass ?: return emptyList(),
+                    handler.project,
+                )
+                else -> if (isKotlinPluginAvailable()) {
+                    ArmeriaKotlinRouteNavigationSupport.relatedRegistrations(handler)
+                } else {
+                    emptyList()
+                }
             }
+        } catch (_: IndexNotReadyException) {
+            emptyList()
         }
     }
 
@@ -82,14 +89,19 @@ internal object ArmeriaRouteNavigationSupport {
         if (isIndexUnavailable(context.project)) {
             return emptyList()
         }
-        javaRegistrationCallFromContext(context)?.let { call ->
-            val serviceClass = resolveServiceClassFromJavaCall(call) ?: return emptyList()
-            return annotatedHandlersInClass(serviceClass)
+        return try {
+            javaRegistrationCallFromContext(context)?.let { call ->
+                val serviceClass = resolveServiceClassFromJavaCall(call) ?: return emptyList()
+                return annotatedHandlersInClass(serviceClass)
+            }
+            if (isKotlinPluginAvailable()) {
+                ArmeriaKotlinRouteNavigationSupport.relatedHandlers(context)
+            } else {
+                emptyList()
+            }
+        } catch (_: IndexNotReadyException) {
+            emptyList()
         }
-        if (isKotlinPluginAvailable()) {
-            return ArmeriaKotlinRouteNavigationSupport.relatedHandlers(context)
-        }
-        return emptyList()
     }
 
     fun relatedGotoItems(handler: PsiElement): List<GotoRelatedItem> =

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupport.kt
@@ -102,10 +102,17 @@ internal object ArmeriaRouteNavigationSupport {
 
     fun relatedHandlerGotoItems(context: PsiElement): List<GotoRelatedItem> =
         relatedHandlers(context).map { handler ->
-            GotoRelatedItem(
-                handlerNavigationElement(handler),
-                message("editor.route.gotoRelated.handler", httpMethod(handler).orEmpty(), routePath(handler)),
+            val label = message(
+                "editor.route.gotoRelated.handler",
+                httpMethod(handler).orEmpty(),
+                routePath(handler),
             )
+            object : GotoRelatedItem(
+                handlerNavigationElement(handler),
+                message("editor.route.gotoRelated.handlers"),
+            ) {
+                override fun getCustomName(): String = label
+            }
         }
 
     fun findRegistrationsForServiceClass(serviceClass: PsiClass, project: Project): List<PsiElement> {

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupport.kt
@@ -279,11 +279,12 @@ internal object ArmeriaRouteNavigationSupport {
         var current: PsiClass? = serviceClass
         while (current != null) {
             for (method in current.allMethods) {
+                val kotlinFunction = method.originalElement as? KtNamedFunction
                 when {
-                    ArmeriaRouteSupport.findRouteAnnotation(method) != null -> handlers += method
-                    else -> (method.originalElement as? KtNamedFunction)
-                        ?.takeIf { ArmeriaKotlinMethodRoute.from(it) != null }
-                        ?.let { handlers += it }
+                    kotlinFunction != null && ArmeriaKotlinMethodRoute.from(kotlinFunction) != null ->
+                        handlers += kotlinFunction
+                    ArmeriaRouteSupport.findRouteAnnotation(method) != null ->
+                        handlers += method
                 }
             }
             current = current.superClass
@@ -354,7 +355,7 @@ internal object ArmeriaRouteNavigationSupport {
         }
     }
 
-    private val SERVICE_REGISTRATION_METHOD_NAMES = ServiceRegistrationMethod.METHOD_NAMES
+    private val SERVICE_REGISTRATION_METHOD_NAMES = ServiceRegistrationMethod.CORE_METHOD_NAMES
 
     private val INDEXED_REGISTRATION_METHOD_NAMES = setOf(
         ServiceRegistrationMethod.ANNOTATED_SERVICE.methodName,

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupport.kt
@@ -4,11 +4,14 @@ import com.intellij.navigation.GotoRelatedItem
 import com.intellij.openapi.project.Project
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiClassType
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiIdentifier
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.psi.PsiReferenceExpression
+import com.intellij.psi.PsiVariable
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.PsiTreeUtil
@@ -27,6 +30,7 @@ import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtValueArgument
 
 internal object ArmeriaRouteNavigationSupport {
@@ -53,8 +57,8 @@ internal object ArmeriaRouteNavigationSupport {
     }
 
     fun routePath(handler: PsiElement): String = when (handler) {
-        is PsiMethod -> routePathForJavaMethod(handler)
-        is KtNamedFunction -> ArmeriaKotlinMethodRoute.from(handler)?.paths?.firstOrNull().orEmpty()
+        is PsiMethod -> routePathsForJavaMethod(handler).joinToString(", ")
+        is KtNamedFunction -> ArmeriaKotlinMethodRoute.from(handler)?.paths?.joinToString(", ").orEmpty()
         else -> ""
     }
 
@@ -92,13 +96,17 @@ internal object ArmeriaRouteNavigationSupport {
             )
         }
 
-    private fun routePathForJavaMethod(method: PsiMethod): String {
-        val annotation = ArmeriaRouteSupport.findRouteAnnotation(method) ?: return ""
+    private fun routePathsForJavaMethod(method: PsiMethod): List<String> {
+        val annotation = ArmeriaRouteSupport.findRouteAnnotation(method) ?: return emptyList()
         val classPrefix = ArmeriaRouteSupport.extractPrimaryPath(
             method.containingClass?.getAnnotation(ArmeriaRouteSupport.PATH_PREFIX_ANNOTATION),
         )
-        val path = ArmeriaRouteSupport.extractPaths(annotation.first).firstOrNull().orEmpty().ifBlank { "/" }
-        return ArmeriaRouteSupport.combinePaths(classPrefix, ArmeriaRouteSupport.normalizePath(path))
+        return ArmeriaRouteSupport.extractPaths(annotation.first)
+            .ifEmpty { listOf("/") }
+            .map { path ->
+                val normalized = path.ifBlank { "/" }
+                ArmeriaRouteSupport.combinePaths(classPrefix, ArmeriaRouteSupport.normalizePath(normalized))
+            }
     }
 
     private fun methodFromElement(element: PsiElement): PsiMethod? = when (element) {
@@ -115,39 +123,37 @@ internal object ArmeriaRouteNavigationSupport {
     private fun findRegistrationsForServiceClass(serviceClass: PsiClass, project: Project): List<PsiElement> {
         val registrations = linkedSetOf<PsiElement>()
         val scope = GlobalSearchScope.projectScope(project)
-        val searchTargets = mutableListOf<PsiElement>()
-        searchTargets += serviceClass
-        val ktClass = serviceClass.originalElement as? KtClass
-        if (ktClass != null) {
-            searchTargets += ktClass
-            ktClass.primaryConstructor?.let { searchTargets += it }
-        }
-        for (target in searchTargets) {
-            collectRegistrationsFromReferences(target, serviceClass, registrations)
+        val builderClass = JavaPsiFacade.getInstance(project)
+            .findClass(ArmeriaRouteSupport.SERVER_BUILDER_CLASS, scope)
+            ?: return emptyList()
+        for (methodName in INDEXED_REGISTRATION_METHOD_NAMES) {
+            for (method in builderClass.findMethodsByName(methodName, false)) {
+                ReferencesSearch.search(method, scope).forEach { reference ->
+                    collectRegistrationFromReference(reference.element, serviceClass, registrations)
+                }
+            }
         }
         return registrations.toList()
     }
 
-    private fun collectRegistrationsFromReferences(
-        target: PsiElement,
+    private fun collectRegistrationFromReference(
+        element: PsiElement,
         serviceClass: PsiClass,
         registrations: MutableSet<PsiElement>,
     ) {
-        ReferencesSearch.search(target, GlobalSearchScope.projectScope(target.project)).forEach { reference ->
-            val javaCall = PsiTreeUtil.getParentOfType(reference.element, PsiMethodCallExpression::class.java)
-            if (javaCall != null && isJavaServiceRegistrationCall(javaCall)) {
-                val resolvedClass = resolveServiceClassFromJavaCall(javaCall) ?: return@forEach
-                if (serviceTypesMatch(serviceClass, resolvedClass)) {
-                    registrations += javaCall
-                }
-                return@forEach
+        val javaCall = PsiTreeUtil.getParentOfType(element, PsiMethodCallExpression::class.java, false)
+        if (javaCall != null && isJavaServiceRegistrationCall(javaCall)) {
+            val resolvedClass = resolveServiceClassFromJavaCall(javaCall) ?: return
+            if (serviceTypesMatch(serviceClass, resolvedClass)) {
+                registrations += javaCall
             }
-            val kotlinCall = kotlinRegistrationCallFromReference(reference.element)
-            if (kotlinCall != null) {
-                val resolvedClass = resolveServiceClassFromKotlinCall(kotlinCall) ?: return@forEach
-                if (serviceTypesMatch(serviceClass, resolvedClass)) {
-                    registrations += kotlinCall
-                }
+            return
+        }
+        val kotlinCall = kotlinRegistrationCallFromReference(element)
+        if (kotlinCall != null) {
+            val resolvedClass = resolveServiceClassFromKotlinCall(kotlinCall) ?: return
+            if (serviceTypesMatch(serviceClass, resolvedClass)) {
+                registrations += kotlinCall
             }
         }
     }
@@ -208,17 +214,7 @@ internal object ArmeriaRouteNavigationSupport {
     }
 
     private fun resolveServiceClassFromImplementation(expression: PsiElement, project: Project): PsiClass? {
-        if (expression is PsiExpression) {
-            val target = extractArmeriaRouteTarget(expression)
-            return findClassByTarget(project, target)
-        }
-        if (expression is KtExpression) {
-            return resolveKotlinImplementationClass(expression, project)
-        }
-        return null
-    }
-
-    private fun resolveKotlinImplementationClass(expression: KtExpression, project: Project): PsiClass? {
+        resolvedClassFromReference(expression)?.let { return it }
         when (expression) {
             is KtCallExpression -> {
                 val reference = when (val callee = expression.calleeExpression) {
@@ -226,33 +222,56 @@ internal object ArmeriaRouteNavigationSupport {
                     is KtDotQualifiedExpression -> callee.selectorExpression as? KtNameReferenceExpression
                     else -> null
                 }
-                classFromResolved(reference?.references?.firstOrNull()?.resolve(), project)?.let { return it }
-            }
-            is KtNameReferenceExpression -> {
-                classFromResolved(expression.references.firstOrNull()?.resolve(), project)?.let { return it }
+                classFromResolved(reference?.references?.firstOrNull()?.resolve())?.let { return it }
             }
         }
-        return (expression as? PsiExpression)?.let {
-            findClassByTarget(project, extractArmeriaRouteTarget(it))
+        return (expression as? PsiExpression)?.let { psiExpression ->
+            findClassByFqn(project, extractArmeriaRouteTarget(psiExpression))
         }
     }
 
-    private fun classFromResolved(resolved: PsiElement?, project: Project): PsiClass? = when (resolved) {
-        is PsiClass -> resolved
-        is PsiMethod -> resolved.takeIf { it.isConstructor }?.containingClass
-        is KtClass -> resolved.toLightClass()
-        is KtConstructor<*> -> resolved.getContainingClassOrObject().toLightClass()
+    private fun resolvedClassFromReference(expression: PsiElement): PsiClass? = when (expression) {
+        is PsiReferenceExpression -> classFromResolved(expression.resolve())
+        is KtNameReferenceExpression -> classFromResolved(expression.references.firstOrNull()?.resolve())
         else -> null
     }
 
-    private fun findClassByTarget(project: Project, target: String): PsiClass? {
-        val facade = JavaPsiFacade.getInstance(project)
-        val scope = GlobalSearchScope.projectScope(project)
-        facade.findClass(target, scope)?.let { return it }
-        if (!target.contains('.')) {
-            return facade.findClass("example.$target", scope)
+    private fun classFromResolved(resolved: PsiElement?): PsiClass? = when (resolved) {
+        is PsiClass -> resolved
+        is PsiMethod -> resolved.takeIf { it.isConstructor }?.containingClass
+        is PsiVariable -> (resolved.type as? PsiClassType)?.resolve()
+        is KtClass -> resolved.toLightClass()
+        is KtConstructor<*> -> resolved.getContainingClassOrObject().toLightClass()
+        is KtProperty -> classFromKotlinProperty(resolved)
+        else -> null
+    }
+
+    private fun classFromKotlinProperty(property: KtProperty): PsiClass? {
+        property.typeReference?.references?.firstOrNull()?.resolve()?.let { typeResolved ->
+            when (typeResolved) {
+                is PsiClass -> return typeResolved
+                is KtClass -> return typeResolved.toLightClass()
+            }
         }
-        return null
+        val initializer = property.initializer ?: return null
+        if (initializer is KtCallExpression) {
+            val reference = when (val callee = initializer.calleeExpression) {
+                is KtNameReferenceExpression -> callee
+                is KtDotQualifiedExpression -> callee.selectorExpression as? KtNameReferenceExpression
+                else -> null
+            }
+            classFromResolved(reference?.references?.firstOrNull()?.resolve())?.let { return it }
+        }
+        return (initializer as? PsiExpression)?.let { expression ->
+            findClassByFqn(property.project, extractArmeriaRouteTarget(expression))
+        }
+    }
+
+    private fun findClassByFqn(project: Project, target: String): PsiClass? {
+        if (target.isBlank() || !target.contains('.')) {
+            return null
+        }
+        return JavaPsiFacade.getInstance(project).findClass(target, GlobalSearchScope.projectScope(project))
     }
 
     private fun annotatedHandlersInClass(serviceClass: PsiClass): List<PsiElement> {
@@ -336,4 +355,10 @@ internal object ArmeriaRouteNavigationSupport {
     }
 
     private val SERVICE_REGISTRATION_METHOD_NAMES = ServiceRegistrationMethod.METHOD_NAMES
+
+    private val INDEXED_REGISTRATION_METHOD_NAMES = setOf(
+        ServiceRegistrationMethod.ANNOTATED_SERVICE.methodName,
+        ServiceRegistrationMethod.SERVICE.methodName,
+        ServiceRegistrationMethod.SERVICE_UNDER.methodName,
+    )
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupport.kt
@@ -162,8 +162,11 @@ internal object ArmeriaRouteNavigationSupport {
         val classPrefix = ArmeriaRouteSupport.extractPrimaryPath(
             method.containingClass?.getAnnotation(ArmeriaRouteSupport.PATH_PREFIX_ANNOTATION),
         )
-        return ArmeriaRouteSupport.extractPaths(annotation.first)
-            .ifEmpty { listOf("/") }
+        return buildList {
+            addAll(ArmeriaRouteSupport.extractPaths(annotation.first))
+            addAll(ArmeriaRouteSupport.extractPathAnnotations(method))
+        }.ifEmpty { listOf("/") }
+            .distinct()
             .map { path -> ArmeriaRouteSupport.formatAnnotatedHandlerPath(classPrefix, path) }
     }
 

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -49,6 +49,7 @@
                      description="Include gRPC routes parsed from .proto files in Route Explorer"/>
         <codeInsight.lineMarkerProvider language="JAVA"
                                         implementationClass="com.linecorp.intellij.plugins.armeria.marker.ArmeriaRouteLineMarkerProvider"/>
+        <gotoRelatedProvider implementation="com.linecorp.intellij.plugins.armeria.editor.ArmeriaRouteGotoRelatedProvider" />
 
         <!-- Run configuration -->
         <configurationType implementation="com.linecorp.intellij.plugins.armeria.run.ArmeriaRunConfigurationType" />

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
@@ -229,6 +229,27 @@ class ArmeriaRouteNavigationSupportTest : LightJavaCodeInsightFixtureTestCase() 
         assertEquals("/one, /two", ArmeriaRouteNavigationSupport.routePath(method))
     }
 
+    fun testRoutePathPreservesPathTypePrefix() {
+        myFixture.configureByText(
+            "PrefixService.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Get;
+            import com.linecorp.armeria.server.annotation.PathPrefix;
+
+            @PathPrefix("/api")
+            public class PrefixService {
+                @Get("prefix:/hello")
+                public String hello() { return "hello"; }
+            }
+            """.trimIndent(),
+        )
+
+        val method = findMethod("example.PrefixService", "hello")
+        assertEquals("prefix:/api/hello", ArmeriaRouteNavigationSupport.routePath(method))
+    }
+
     private fun findMethod(className: String, name: String): PsiMethod {
         val clazz = JavaPsiFacade.getInstance(project).findClass(
             className,
@@ -243,7 +264,7 @@ class ArmeriaRouteNavigationSupportTest : LightJavaCodeInsightFixtureTestCase() 
     private fun findMethod(name: String): PsiMethod = findMethod("example.HelloService", name)
 
     private fun registerArmeriaStubs() {
-        myFixture.addClass("package com.linecorp.armeria.server.annotation; public @interface Get { String value() default \"\"; String path() default \"\"; }")
+        myFixture.addClass("package com.linecorp.armeria.server.annotation; public @interface Get { String[] value() default {}; String[] path() default {}; }")
         myFixture.addClass("package com.linecorp.armeria.server.annotation; public @interface PathPrefix { String value(); }")
         myFixture.addClass("package com.linecorp.armeria.server; public final class Server { public static ServerBuilder builder() { return null; } }")
         myFixture.addClass(

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
@@ -30,6 +30,30 @@ class ArmeriaRouteNavigationSupportTest : LightJavaCodeInsightFixtureTestCase() 
         assertEquals("/api/hello", ArmeriaRouteNavigationSupport.routePath(method))
     }
 
+    fun testRelatedItemsBetweenHandlerAndServiceRegistration() {
+        myFixture.configureByText(
+            "Main.java",
+            """
+            package example; import com.linecorp.armeria.server.Server;
+            public class Main { public static void main(String[] a) {
+                Server.builder().service("/api", new HelloService()).build();
+            }}
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example; import com.linecorp.armeria.server.annotation.Get;
+            public class HelloService { @Get("/hello") public String hello() { return "hello"; } }
+            """.trimIndent(),
+        )
+        val handler = findMethod("hello")
+        assertEquals(1, ArmeriaRouteNavigationSupport.relatedRegistrations(handler).size)
+        val reg = ArmeriaRouteNavigationSupport.relatedRegistrations(handler).single()
+        assertTrue(reg is com.intellij.psi.PsiMethodCallExpression)
+        assertEquals("service", (reg as com.intellij.psi.PsiMethodCallExpression).methodExpression.referenceName)
+        assertEquals(1, ArmeriaRouteNavigationSupport.relatedHandlers(reg).size)
+    }
+
     fun testRelatedItemsBetweenHandlerAndRegistration() {
         myFixture.configureByText(
             "Main.java",

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
@@ -271,6 +271,56 @@ class ArmeriaRouteNavigationSupportTest : LightJavaCodeInsightFixtureTestCase() 
         assertEquals("prefix:/api/hello", ArmeriaRouteNavigationSupport.routePath(method))
     }
 
+    fun testFindClassByTargetResolvesSimpleClassName() {
+        myFixture.addClass("package services; public class HelloService {}")
+
+        val resolved = ArmeriaRouteNavigationSupport.findClassByTarget(project, "HelloService")
+
+        assertNotNull(resolved)
+        assertEquals("services.HelloService", resolved!!.qualifiedName)
+    }
+
+    fun testFindClassByTargetReturnsNullWhenAmbiguous() {
+        myFixture.addClass("package foo; public class Dup {}")
+        myFixture.addClass("package bar; public class Dup {}")
+
+        assertNull(ArmeriaRouteNavigationSupport.findClassByTarget(project, "Dup"))
+    }
+
+    fun testRelatedHandlersResolvesUnqualifiedServiceClass() {
+        myFixture.configureByText(
+            "Main.java",
+            """
+            package app;
+
+            import com.linecorp.armeria.server.Server;
+            import services.HelloService;
+
+            public class Main {
+                public static void main(String[] args) {
+                    Server.builder().annotatedService(new HelloService()).build();
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package services;
+
+            import com.linecorp.armeria.server.annotation.Get;
+
+            public class HelloService {
+                @Get("/hello")
+                public String hello() { return "hello"; }
+            }
+            """.trimIndent(),
+        )
+
+        val handler = findMethod("services.HelloService", "hello")
+        val registration = ArmeriaRouteNavigationSupport.relatedRegistrations(handler).single()
+        assertEquals(1, ArmeriaRouteNavigationSupport.relatedHandlers(registration).size)
+    }
+
     private fun findMethod(className: String, name: String): PsiMethod {
         val clazz = JavaPsiFacade.getInstance(project).findClass(
             className,

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
@@ -80,14 +80,6 @@ class ArmeriaRouteNavigationSupportTest : LightJavaCodeInsightFixtureTestCase() 
 
     fun testKotlinRoutePathFromAnnotatedHandler() {
         myFixture.configureByText(
-            "Annotations.kt",
-            """
-            package com.linecorp.armeria.server.annotation
-            annotation class Get(val value: String = "", val path: String = "")
-            annotation class PathPrefix(val value: String)
-            """.trimIndent(),
-        )
-        myFixture.configureByText(
             "HelloService.kt",
             """
             package example
@@ -109,13 +101,6 @@ class ArmeriaRouteNavigationSupportTest : LightJavaCodeInsightFixtureTestCase() 
     }
 
     fun testRelatedItemsBetweenKotlinHandlerAndRegistration() {
-        myFixture.configureByText(
-            "Get.kt",
-            """
-            package com.linecorp.armeria.server.annotation
-            annotation class Get(val value: String = "")
-            """.trimIndent(),
-        )
         val helloServiceFile = myFixture.configureByText(
             "HelloService.kt",
             """
@@ -190,13 +175,6 @@ class ArmeriaRouteNavigationSupportTest : LightJavaCodeInsightFixtureTestCase() 
     }
 
     fun testRelatedItemsWithKotlinVariableReference() {
-        myFixture.configureByText(
-            "Get.kt",
-            """
-            package com.linecorp.armeria.server.annotation
-            annotation class Get(val value: String = "")
-            """.trimIndent(),
-        )
         val helloServiceFile = myFixture.configureByText(
             "HelloService.kt",
             """

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
@@ -130,9 +130,106 @@ class ArmeriaRouteNavigationSupportTest : LightJavaCodeInsightFixtureTestCase() 
         assertTrue(ArmeriaRouteNavigationSupport.relatedRegistrations(function).single() is KtCallExpression)
     }
 
-    private fun findMethod(name: String): PsiMethod {
+    fun testRelatedItemsWithJavaVariableReference() {
+        myFixture.configureByText(
+            "Main.java",
+            """
+            package com.acme;
+
+            import com.linecorp.armeria.server.Server;
+
+            public class Main {
+                public static void main(String[] args) {
+                    HelloService service = new HelloService();
+                    Server.builder().annotatedService(service).build();
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package com.acme;
+
+            import com.linecorp.armeria.server.annotation.Get;
+
+            public class HelloService {
+                @Get("/hello")
+                public String hello() { return "hello"; }
+            }
+            """.trimIndent(),
+        )
+
+        val handler = findMethod("com.acme.HelloService", "hello")
+        assertEquals(1, ArmeriaRouteNavigationSupport.relatedRegistrations(handler).size)
+        val registration = ArmeriaRouteNavigationSupport.relatedRegistrations(handler).single()
+        assertEquals(1, ArmeriaRouteNavigationSupport.relatedHandlers(registration).size)
+    }
+
+    fun testRelatedItemsWithKotlinVariableReference() {
+        myFixture.configureByText(
+            "Get.kt",
+            """
+            package com.linecorp.armeria.server.annotation
+            annotation class Get(val value: String = "")
+            """.trimIndent(),
+        )
+        val helloServiceFile = myFixture.configureByText(
+            "HelloService.kt",
+            """
+            package com.acme
+
+            import com.linecorp.armeria.server.annotation.Get
+
+            class HelloService {
+                @Get("/hello")
+                fun hello(): String = "hello"
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package com.acme
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                val service = HelloService()
+                Server.builder()
+                    .annotatedService(service)
+                    .build()
+            }
+            """.trimIndent(),
+        )
+
+        val function = PsiTreeUtil.findChildOfType(helloServiceFile, KtNamedFunction::class.java)!!
+        assertEquals(1, ArmeriaRouteNavigationSupport.relatedRegistrations(function).size)
+        val registration = ArmeriaRouteNavigationSupport.relatedRegistrations(function).single()
+        assertEquals(1, ArmeriaRouteNavigationSupport.relatedHandlers(registration).size)
+    }
+
+    fun testRoutePathJoinsMultiplePaths() {
+        myFixture.configureByText(
+            "MultiPathService.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Get;
+
+            public class MultiPathService {
+                @Get({"/one", "/two"})
+                public String multi() { return "multi"; }
+            }
+            """.trimIndent(),
+        )
+
+        val method = findMethod("example.MultiPathService", "multi")
+        assertEquals("/one, /two", ArmeriaRouteNavigationSupport.routePath(method))
+    }
+
+    private fun findMethod(className: String, name: String): PsiMethod {
         val clazz = JavaPsiFacade.getInstance(project).findClass(
-            "example.HelloService",
+            className,
             GlobalSearchScope.projectScope(project),
         )
         assertNotNull(clazz)
@@ -140,6 +237,8 @@ class ArmeriaRouteNavigationSupportTest : LightJavaCodeInsightFixtureTestCase() 
         assertNotNull(method)
         return method!!
     }
+
+    private fun findMethod(name: String): PsiMethod = findMethod("example.HelloService", name)
 
     private fun registerArmeriaStubs() {
         myFixture.addClass("package com.linecorp.armeria.server.annotation; public @interface Get { String value() default \"\"; String path() default \"\"; }")

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
@@ -210,6 +210,41 @@ class ArmeriaRouteNavigationSupportTest : LightJavaCodeInsightFixtureTestCase() 
         assertEquals(1, ArmeriaRouteNavigationSupport.relatedHandlers(registration).size)
     }
 
+    fun testRelatedItemsWithKotlinObjectDeclaration() {
+        val helloServiceFile = myFixture.configureByText(
+            "HelloService.kt",
+            """
+            package com.acme
+
+            import com.linecorp.armeria.server.annotation.Get
+
+            object HelloService {
+                @Get("/hello")
+                fun hello(): String = "hello"
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package com.acme
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder()
+                    .annotatedService(HelloService)
+                    .build()
+            }
+            """.trimIndent(),
+        )
+
+        val function = PsiTreeUtil.findChildOfType(helloServiceFile, KtNamedFunction::class.java)!!
+        assertEquals(1, ArmeriaRouteNavigationSupport.relatedRegistrations(function).size)
+        val registration = ArmeriaRouteNavigationSupport.relatedRegistrations(function).single()
+        assertEquals(1, ArmeriaRouteNavigationSupport.relatedHandlers(registration).size)
+    }
+
     fun testRoutePathJoinsMultiplePaths() {
         myFixture.configureByText(
             "MultiPathService.java",

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
@@ -308,6 +308,41 @@ class ArmeriaRouteNavigationSupportTest : LightJavaCodeInsightFixtureTestCase() 
         assertNull(ArmeriaRouteNavigationSupport.findClassByTarget(project, "Dup"))
     }
 
+    fun testRelatedHandlersResolvesNewExpressionWhenSimpleNameIsAmbiguous() {
+        myFixture.configureByText(
+            "Main.java",
+            """
+            package app;
+
+            import com.linecorp.armeria.server.Server;
+            import services.HelloService;
+
+            public class Main {
+                public static void main(String[] args) {
+                    Server.builder().annotatedService(new HelloService()).build();
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package services;
+
+            import com.linecorp.armeria.server.annotation.Get;
+
+            public class HelloService {
+                @Get("/hello")
+                public String hello() { return "hello"; }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass("package other; public class HelloService {}")
+
+        val handler = findMethod("services.HelloService", "hello")
+        val registration = ArmeriaRouteNavigationSupport.relatedRegistrations(handler).single()
+        assertEquals(1, ArmeriaRouteNavigationSupport.relatedHandlers(registration).size)
+    }
+
     fun testRelatedHandlersResolvesUnqualifiedServiceClass() {
         myFixture.configureByText(
             "Main.java",

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
@@ -1,0 +1,57 @@
+package com.linecorp.intellij.plugins.armeria.editor
+
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+
+class ArmeriaRouteNavigationSupportTest : LightJavaCodeInsightFixtureTestCase() {
+    override fun setUp() { super.setUp(); registerArmeriaStubs() }
+
+    fun testRoutePathFromAnnotatedHandler() {
+        myFixture.configureByText("HelloService.java", """
+            package example;
+            import com.linecorp.armeria.server.annotation.*;
+            @PathPrefix("/api") public class HelloService {
+                @Get("/hello") public String hello() { return "hello"; }
+            }""".trimIndent())
+        val method = findMethod("hello")
+        assertEquals("GET", ArmeriaRouteNavigationSupport.httpMethod(method))
+        assertEquals("/api/hello", ArmeriaRouteNavigationSupport.routePath(method))
+    }
+
+    fun testRelatedItemsBetweenHandlerAndRegistration() {
+        myFixture.configureByText("Main.java", """
+            package example; import com.linecorp.armeria.server.Server;
+            public class Main { public static void main(String[] a) {
+                Server.builder().annotatedService(new HelloService()).build();
+            }}""".trimIndent())
+        myFixture.addClass("""
+            package example; import com.linecorp.armeria.server.annotation.Get;
+            public class HelloService { @Get("/hello") public String hello() { return "hello"; } }
+            """.trimIndent())
+        val handler = findMethod("hello")
+        assertEquals(1, ArmeriaRouteNavigationSupport.relatedRegistrations(handler).size)
+        val reg = ArmeriaRouteNavigationSupport.relatedRegistrations(handler).single()
+        assertEquals("annotatedService", reg.methodExpression.referenceName)
+        assertEquals(1, ArmeriaRouteNavigationSupport.relatedHandlers(reg).size)
+    }
+
+    private fun findMethod(name: String): PsiMethod {
+        val clazz = JavaPsiFacade.getInstance(project).findClass(
+            "example.HelloService",
+            GlobalSearchScope.projectScope(project),
+        )
+        assertNotNull(clazz)
+        val method = clazz!!.findMethodsByName(name, false).singleOrNull()
+        assertNotNull(method)
+        return method!!
+    }
+
+    private fun registerArmeriaStubs() {
+        myFixture.addClass("package com.linecorp.armeria.server.annotation; public @interface Get { String value() default \"\"; String path() default \"\"; }")
+        myFixture.addClass("package com.linecorp.armeria.server.annotation; public @interface PathPrefix { String value(); }")
+        myFixture.addClass("package com.linecorp.armeria.server; public final class Server { public static ServerBuilder builder() { return null; } }")
+        myFixture.addClass("package com.linecorp.armeria.server; public final class ServerBuilder { public ServerBuilder annotatedService(Object s) { return this; } public com.linecorp.armeria.server.Server build() { return null; } }")
+    }
+}

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
@@ -229,6 +229,27 @@ class ArmeriaRouteNavigationSupportTest : LightJavaCodeInsightFixtureTestCase() 
         assertEquals("/one, /two", ArmeriaRouteNavigationSupport.routePath(method))
     }
 
+    fun testRoutePathJoinsGetAnnotationWithPathAnnotation() {
+        myFixture.configureByText(
+            "PathAnnotationService.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Get;
+            import com.linecorp.armeria.server.annotation.Path;
+
+            public class PathAnnotationService {
+                @Get
+                @Path("/hello")
+                public String hello() { return "hello"; }
+            }
+            """.trimIndent(),
+        )
+
+        val method = findMethod("example.PathAnnotationService", "hello")
+        assertEquals("/hello", ArmeriaRouteNavigationSupport.routePath(method))
+    }
+
     fun testRoutePathPreservesPathTypePrefix() {
         myFixture.configureByText(
             "PrefixService.java",
@@ -265,6 +286,7 @@ class ArmeriaRouteNavigationSupportTest : LightJavaCodeInsightFixtureTestCase() 
 
     private fun registerArmeriaStubs() {
         myFixture.addClass("package com.linecorp.armeria.server.annotation; public @interface Get { String[] value() default {}; String[] path() default {}; }")
+        myFixture.addClass("package com.linecorp.armeria.server.annotation; public @interface Path { String[] value() default {}; }")
         myFixture.addClass("package com.linecorp.armeria.server.annotation; public @interface PathPrefix { String value(); }")
         myFixture.addClass("package com.linecorp.armeria.server; public final class Server { public static ServerBuilder builder() { return null; } }")
         myFixture.addClass(

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
@@ -271,6 +271,27 @@ class ArmeriaRouteNavigationSupportTest : LightJavaCodeInsightFixtureTestCase() 
         assertEquals("prefix:/api/hello", ArmeriaRouteNavigationSupport.routePath(method))
     }
 
+    fun testRoutePathPreservesRegexPathTypePrefix() {
+        myFixture.configureByText(
+            "RegexService.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Get;
+            import com.linecorp.armeria.server.annotation.PathPrefix;
+
+            @PathPrefix("regex:^/api")
+            public class RegexService {
+                @Get("regex:^/hello$")
+                public String hello() { return "hello"; }
+            }
+            """.trimIndent(),
+        )
+
+        val method = findMethod("example.RegexService", "hello")
+        assertEquals("regex:^/api/hello$", ArmeriaRouteNavigationSupport.routePath(method))
+    }
+
     fun testFindClassByTargetResolvesSimpleClassName() {
         myFixture.addClass("package services; public class HelloService {}")
 

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
@@ -3,38 +3,131 @@ package com.linecorp.intellij.plugins.armeria.editor
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
 
 class ArmeriaRouteNavigationSupportTest : LightJavaCodeInsightFixtureTestCase() {
-    override fun setUp() { super.setUp(); registerArmeriaStubs() }
+    override fun setUp() {
+        super.setUp()
+        registerArmeriaStubs()
+    }
 
     fun testRoutePathFromAnnotatedHandler() {
-        myFixture.configureByText("HelloService.java", """
+        myFixture.configureByText(
+            "HelloService.java",
+            """
             package example;
             import com.linecorp.armeria.server.annotation.*;
             @PathPrefix("/api") public class HelloService {
                 @Get("/hello") public String hello() { return "hello"; }
-            }""".trimIndent())
+            }
+            """.trimIndent(),
+        )
         val method = findMethod("hello")
         assertEquals("GET", ArmeriaRouteNavigationSupport.httpMethod(method))
         assertEquals("/api/hello", ArmeriaRouteNavigationSupport.routePath(method))
     }
 
     fun testRelatedItemsBetweenHandlerAndRegistration() {
-        myFixture.configureByText("Main.java", """
+        myFixture.configureByText(
+            "Main.java",
+            """
             package example; import com.linecorp.armeria.server.Server;
             public class Main { public static void main(String[] a) {
                 Server.builder().annotatedService(new HelloService()).build();
-            }}""".trimIndent())
-        myFixture.addClass("""
+            }}
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
             package example; import com.linecorp.armeria.server.annotation.Get;
             public class HelloService { @Get("/hello") public String hello() { return "hello"; } }
-            """.trimIndent())
+            """.trimIndent(),
+        )
         val handler = findMethod("hello")
         assertEquals(1, ArmeriaRouteNavigationSupport.relatedRegistrations(handler).size)
         val reg = ArmeriaRouteNavigationSupport.relatedRegistrations(handler).single()
-        assertEquals("annotatedService", reg.methodExpression.referenceName)
+        assertTrue(reg is com.intellij.psi.PsiMethodCallExpression)
+        assertEquals("annotatedService", (reg as com.intellij.psi.PsiMethodCallExpression).methodExpression.referenceName)
         assertEquals(1, ArmeriaRouteNavigationSupport.relatedHandlers(reg).size)
+    }
+
+    fun testKotlinRoutePathFromAnnotatedHandler() {
+        myFixture.configureByText(
+            "Annotations.kt",
+            """
+            package com.linecorp.armeria.server.annotation
+            annotation class Get(val value: String = "", val path: String = "")
+            annotation class PathPrefix(val value: String)
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "HelloService.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.annotation.Get
+            import com.linecorp.armeria.server.annotation.PathPrefix
+
+            @PathPrefix("/api")
+            class HelloService {
+                @Get("/hello")
+                fun hello(): String = "hello"
+            }
+            """.trimIndent(),
+        )
+
+        val function = PsiTreeUtil.findChildOfType(myFixture.file, KtNamedFunction::class.java)!!
+        assertEquals("GET", ArmeriaRouteNavigationSupport.httpMethod(function))
+        assertEquals("/api/hello", ArmeriaRouteNavigationSupport.routePath(function))
+    }
+
+    fun testRelatedItemsBetweenKotlinHandlerAndRegistration() {
+        myFixture.configureByText(
+            "Get.kt",
+            """
+            package com.linecorp.armeria.server.annotation
+            annotation class Get(val value: String = "")
+            """.trimIndent(),
+        )
+        val helloServiceFile = myFixture.configureByText(
+            "HelloService.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.annotation.Get
+
+            class HelloService {
+                @Get("/hello")
+                fun hello(): String = "hello"
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder()
+                    .annotatedService(HelloService())
+                    .build()
+            }
+            """.trimIndent(),
+        )
+
+        val mainFile = myFixture.file
+        val registrationCall = PsiTreeUtil.collectElementsOfType(mainFile, KtCallExpression::class.java)
+            .first { it.text.contains("annotatedService") }
+        assertEquals(1, ArmeriaRouteNavigationSupport.relatedHandlers(registrationCall).size)
+
+        val function = PsiTreeUtil.findChildOfType(helloServiceFile, KtNamedFunction::class.java)!!
+        assertEquals(1, ArmeriaRouteNavigationSupport.relatedRegistrations(function).size)
+        assertTrue(ArmeriaRouteNavigationSupport.relatedRegistrations(function).single() is KtCallExpression)
     }
 
     private fun findMethod(name: String): PsiMethod {
@@ -52,6 +145,15 @@ class ArmeriaRouteNavigationSupportTest : LightJavaCodeInsightFixtureTestCase() 
         myFixture.addClass("package com.linecorp.armeria.server.annotation; public @interface Get { String value() default \"\"; String path() default \"\"; }")
         myFixture.addClass("package com.linecorp.armeria.server.annotation; public @interface PathPrefix { String value(); }")
         myFixture.addClass("package com.linecorp.armeria.server; public final class Server { public static ServerBuilder builder() { return null; } }")
-        myFixture.addClass("package com.linecorp.armeria.server; public final class ServerBuilder { public ServerBuilder annotatedService(Object s) { return this; } public com.linecorp.armeria.server.Server build() { return null; } }")
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.server;
+            public final class ServerBuilder {
+                public ServerBuilder service(String path, Object handler) { return this; }
+                public ServerBuilder annotatedService(Object service) { return this; }
+                public com.linecorp.armeria.server.Server build() { return null; }
+            }
+            """.trimIndent(),
+        )
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Go to Related navigation between annotated route handlers and their `Server.builder()` registration sites. Gutter icons are provided by #210; this PR adds only the navigation layer on top.

## Changes

- `ArmeriaRouteGotoRelatedProvider` for Go to Related between handlers and `service` / `annotatedService` registrations
- Shared `ArmeriaRouteNavigationSupport` with registration/handler lookup for Java and Kotlin
- Kotlin-dependent logic isolated in `ArmeriaKotlinRouteNavigationSupport` with runtime Kotlin-plugin checks
- Resolve service classes from variable/property types (no test-only `example.` package fallback)
- Index `ServerBuilder` registration calls for handler → registration lookup, including variable arguments
- Join multiple `@Get`/`@Path` values in Go to Related labels; preserve `prefix:`/`regex:`/`glob:` path-type prefixes via `formatAnnotatedHandlerPath`
- Restrict registration detection to core methods (`service`, `serviceUnder`, `annotatedService`)
- Bail out during dumb mode / index-not-ready to avoid slow or failing reference searches
- Prefer Kotlin `KtNamedFunction` source elements over light `PsiMethod` in handler lookup
- Bundle strings for navigation labels
- Unit tests for route path resolution, bidirectional related-item lookup, `com.acme` packages, variable references, multi-path labels, path-type prefixes, and `service()` registration

## Depends on

- #210 — gutter icons and Kotlin route parsing stack

## Test plan

- [x] `./gradlew :plugin:test --tests "com.linecorp.intellij.plugins.armeria.editor.ArmeriaRouteNavigationSupportTest"`
- [ ] In the IDE sandbox, use Go to Related on an annotated handler and on a `Server.builder().annotatedService(...)` call

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2f83-3c3e-7f3f-b835-be2c90fec8ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2f83-3c3e-7f3f-b835-be2c90fec8ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

