### PR TITLE
feat: Kotlin annotated route duplicate inspection

### DIFF
--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtConstructor
 import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtCollectionLiteralExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFile
@@ -187,6 +188,14 @@ object ArmeriaKotlinRouteCollector {
 
     private fun extractKotlinString(expression: KtExpression?): String? =
         ArmeriaKotlinExpressionSupport.extractKotlinString(expression)
+
+    internal fun extractKotlinStrings(expression: KtExpression?): List<String> {
+        val unwrapped = unwrapKotlinExpression(expression) ?: return emptyList()
+        if (unwrapped is KtCollectionLiteralExpression) {
+            return unwrapped.getInnerExpressions().mapNotNull(::extractKotlinString)
+        }
+        return extractKotlinString(unwrapped)?.let { listOf(it) }.orEmpty()
+    }
 
     private fun unwrapKotlinExpression(expression: KtExpression?): KtExpression? {
         var current = expression ?: return null

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
@@ -189,7 +189,7 @@ object ArmeriaKotlinRouteCollector {
     private fun extractKotlinString(expression: KtExpression?): String? =
         ArmeriaKotlinExpressionSupport.extractKotlinString(expression)
 
-    internal fun extractKotlinStrings(expression: KtExpression?): List<String> {
+    fun extractKotlinStrings(expression: KtExpression?): List<String> {
         val unwrapped = unwrapKotlinExpression(expression) ?: return emptyList()
         if (unwrapped is KtCollectionLiteralExpression) {
             return unwrapped.getInnerExpressions().mapNotNull(::extractKotlinString)

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndex.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndex.kt
@@ -1,6 +1,5 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
-import com.intellij.lang.java.JavaLanguage
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiClass
@@ -21,8 +20,9 @@ import com.intellij.psi.util.PsiModificationTracker
  * Excludes non-HTTP protocols such as gRPC and mount-only registrations such as file services.
  *
  * Cross-registration conflicts are detected, for example `@Get("/foo")` versus
- * `.service("/foo", …)`. Java in-class annotated duplicate HTTP routes are excluded because
- * [com.linecorp.intellij.plugins.armeria.inspection.ArmeriaDuplicateRouteInspection] covers them.
+ * `.service("/foo", …)`. In-class annotated duplicate HTTP routes are excluded because
+ * [com.linecorp.intellij.plugins.armeria.inspection.ArmeriaDuplicateRouteInspection] and
+ * [com.linecorp.intellij.plugins.armeria.inspection.ArmeriaDuplicateRouteKotlinInspection] cover them.
  */
 object ArmeriaRouteDuplicateIndex {
     private val CHECKED_MATCHES = setOf(
@@ -54,7 +54,7 @@ object ArmeriaRouteDuplicateIndex {
                 continue
             }
             for (component in findConnectedComponents(moduleRoutes)) {
-                if (component.size < 2 || isJavaInClassAnnotatedHttpOnly(component)) {
+                if (component.size < 2 || isInClassAnnotatedHttpOnly(component)) {
                     continue
                 }
                 groups += DuplicateRegistrationGroup(component)
@@ -123,16 +123,13 @@ object ArmeriaRouteDuplicateIndex {
             .map { indices -> indices.map { routes[it] } }
     }
 
-    private fun isJavaInClassAnnotatedHttpOnly(routes: List<ArmeriaRoute>): Boolean {
+    private fun isInClassAnnotatedHttpOnly(routes: List<ArmeriaRoute>): Boolean {
         if (routes.any { it.routeMatch != RouteMatch.ANNOTATED_HTTP }) {
             return false
         }
         var containingClass: PsiClass? = null
         for (route in routes) {
             val method = route.pointer.element as? PsiMethod ?: return false
-            if (!method.language.isKindOf(JavaLanguage.INSTANCE)) {
-                return false
-            }
             val routeClass = method.containingClass ?: return false
             if (containingClass == null) {
                 containingClass = routeClass

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndexCoreTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndexCoreTest.kt
@@ -281,7 +281,7 @@ class ArmeriaRouteDuplicateIndexCoreTest : ArmeriaFixtureTestBase() {
     }
 
 
-    fun testInClassKotlinAnnotatedDuplicatesAreReported() {
+    fun testInClassKotlinAnnotatedDuplicatesAreExcluded() {
         myFixture.configureByText(
             "BadService.kt",
             """
@@ -299,15 +299,7 @@ class ArmeriaRouteDuplicateIndexCoreTest : ArmeriaFixtureTestBase() {
             """.trimIndent(),
         )
 
-        val groups = ArmeriaRouteDuplicateIndex.duplicateGroups(project)
-
-        assertEquals(1, groups.size)
-        assertEquals(2, groups.single().routes.size)
-
-        val hits = ArmeriaRouteDuplicateIndex.duplicateHitsInFile(project, myFixture.file)
-        assertEquals(2, hits.size)
-        assertEquals(setOf("GET /dup"), hits.map { it.registrationLabel }.toSet())
-        assertTrue(hits.all { it.registrationCount == 2 })
+        assertTrue(ArmeriaRouteDuplicateIndex.duplicateGroups(project).isEmpty())
     }
 
 

--- a/plugin-shared/src/main/resources/messages/ArmeriaBundle.properties
+++ b/plugin-shared/src/main/resources/messages/ArmeriaBundle.properties
@@ -7,6 +7,7 @@ inspection.entrypoint.armeria=Armeria Methods
 inspection.group.armeria=Armeria
 inspection.duplicate.route.display.name=Duplicate annotated Armeria route
 inspection.duplicate.route.problem=This annotated Armeria route duplicates another HTTP method/path combination in the same service class.
+inspection.duplicate.route.kotlin.display.name=Duplicate annotated Armeria route (Kotlin)
 inspection.duplicate.registration.display.name=Duplicate Armeria route registration
 inspection.duplicate.registration.kotlin.display.name=Duplicate Armeria route registration (Kotlin)
 inspection.duplicate.registration.problem=This Armeria route {0} is part of a group of {1} conflicting registrations in this module.

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRouteKotlinInspection.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRouteKotlinInspection.kt
@@ -1,0 +1,40 @@
+package com.linecorp.intellij.plugins.armeria.inspection
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElementVisitor
+import com.linecorp.intellij.plugins.armeria.message
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtVisitorVoid
+
+class ArmeriaDuplicateRouteKotlinInspection : LocalInspectionTool() {
+    override fun getDisplayName(): String = message("inspection.duplicate.route.kotlin.display.name")
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return object : KtVisitorVoid() {
+            override fun visitClass(klass: KtClass) {
+                super.visitClass(klass)
+                val duplicateFunctions = linkedSetOf<KtNamedFunction>()
+                val seen = mutableMapOf<Pair<String, String>, KtNamedFunction>()
+                for (function in klass.declarations.filterIsInstance<KtNamedFunction>()) {
+                    val route = ArmeriaKotlinMethodRoute.from(function) ?: continue
+                    for (path in route.paths) {
+                        val key = route.httpMethod to path
+                        val previous = seen.putIfAbsent(key, function)
+                        if (previous != null) {
+                            duplicateFunctions += previous
+                            duplicateFunctions += function
+                        }
+                    }
+                }
+                for (function in duplicateFunctions) {
+                    holder.registerProblem(
+                        function.nameIdentifier ?: function,
+                        message("inspection.duplicate.route.problem"),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRouteKotlinInspection.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRouteKotlinInspection.kt
@@ -4,6 +4,7 @@ import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElementVisitor
 import com.linecorp.intellij.plugins.armeria.message
+import org.jetbrains.kotlin.asJava.toLightClass
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtVisitorVoid
@@ -17,7 +18,7 @@ class ArmeriaDuplicateRouteKotlinInspection : LocalInspectionTool() {
                 super.visitClass(klass)
                 val duplicateFunctions = linkedSetOf<KtNamedFunction>()
                 val seen = mutableMapOf<Pair<String, String>, KtNamedFunction>()
-                for (function in klass.declarations.filterIsInstance<KtNamedFunction>()) {
+                for (function in routeAnnotatedFunctions(klass)) {
                     val route = ArmeriaKotlinMethodRoute.from(function) ?: continue
                     for (path in route.paths) {
                         val key = route.httpMethod to path
@@ -36,5 +37,23 @@ class ArmeriaDuplicateRouteKotlinInspection : LocalInspectionTool() {
                 }
             }
         }
+    }
+
+    private fun routeAnnotatedFunctions(klass: KtClass): List<KtNamedFunction> {
+        val functions = linkedSetOf<KtNamedFunction>()
+        var current: KtClass? = klass
+        while (current != null) {
+            functions += current.declarations.filterIsInstance<KtNamedFunction>()
+            current = superClass(current)
+        }
+        return functions.toList()
+    }
+
+    private fun superClass(klass: KtClass): KtClass? {
+        val typeReference = klass.superTypeListEntries.firstOrNull()?.typeReference ?: return null
+        (typeReference.references.firstOrNull()?.resolve() as? KtClass)?.let { return it }
+        val superName = klass.superTypeListEntries.firstOrNull()?.typeAsUserType?.referencedName ?: return null
+        klass.containingKtFile.declarations.filterIsInstance<KtClass>().firstOrNull { it.name == superName }?.let { return it }
+        return klass.toLightClass()?.superClass?.originalElement as? KtClass
     }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaKotlinMethodRoute.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaKotlinMethodRoute.kt
@@ -1,8 +1,9 @@
 package com.linecorp.intellij.plugins.armeria.inspection
 
+import com.intellij.psi.PsiClass
+import com.intellij.psi.util.PsiTreeUtil
 import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaKotlinRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteSupport
-import com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -12,35 +13,52 @@ internal data class ArmeriaKotlinMethodRoute(
     val paths: List<String>,
 ) {
     companion object {
-        private val HTTP_METHOD_ANNOTATIONS = mapOf(
-            "Get" to "GET",
-            "Head" to "HEAD",
-            "Post" to "POST",
-            "Put" to "PUT",
-            "Delete" to "DELETE",
-            "Options" to "OPTIONS",
-            "Patch" to "PATCH",
-            "Trace" to "TRACE",
-        )
-
         fun from(function: KtNamedFunction): ArmeriaKotlinMethodRoute? {
             val methodAnnotation = function.annotationEntries.firstNotNullOfOrNull { entry ->
-                val method = HTTP_METHOD_ANNOTATIONS[entry.shortName?.asString()] ?: return@firstNotNullOfOrNull null
+                val qualifiedName = entry.qualifiedName() ?: return@firstNotNullOfOrNull null
+                val method = ArmeriaRouteSupport.routeAnnotations[qualifiedName] ?: return@firstNotNullOfOrNull null
                 entry to method
             } ?: return null
             val classPrefix = PsiTreeUtil.getParentOfType(function, KtClass::class.java)?.annotationEntries
-                ?.firstOrNull { it.shortName?.asString() == "PathPrefix" }
+                ?.firstOrNull { it.qualifiedName() == ArmeriaRouteSupport.PATH_PREFIX_ANNOTATION }
                 ?.let(::extractPathPrefix)
                 .orEmpty()
             val paths = buildList {
                 addAll(extractPaths(methodAnnotation.first))
                 function.annotationEntries
-                    .filter { it.shortName?.asString() == "Path" }
+                    .filter { it.qualifiedName() == ArmeriaRouteSupport.PATH_ANNOTATION }
                     .forEach { addAll(extractPaths(it)) }
             }.ifEmpty { listOf("/") }
-                .map { rawPath -> ArmeriaRouteSupport.combinePaths(classPrefix, ArmeriaRouteSupport.normalizePath(rawPath)) }
+                .map { rawPath -> ArmeriaRouteSupport.combinePaths(classPrefix, rawPath) }
                 .distinct()
             return ArmeriaKotlinMethodRoute(methodAnnotation.second, paths)
+        }
+
+        private fun KtAnnotationEntry.qualifiedName(): String? {
+            resolveAnnotationType()?.let { return it }
+            val shortName = shortName?.asString() ?: return null
+            containingKtFile.importDirectives
+                .mapNotNull { it.importPath?.pathStr }
+                .firstOrNull { it == shortName || it.endsWith(".$shortName") }
+                ?.let { return it }
+            return containingKtFile.declarations
+                .filterIsInstance<KtClass>()
+                .firstOrNull { it.name == shortName }
+                ?.fqName?.asString()
+        }
+
+        private fun KtAnnotationEntry.resolveAnnotationType(): String? {
+            val candidates = listOfNotNull(
+                typeReference?.references?.firstOrNull()?.resolve(),
+                calleeExpression?.references?.firstOrNull()?.resolve(),
+            )
+            for (resolved in candidates) {
+                when (resolved) {
+                    is PsiClass -> resolved.qualifiedName?.let { return it }
+                    is KtClass -> resolved.fqName?.asString()?.let { return it }
+                }
+            }
+            return null
         }
 
         private fun extractPathPrefix(annotation: KtAnnotationEntry): String {
@@ -48,13 +66,45 @@ internal data class ArmeriaKotlinMethodRoute(
         }
 
         private fun extractPaths(annotation: KtAnnotationEntry): List<String> {
-            val valueArguments = annotation.valueArguments
-            if (valueArguments.isEmpty()) {
+            val valuePaths = extractNamedKotlinPaths(annotation, "value")
+            if (valuePaths.isNotEmpty()) {
+                return valuePaths.map(::preserveOrNormalizePath)
+            }
+            val pathPaths = extractNamedKotlinPaths(annotation, "path")
+            if (pathPaths.isNotEmpty()) {
+                return pathPaths.map(::preserveOrNormalizePath)
+            }
+            return emptyList()
+        }
+
+        private fun extractNamedKotlinPaths(annotation: KtAnnotationEntry, name: String): List<String> {
+            val named = annotation.valueArguments
+                .filter { it.getArgumentName()?.asName?.asString() == name }
+                .flatMap { argument ->
+                    ArmeriaKotlinRouteCollector.extractKotlinStrings(argument.getArgumentExpression())
+                }
+            if (named.isNotEmpty()) {
+                return named
+            }
+            if (name != "value") {
                 return emptyList()
             }
-            return valueArguments.flatMap { argument ->
-                ArmeriaKotlinRouteCollector.extractKotlinStrings(argument.getArgumentExpression())
-            }
+            return annotation.valueArguments
+                .filter { it.getArgumentName() == null }
+                .flatMap { argument ->
+                    ArmeriaKotlinRouteCollector.extractKotlinStrings(argument.getArgumentExpression())
+                }
         }
+
+        private fun preserveOrNormalizePath(path: String): String {
+            val trimmed = path.trim()
+            return if (hasPathTypePrefix(trimmed)) trimmed else ArmeriaRouteSupport.normalizePath(trimmed)
+        }
+
+        private fun hasPathTypePrefix(path: String): Boolean =
+            path.startsWith("prefix:") ||
+                path.startsWith("regex:") ||
+                path.startsWith("glob:") ||
+                path.startsWith("exact:")
     }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaKotlinMethodRoute.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaKotlinMethodRoute.kt
@@ -1,11 +1,11 @@
 package com.linecorp.intellij.plugins.armeria.inspection
 
+import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaKotlinRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteSupport
 import com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtNamedFunction
-import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 
 internal data class ArmeriaKotlinMethodRoute(
     val httpMethod: String,
@@ -53,20 +53,7 @@ internal data class ArmeriaKotlinMethodRoute(
                 return emptyList()
             }
             return valueArguments.flatMap { argument ->
-                argument.getArgumentExpression()?.let(::extractStringValues).orEmpty()
-            }
-        }
-
-        private fun extractStringValues(expression: org.jetbrains.kotlin.psi.KtExpression): List<String> {
-            return when (expression) {
-                is KtStringTemplateExpression -> {
-                    if (expression.entries.size == 1 && expression.entries[0].text.startsWith('"')) {
-                        listOf(expression.entries[0].text.trim('"'))
-                    } else {
-                        listOf(expression.text.trim('"'))
-                    }
-                }
-                else -> listOf(expression.text.trim('"')).filter { it.isNotEmpty() }
+                ArmeriaKotlinRouteCollector.extractKotlinStrings(argument.getArgumentExpression())
             }
         }
     }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaKotlinMethodRoute.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaKotlinMethodRoute.kt
@@ -1,0 +1,73 @@
+package com.linecorp.intellij.plugins.armeria.inspection
+
+import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteSupport
+import com.intellij.psi.util.PsiTreeUtil
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+
+internal data class ArmeriaKotlinMethodRoute(
+    val httpMethod: String,
+    val paths: List<String>,
+) {
+    companion object {
+        private val HTTP_METHOD_ANNOTATIONS = mapOf(
+            "Get" to "GET",
+            "Head" to "HEAD",
+            "Post" to "POST",
+            "Put" to "PUT",
+            "Delete" to "DELETE",
+            "Options" to "OPTIONS",
+            "Patch" to "PATCH",
+            "Trace" to "TRACE",
+        )
+
+        fun from(function: KtNamedFunction): ArmeriaKotlinMethodRoute? {
+            val methodAnnotation = function.annotationEntries.firstNotNullOfOrNull { entry ->
+                val method = HTTP_METHOD_ANNOTATIONS[entry.shortName?.asString()] ?: return@firstNotNullOfOrNull null
+                entry to method
+            } ?: return null
+            val classPrefix = PsiTreeUtil.getParentOfType(function, KtClass::class.java)?.annotationEntries
+                ?.firstOrNull { it.shortName?.asString() == "PathPrefix" }
+                ?.let(::extractPathPrefix)
+                .orEmpty()
+            val paths = buildList {
+                addAll(extractPaths(methodAnnotation.first))
+                function.annotationEntries
+                    .filter { it.shortName?.asString() == "Path" }
+                    .forEach { addAll(extractPaths(it)) }
+            }.ifEmpty { listOf("/") }
+                .map { rawPath -> ArmeriaRouteSupport.combinePaths(classPrefix, ArmeriaRouteSupport.normalizePath(rawPath)) }
+                .distinct()
+            return ArmeriaKotlinMethodRoute(methodAnnotation.second, paths)
+        }
+
+        private fun extractPathPrefix(annotation: KtAnnotationEntry): String {
+            return extractPaths(annotation).firstOrNull().orEmpty()
+        }
+
+        private fun extractPaths(annotation: KtAnnotationEntry): List<String> {
+            val valueArguments = annotation.valueArguments
+            if (valueArguments.isEmpty()) {
+                return emptyList()
+            }
+            return valueArguments.flatMap { argument ->
+                argument.getArgumentExpression()?.let(::extractStringValues).orEmpty()
+            }
+        }
+
+        private fun extractStringValues(expression: org.jetbrains.kotlin.psi.KtExpression): List<String> {
+            return when (expression) {
+                is KtStringTemplateExpression -> {
+                    if (expression.entries.size == 1 && expression.entries[0].text.startsWith('"')) {
+                        listOf(expression.entries[0].text.trim('"'))
+                    } else {
+                        listOf(expression.text.trim('"'))
+                    }
+                }
+                else -> listOf(expression.text.trim('"')).filter { it.isNotEmpty() }
+            }
+        }
+    }
+}

--- a/plugin/src/main/resources/META-INF/kotlin-integration.xml
+++ b/plugin/src/main/resources/META-INF/kotlin-integration.xml
@@ -3,6 +3,15 @@
     <extensions defaultExtensionNs="com.intellij">
         <localInspection language="kotlin"
                          bundle="messages.ArmeriaBundle"
+                         key="inspection.duplicate.route.kotlin.display.name"
+                         groupBundle="messages.ArmeriaBundle"
+                         groupKey="inspection.group.armeria"
+                         shortName="ArmeriaDuplicateRouteKotlin"
+                         enabledByDefault="true"
+                         level="WARNING"
+                         implementationClass="com.linecorp.intellij.plugins.armeria.inspection.ArmeriaDuplicateRouteKotlinInspection" />
+        <localInspection language="kotlin"
+                         bundle="messages.ArmeriaBundle"
                          key="inspection.duplicate.registration.kotlin.display.name"
                          groupBundle="messages.ArmeriaBundle"
                          groupKey="inspection.group.armeria"

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRouteKotlinInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRouteKotlinInspectionTest.kt
@@ -1,0 +1,66 @@
+package com.linecorp.intellij.plugins.armeria.inspection
+
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+
+class ArmeriaDuplicateRouteKotlinInspectionTest : LightJavaCodeInsightFixtureTestCase() {
+    override fun setUp() {
+        super.setUp()
+        registerArmeriaStubs()
+        myFixture.enableInspections(ArmeriaDuplicateRouteKotlinInspection())
+    }
+
+    fun testHighlightsDuplicateKotlinRoutes() {
+        myFixture.configureByText(
+            "BadService.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.annotation.Get
+
+            class BadService {
+                @Get("/dup")
+                fun <warning descr="This annotated Armeria route duplicates another HTTP method/path combination in the same service class.">first</warning>(): String = "first"
+
+                @Get("/dup")
+                fun <warning descr="This annotated Armeria route duplicates another HTTP method/path combination in the same service class.">second</warning>(): String = "second"
+            }
+            """.trimIndent(),
+        )
+
+        myFixture.testHighlighting(true, false, true)
+    }
+
+    fun testHighlightsInheritedDuplicateKotlinRoutes() {
+        myFixture.configureByText(
+            "Services.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.annotation.Get
+
+            open class BaseService {
+                @Get("/dup")
+                fun <warning descr="This annotated Armeria route duplicates another HTTP method/path combination in the same service class.">base</warning>(): String = "base"
+            }
+
+            class ChildService : BaseService() {
+                @Get("/dup")
+                fun <warning descr="This annotated Armeria route duplicates another HTTP method/path combination in the same service class.">child</warning>(): String = "child"
+            }
+            """.trimIndent(),
+        )
+
+        myFixture.testHighlighting(true, false, true)
+    }
+
+    private fun registerArmeriaStubs() {
+        myFixture.configureByText(
+            "Get.kt",
+            """
+            package com.linecorp.armeria.server.annotation
+
+            annotation class Get(val value: String = "", val path: String = "")
+            """.trimIndent(),
+        )
+    }
+}

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaKotlinMethodRouteTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaKotlinMethodRouteTest.kt
@@ -1,0 +1,76 @@
+package com.linecorp.intellij.plugins.armeria.inspection
+
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtNamedFunction
+
+class ArmeriaKotlinMethodRouteTest : LightJavaCodeInsightFixtureTestCase() {
+    override fun setUp() {
+        super.setUp()
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.server.annotation;
+            public @interface Get { String value() default ""; String path() default ""; }
+            """.trimIndent(),
+        )
+    }
+
+    fun testDetectsDuplicateKotlinAnnotatedRoutes() {
+        val file = configureKotlinService(
+            """
+            class HelloService {
+                @Get("/hello")
+                fun first(): String = "first"
+
+                @Get("/hello")
+                fun second(): String = "second"
+            }
+            """.trimIndent(),
+        )
+        val functions = functionsIn(file)
+        val routes = functions.mapNotNull(ArmeriaKotlinMethodRoute::from)
+        val duplicateKeys = routes
+            .flatMap { route -> route.paths.map { route.httpMethod to it } }
+            .groupingBy { it }
+            .eachCount()
+            .filterValues { it > 1 }
+
+        assertEquals(setOf("GET" to "/hello"), duplicateKeys.keys)
+    }
+
+    fun testAllowsDistinctPaths() {
+        val file = configureKotlinService(
+            """
+            class HelloService {
+                @Get("/hello")
+                fun hello(): String = "hello"
+
+                @Get("/goodbye")
+                fun goodbye(): String = "goodbye"
+            }
+            """.trimIndent(),
+        )
+        val routes = functionsIn(file).mapNotNull(ArmeriaKotlinMethodRoute::from)
+
+        assertEquals(2, routes.size)
+        assertEquals(setOf("/hello", "/goodbye"), routes.flatMap { it.paths }.toSet())
+    }
+
+    private fun configureKotlinService(body: String) =
+        myFixture.configureByText(
+            "HelloService.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.annotation.Get
+
+            $body
+            """.trimIndent(),
+        ) as KtFile
+
+    private fun functionsIn(file: KtFile): List<KtNamedFunction> {
+        val klass = file.declarations.filterIsInstance<KtClass>().single()
+        return klass.declarations.filterIsInstance<KtNamedFunction>()
+    }
+}

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaKotlinMethodRouteTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaKotlinMethodRouteTest.kt
@@ -14,6 +14,12 @@ class ArmeriaKotlinMethodRouteTest : LightJavaCodeInsightFixtureTestCase() {
             public @interface Get { String value() default ""; String path() default ""; }
             """.trimIndent(),
         )
+        myFixture.addClass(
+            """
+            package example.other;
+            public @interface Get { String value() default ""; }
+            """.trimIndent(),
+        )
     }
 
     fun testDetectsDuplicateKotlinAnnotatedRoutes() {
@@ -37,6 +43,39 @@ class ArmeriaKotlinMethodRouteTest : LightJavaCodeInsightFixtureTestCase() {
             .filterValues { it > 1 }
 
         assertEquals(setOf("GET" to "/hello"), duplicateKeys.keys)
+    }
+
+    fun testPrefersValueOverPathAnnotationArgument() {
+        val file = configureKotlinService(
+            """
+            class HelloService {
+                @Get(value = "/value", path = "/path")
+                fun hello(): String = "hello"
+            }
+            """.trimIndent(),
+        )
+        val route = functionsIn(file).mapNotNull(ArmeriaKotlinMethodRoute::from).single()
+
+        assertEquals(listOf("/value"), route.paths)
+    }
+
+    fun testIgnoresNonArmeriaGetAnnotation() {
+        val file = myFixture.configureByText(
+            "HelloService.kt",
+            """
+            package example
+
+            import example.other.Get
+
+            class HelloService {
+                @Get("/other")
+                fun hello(): String = "hello"
+            }
+            """.trimIndent(),
+        ) as KtFile
+        val routes = functionsIn(file).mapNotNull(ArmeriaKotlinMethodRoute::from)
+
+        assertTrue(routes.isEmpty())
     }
 
     fun testAllowsDistinctPaths() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Kotlin-language inspection that flags duplicate HTTP method and path combinations within the same annotated service class. This closes the gap where only Java in-class duplicates were reported while Kotlin projects relied on the module-scoped registration inspection alone.

## Changes

- Add `ArmeriaDuplicateRouteKotlinInspection` for Kotlin annotated services
- Add `ArmeriaKotlinMethodRoute` helper to extract method, path, and `@PathPrefix` metadata from Kotlin PSI
- Register the inspection in `kotlin-integration.xml`
- Add PSI-level regression tests for duplicate and distinct route detection

## Test plan

- [x] `./gradlew :plugin:test --tests "com.linecorp.intellij.plugins.armeria.inspection.ArmeriaKotlinMethodRouteTest"`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2f99-960e-7eff-b723-5f94c74e70ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2f99-960e-7eff-b723-5f94c74e70ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

