### PR TITLE
feat: add Armeria JUnit test support in IDE

### DIFF
--- a/plugin-shared/src/main/resources/messages/ArmeriaBundle.properties
+++ b/plugin-shared/src/main/resources/messages/ArmeriaBundle.properties
@@ -285,5 +285,15 @@ route.explorer.footnote.runtime={0} runtime routes from DocService are shown alo
 route.explorer.action.openDocService=Open DocService
 route.explorer.action.openDocService.description=Opens DocService in the browser using http://localhost:8080 (static analysis cannot resolve the runtime port).
 route.explorer.action.openDocService.descriptionWithUrl=Open {0} (assumes http://localhost:8080 unless the server uses a different port).
+route.explorer.action.generateTestMethod=Generate Test Method
 route.explorer.footnote.static=Routes are discovered by static analysis and may differ from runtime.
 route.explorer.tree.module={0} ({1})
+
+inspection.blocking.client.display.name=Blocking route called with async WebClient in test
+inspection.blocking.client.kotlin.display.name=Blocking route called with async WebClient in test (Kotlin)
+inspection.blocking.client.problem=Route {0} is marked @Blocking; use blockingWebClient() in tests instead of async WebClient.
+test.support.lineMarker.name=Armeria JUnit ServerExtension
+test.support.lineMarker.tooltip=Armeria ServerExtension: {0}
+test.support.insert.title=Generate Armeria test
+test.support.insert.noTarget=Open a JUnit test class with a @RegisterExtension ServerExtension to insert a test method.
+test.support.insert.noServerExtension=No @RegisterExtension ServerExtension field was found in the target test class.

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGenerateTestMethodAction.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGenerateTestMethodAction.kt
@@ -1,0 +1,35 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAwareAction
+import com.linecorp.intellij.plugins.armeria.message
+import com.linecorp.intellij.plugins.armeria.test.ArmeriaTestMethodGenerator
+import com.linecorp.intellij.plugins.armeria.test.ArmeriaTestMethodInserter
+
+internal class ArmeriaGenerateTestMethodAction(
+    private val selectedRouteProvider: () -> ArmeriaRoute?,
+) : DumbAwareAction(
+    message("route.explorer.action.generateTestMethod"),
+) {
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
+
+    override fun update(e: AnActionEvent) {
+        val project = e.project
+        if (project == null || project.basePath == null) {
+            e.presentation.isEnabled = false
+            return
+        }
+        val route = selectedRouteProvider()
+        e.presentation.isEnabled = route != null && ArmeriaTestMethodGenerator.supports(route)
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val route = selectedRouteProvider() ?: return
+        if (!ArmeriaTestMethodGenerator.supports(route)) {
+            return
+        }
+        ArmeriaTestMethodInserter.insertFromRouteExplorer(project, route)
+    }
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerPanel.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerPanel.kt
@@ -75,6 +75,7 @@ class ArmeriaRouteExplorerPanel(
             add(ArmeriaGenerateHttpRequestAction { selectedRouteFromTree() })
             add(ArmeriaSyncRuntimeRoutesAction())
             add(ArmeriaOpenDocServiceAction { filterRoutes(allRoutes()) })
+            add(ArmeriaGenerateTestMethodAction { selectedRouteFromTree() })
         }
         toolbar = ActionManager.getInstance().createActionToolbar("ArmeriaRouteExplorer", actionGroup, true).also {
             it.targetComponent = this

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientInspection.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientInspection.kt
@@ -1,0 +1,98 @@
+package com.linecorp.intellij.plugins.armeria.test
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.JavaElementVisitor
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiLiteralExpression
+import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.psi.PsiReferenceExpression
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.util.PsiTreeUtil
+import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteCollector
+import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteSupport
+import com.linecorp.intellij.plugins.armeria.message
+
+class ArmeriaBlockingClientInspection : LocalInspectionTool() {
+    override fun getDisplayName(): String = message("inspection.blocking.client.display.name")
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        val scope = GlobalSearchScope.projectScope(holder.project)
+        val blockingPaths = ArmeriaBlockingClientInspectionPaths.blockingRoutePaths(holder.project)
+        if (blockingPaths.isEmpty()) {
+            return PsiElementVisitor.EMPTY_VISITOR
+        }
+        return object : JavaElementVisitor() {
+            override fun visitMethodCallExpression(expression: PsiMethodCallExpression) {
+                val extension = ArmeriaJUnitServerExtensionSupport.enclosingServerExtension(expression, scope) ?: return
+                if (!usesAsyncWebClient(expression, extension.variableName)) {
+                    return
+                }
+                val path = extractRequestPath(expression) ?: return
+                if (!blockingPaths.contains(ArmeriaRouteSupport.normalizePath(path))) {
+                    return
+                }
+                holder.registerProblem(
+                    expression.methodExpression,
+                    message("inspection.blocking.client.problem", path),
+                )
+            }
+        }
+    }
+
+    private fun usesAsyncWebClient(expression: PsiMethodCallExpression, serverVariableName: String): Boolean {
+        val qualifier = expression.methodExpression.qualifierExpression ?: return false
+        if (qualifier is PsiReferenceExpression && qualifier.referenceName == serverVariableName) {
+            return expression.methodExpression.referenceName in setOf("webClient", "httpUri")
+        }
+        if (qualifier is PsiMethodCallExpression) {
+            val receiver = qualifier.methodExpression.qualifierExpression as? PsiReferenceExpression
+            if (receiver?.referenceName == serverVariableName &&
+                qualifier.methodExpression.referenceName == "webClient"
+            ) {
+                return expression.methodExpression.referenceName in HTTP_METHOD_NAMES
+            }
+            if (qualifier.methodExpression.referenceName == "of" &&
+                qualifier.resolveMethod()?.containingClass?.qualifiedName == ArmeriaJUnitServerExtensionSupport.WEB_CLIENT_CLASS
+            ) {
+                return expression.methodExpression.referenceName in HTTP_METHOD_NAMES
+            }
+        }
+        if (qualifier is PsiReferenceExpression && isWebClientType(qualifier)) {
+            return expression.methodExpression.referenceName in HTTP_METHOD_NAMES
+        }
+        return false
+    }
+
+    private fun isWebClientType(reference: PsiReferenceExpression): Boolean {
+        val typeName = when (val resolved = reference.resolve()) {
+            is com.intellij.psi.PsiVariable -> resolved.type.canonicalText
+            is PsiClass -> resolved.qualifiedName
+            else -> PsiTreeUtil.getParentOfType(resolved, PsiClass::class.java)?.qualifiedName
+        } ?: reference.text
+        return typeName == ArmeriaJUnitServerExtensionSupport.WEB_CLIENT_CLASS || typeName.endsWith(".WebClient")
+    }
+
+    private fun extractRequestPath(expression: PsiMethodCallExpression): String? {
+        val methodName = expression.methodExpression.referenceName ?: return null
+        if (methodName !in HTTP_METHOD_NAMES) {
+            return null
+        }
+        return (expression.argumentList.expressions.firstOrNull() as? PsiLiteralExpression)?.value as? String
+    }
+
+    companion object {
+        private val HTTP_METHOD_NAMES = setOf("get", "post", "put", "patch", "delete", "head", "options", "trace")
+    }
+}
+
+internal object ArmeriaBlockingClientInspectionPaths {
+    fun blockingRoutePaths(project: com.intellij.openapi.project.Project): Set<String> {
+        return ArmeriaRouteCollector.collect(project)
+            .asSequence()
+            .filter { ArmeriaTestMethodGenerator.supports(it) && ArmeriaTestMethodGenerator.requiresBlockingClient(it) }
+            .map { ArmeriaRouteSupport.normalizePath(it.path) }
+            .toSet()
+    }
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientKotlinInspection.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientKotlinInspection.kt
@@ -2,7 +2,6 @@ package com.linecorp.intellij.plugins.armeria.test
 
 import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.ProblemsHolder
-import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.search.GlobalSearchScope
 import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteSupport
@@ -10,6 +9,7 @@ import com.linecorp.intellij.plugins.armeria.message
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.psi.KtVisitorVoid
 
 class ArmeriaBlockingClientKotlinInspection : LocalInspectionTool() {
     override fun getDisplayName(): String = message("inspection.blocking.client.kotlin.display.name")
@@ -20,19 +20,19 @@ class ArmeriaBlockingClientKotlinInspection : LocalInspectionTool() {
         if (blockingPaths.isEmpty()) {
             return PsiElementVisitor.EMPTY_VISITOR
         }
-        return object : PsiElementVisitor() {
-            override fun visitElement(element: PsiElement) {
-                val call = element as? KtCallExpression ?: return
-                val extension = ArmeriaJUnitServerExtensionSupport.enclosingServerExtension(call, scope) ?: return
-                if (!usesAsyncWebClient(call, extension.variableName)) {
+        return object : KtVisitorVoid() {
+            override fun visitCallExpression(expression: KtCallExpression) {
+                super.visitCallExpression(expression)
+                val extension = ArmeriaJUnitServerExtensionSupport.enclosingServerExtension(expression, scope) ?: return
+                if (!usesAsyncWebClient(expression, extension.variableName)) {
                     return
                 }
-                val path = extractRequestPath(call) ?: return
+                val path = extractRequestPath(expression) ?: return
                 if (!blockingPaths.contains(ArmeriaRouteSupport.normalizePath(path))) {
                     return
                 }
                 holder.registerProblem(
-                    call.calleeExpression ?: call,
+                    expression.calleeExpression ?: expression,
                     message("inspection.blocking.client.problem", path),
                 )
             }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientKotlinInspection.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientKotlinInspection.kt
@@ -1,0 +1,69 @@
+package com.linecorp.intellij.plugins.armeria.test
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.search.GlobalSearchScope
+import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteSupport
+import com.linecorp.intellij.plugins.armeria.message
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+
+class ArmeriaBlockingClientKotlinInspection : LocalInspectionTool() {
+    override fun getDisplayName(): String = message("inspection.blocking.client.kotlin.display.name")
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        val scope = GlobalSearchScope.projectScope(holder.project)
+        val blockingPaths = ArmeriaBlockingClientInspectionPaths.blockingRoutePaths(holder.project)
+        if (blockingPaths.isEmpty()) {
+            return PsiElementVisitor.EMPTY_VISITOR
+        }
+        return object : PsiElementVisitor() {
+            override fun visitElement(element: PsiElement) {
+                val call = element as? KtCallExpression ?: return
+                val extension = ArmeriaJUnitServerExtensionSupport.enclosingServerExtension(call, scope) ?: return
+                if (!usesAsyncWebClient(call, extension.variableName)) {
+                    return
+                }
+                val path = extractRequestPath(call) ?: return
+                if (!blockingPaths.contains(ArmeriaRouteSupport.normalizePath(path))) {
+                    return
+                }
+                holder.registerProblem(
+                    call.calleeExpression ?: call,
+                    message("inspection.blocking.client.problem", path),
+                )
+            }
+        }
+    }
+
+    private fun usesAsyncWebClient(call: KtCallExpression, serverVariableName: String): Boolean {
+        val parent = call.parent as? KtDotQualifiedExpression ?: return false
+        val receiver = parent.receiverExpression.text
+        if (receiver == serverVariableName) {
+            return (parent.selectorExpression as? KtCallExpression)?.calleeExpression?.text in setOf("webClient", "httpUri")
+        }
+        if (receiver.startsWith("WebClient.of") || receiver.endsWith("WebClient") || receiver.contains("webClient")) {
+            return call.calleeExpression?.text in HTTP_METHOD_NAMES
+        }
+        return false
+    }
+
+    private fun extractRequestPath(call: KtCallExpression): String? {
+        val methodName = call.calleeExpression?.text ?: return null
+        if (methodName !in HTTP_METHOD_NAMES) {
+            return null
+        }
+        val argument = call.valueArguments.firstOrNull()?.getArgumentExpression() as? KtStringTemplateExpression ?: return null
+        if (argument.entries.size != 1) {
+            return null
+        }
+        return argument.entries.single().text.removeSurrounding("\"")
+    }
+
+    companion object {
+        private val HTTP_METHOD_NAMES = setOf("get", "post", "put", "patch", "delete", "head", "options", "trace")
+    }
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaJUnitServerExtension.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaJUnitServerExtension.kt
@@ -1,0 +1,28 @@
+package com.linecorp.intellij.plugins.armeria.test
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.SmartPointerManager
+import com.intellij.psi.SmartPsiElementPointer
+
+data class ArmeriaJUnitServerExtension(
+    val variableName: String,
+    val containingClassName: String,
+    val moduleName: String,
+    val pointer: SmartPsiElementPointer<PsiElement>,
+) {
+    companion object {
+        fun create(
+            element: PsiElement,
+            variableName: String,
+            containingClassName: String,
+            moduleName: String,
+        ): ArmeriaJUnitServerExtension {
+            return ArmeriaJUnitServerExtension(
+                variableName = variableName,
+                containingClassName = containingClassName,
+                moduleName = moduleName,
+                pointer = SmartPointerManager.createPointer(element),
+            )
+        }
+    }
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaJUnitServerExtensionCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaJUnitServerExtensionCollector.kt
@@ -1,0 +1,73 @@
+package com.linecorp.intellij.plugins.armeria.test
+
+import com.intellij.ide.highlighter.JavaFileType
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.extensions.PluginId
+import com.intellij.openapi.project.Project
+import com.intellij.psi.JavaRecursiveElementWalkingVisitor
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiJavaFile
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.FileTypeIndex
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
+import com.intellij.psi.util.PsiModificationTracker
+
+object ArmeriaJUnitServerExtensionCollector {
+    private val KOTLIN_PLUGIN_ID = PluginId.getId("org.jetbrains.kotlin")
+
+    fun collect(project: Project): List<ArmeriaJUnitServerExtension> {
+        return CachedValuesManager.getManager(project).getCachedValue(project) {
+            compute(project)
+        }
+    }
+
+    fun extensionsInClass(project: Project, psiClass: PsiClass): List<ArmeriaJUnitServerExtension> {
+        val scope = GlobalSearchScope.projectScope(project)
+        val fromFields = ArmeriaJUnitServerExtensionSupport.serverExtensionsInClass(psiClass, scope)
+        if (fromFields.isNotEmpty()) {
+            return fromFields
+        }
+        val className = psiClass.qualifiedName ?: return emptyList()
+        return collect(project).filter { it.containingClassName == className }
+    }
+
+    private fun compute(project: Project): CachedValueProvider.Result<List<ArmeriaJUnitServerExtension>> {
+        val scope = GlobalSearchScope.projectScope(project)
+        val extensions = mutableListOf<ArmeriaJUnitServerExtension>()
+        val seen = mutableSetOf<String>()
+        for (virtualFile in FileTypeIndex.getFiles(JavaFileType.INSTANCE, scope)) {
+            val file = PsiManager.getInstance(project).findFile(virtualFile) as? PsiJavaFile ?: continue
+            if (!file.text.contains(ArmeriaJUnitServerExtensionSupport.REGISTER_EXTENSION_ANNOTATION)) {
+                continue
+            }
+            file.accept(
+                object : JavaRecursiveElementWalkingVisitor() {
+                    override fun visitClass(aClass: PsiClass) {
+                        for (extension in ArmeriaJUnitServerExtensionSupport.serverExtensionsInClass(aClass, scope)) {
+                            add(extension, extensions, seen)
+                        }
+                        super.visitClass(aClass)
+                    }
+                },
+            )
+        }
+        if (PluginManagerCore.isLoaded(KOTLIN_PLUGIN_ID)) {
+            ArmeriaKotlinJUnitServerExtensionCollector.collect(project, scope, extensions, seen)
+        }
+        val sorted = extensions.sortedWith(compareBy({ it.moduleName }, { it.containingClassName }, { it.variableName }))
+        return CachedValueProvider.Result.create(sorted, PsiModificationTracker.MODIFICATION_COUNT)
+    }
+
+    internal fun add(
+        extension: ArmeriaJUnitServerExtension,
+        extensions: MutableList<ArmeriaJUnitServerExtension>,
+        seen: MutableSet<String>,
+    ) {
+        val key = "${extension.containingClassName}#${extension.variableName}"
+        if (seen.add(key)) {
+            extensions += extension
+        }
+    }
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaJUnitServerExtensionLineMarkerProvider.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaJUnitServerExtensionLineMarkerProvider.kt
@@ -1,0 +1,33 @@
+package com.linecorp.intellij.plugins.armeria.test
+
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.codeInsight.daemon.LineMarkerProviderDescriptor
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.editor.markup.GutterIconRenderer
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiField
+import com.intellij.psi.search.GlobalSearchScope
+import com.linecorp.intellij.plugins.armeria.message
+
+class ArmeriaJUnitServerExtensionLineMarkerProvider : LineMarkerProviderDescriptor() {
+    override fun getName(): String = message("test.support.lineMarker.name")
+
+    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
+        val field = element as? PsiField ?: return null
+        if (element != field.nameIdentifier && element != field) {
+            return null
+        }
+        val scope = GlobalSearchScope.projectScope(field.project)
+        if (ArmeriaJUnitServerExtensionSupport.serverExtensionFromField(field, scope) == null) {
+            return null
+        }
+        return LineMarkerInfo(
+            field,
+            field.textRange,
+            AllIcons.RunConfigurations.Junit,
+            { message("test.support.lineMarker.tooltip", field.name) },
+            null,
+            GutterIconRenderer.Alignment.CENTER,
+        )
+    }
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaJUnitServerExtensionSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaJUnitServerExtensionSupport.kt
@@ -9,6 +9,9 @@ import com.intellij.psi.PsiField
 import com.intellij.psi.PsiModifierListOwner
 import com.intellij.psi.PsiType
 import com.intellij.psi.search.GlobalSearchScope
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 
 internal object ArmeriaJUnitServerExtensionSupport {
     const val REGISTER_EXTENSION_ANNOTATION = "org.junit.jupiter.api.extension.RegisterExtension"
@@ -50,6 +53,24 @@ internal object ArmeriaJUnitServerExtensionSupport {
 
     fun serverExtensionsInClass(psiClass: PsiClass, scope: GlobalSearchScope): List<ArmeriaJUnitServerExtension> {
         return psiClass.fields.mapNotNull { serverExtensionFromField(it, scope) }
+    }
+
+    fun serverExtensionFromKotlinProperty(property: KtProperty, scope: GlobalSearchScope): ArmeriaJUnitServerExtension? {
+        if (!property.annotationEntries.any { it.shortName?.asString() == "RegisterExtension" }) {
+            return null
+        }
+        val typeText = property.typeReference?.text ?: return null
+        if (!typeText.contains("ServerExtension")) {
+            return null
+        }
+        val variableName = property.name ?: return null
+        val containingClass = property.getParentOfType<KtClass>(true) ?: return null
+        return ArmeriaJUnitServerExtension.create(
+            element = property,
+            variableName = variableName,
+            containingClassName = containingClass.fqName?.asString().orEmpty(),
+            moduleName = ArmeriaTestMetadata.moduleName(property),
+        )
     }
 
     fun enclosingServerExtension(element: PsiElement, scope: GlobalSearchScope): ArmeriaJUnitServerExtension? {

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaJUnitServerExtensionSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaJUnitServerExtensionSupport.kt
@@ -1,0 +1,65 @@
+package com.linecorp.intellij.plugins.armeria.test
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiModifierListOwner
+import com.intellij.psi.PsiType
+import com.intellij.psi.search.GlobalSearchScope
+
+internal object ArmeriaJUnitServerExtensionSupport {
+    const val REGISTER_EXTENSION_ANNOTATION = "org.junit.jupiter.api.extension.RegisterExtension"
+    const val SERVER_EXTENSION_CLASS = "com.linecorp.armeria.testing.junit5.server.ServerExtension"
+    const val WEB_CLIENT_CLASS = "com.linecorp.armeria.client.WebClient"
+    const val BLOCKING_WEB_CLIENT_CLASS = "com.linecorp.armeria.client.blocking.BlockingWebClient"
+
+    fun hasRegisterExtensionAnnotation(owner: PsiModifierListOwner): Boolean {
+        return owner.annotations.any { it.qualifiedName == REGISTER_EXTENSION_ANNOTATION }
+    }
+
+    fun isServerExtensionType(type: PsiType?, project: Project, scope: GlobalSearchScope): Boolean {
+        val resolvedClass = (type as? PsiClassType)?.resolve() ?: return false
+        return isServerExtensionClass(resolvedClass, project, scope)
+    }
+
+    fun isServerExtensionClass(psiClass: PsiClass, project: Project, scope: GlobalSearchScope): Boolean {
+        val qualifiedName = psiClass.qualifiedName ?: return false
+        if (qualifiedName == SERVER_EXTENSION_CLASS) {
+            return true
+        }
+        val baseClass = JavaPsiFacade.getInstance(project).findClass(SERVER_EXTENSION_CLASS, scope) ?: return false
+        return psiClass.isInheritor(baseClass, true)
+    }
+
+    fun serverExtensionFromField(field: PsiField, scope: GlobalSearchScope): ArmeriaJUnitServerExtension? {
+        if (!hasRegisterExtensionAnnotation(field) || !isServerExtensionType(field.type, field.project, scope)) {
+            return null
+        }
+        val variableName = field.name ?: return null
+        val containingClass = field.containingClass ?: return null
+        return ArmeriaJUnitServerExtension.create(
+            element = field,
+            variableName = variableName,
+            containingClassName = containingClass.qualifiedName.orEmpty(),
+            moduleName = ArmeriaTestMetadata.moduleName(field),
+        )
+    }
+
+    fun serverExtensionsInClass(psiClass: PsiClass, scope: GlobalSearchScope): List<ArmeriaJUnitServerExtension> {
+        return psiClass.fields.mapNotNull { serverExtensionFromField(it, scope) }
+    }
+
+    fun enclosingServerExtension(element: PsiElement, scope: GlobalSearchScope): ArmeriaJUnitServerExtension? {
+        var current: PsiElement? = element
+        while (current != null) {
+            if (current is PsiClass) {
+                serverExtensionsInClass(current, scope).firstOrNull()?.let { return it }
+            }
+            current = current.parent
+        }
+        return null
+    }
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaKotlinJUnitServerExtensionCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaKotlinJUnitServerExtensionCollector.kt
@@ -1,0 +1,53 @@
+package com.linecorp.intellij.plugins.armeria.test
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.FileTypeIndex
+import com.intellij.psi.search.GlobalSearchScope
+import org.jetbrains.kotlin.idea.KotlinFileType
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
+
+internal object ArmeriaKotlinJUnitServerExtensionCollector {
+    fun collect(
+        project: Project,
+        scope: GlobalSearchScope,
+        extensions: MutableList<ArmeriaJUnitServerExtension>,
+        seen: MutableSet<String>,
+    ) {
+        for (virtualFile in FileTypeIndex.getFiles(KotlinFileType.INSTANCE, scope)) {
+            val file = PsiManager.getInstance(project).findFile(virtualFile) as? KtFile ?: continue
+            if (!file.text.contains(ArmeriaJUnitServerExtensionSupport.REGISTER_EXTENSION_ANNOTATION)) {
+                continue
+            }
+            for (property in file.declarations.filterIsInstance<KtProperty>()) {
+                from(property, scope)?.let { ArmeriaJUnitServerExtensionCollector.add(it, extensions, seen) }
+            }
+            for (ktClass in file.declarations.filterIsInstance<KtClass>()) {
+                for (property in ktClass.declarations.filterIsInstance<KtProperty>()) {
+                    from(property, scope)?.let { ArmeriaJUnitServerExtensionCollector.add(it, extensions, seen) }
+                }
+            }
+        }
+    }
+
+    private fun from(property: KtProperty, scope: GlobalSearchScope): ArmeriaJUnitServerExtension? {
+        if (!property.annotationEntries.any { it.shortName?.asString() == "RegisterExtension" }) {
+            return null
+        }
+        val typeText = property.typeReference?.text ?: return null
+        if (!typeText.contains("ServerExtension")) {
+            return null
+        }
+        val variableName = property.name ?: return null
+        val containingClass = property.getParentOfType<KtClass>(true) ?: return null
+        return ArmeriaJUnitServerExtension.create(
+            element = property,
+            variableName = variableName,
+            containingClassName = containingClass.fqName?.asString().orEmpty(),
+            moduleName = ArmeriaTestMetadata.moduleName(property),
+        )
+    }
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaKotlinJUnitServerExtensionCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaKotlinJUnitServerExtensionCollector.kt
@@ -7,6 +7,7 @@ import com.intellij.psi.search.GlobalSearchScope
 import org.jetbrains.kotlin.idea.KotlinFileType
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 
@@ -22,14 +23,30 @@ internal object ArmeriaKotlinJUnitServerExtensionCollector {
             if (!file.text.contains(ArmeriaJUnitServerExtensionSupport.REGISTER_EXTENSION_ANNOTATION)) {
                 continue
             }
-            for (property in file.declarations.filterIsInstance<KtProperty>()) {
-                from(property, scope)?.let { ArmeriaJUnitServerExtensionCollector.add(it, extensions, seen) }
-            }
+            collectProperties(file.declarations.filterIsInstance<KtProperty>(), scope, extensions, seen)
             for (ktClass in file.declarations.filterIsInstance<KtClass>()) {
-                for (property in ktClass.declarations.filterIsInstance<KtProperty>()) {
-                    from(property, scope)?.let { ArmeriaJUnitServerExtensionCollector.add(it, extensions, seen) }
+                collectProperties(ktClass.declarations.filterIsInstance<KtProperty>(), scope, extensions, seen)
+                ktClass.companionObjects.forEach { companion ->
+                    collectProperties(companion.declarations.filterIsInstance<KtProperty>(), scope, extensions, seen)
                 }
             }
+            for (objectDeclaration in file.declarations.filterIsInstance<KtObjectDeclaration>()) {
+                if (!objectDeclaration.isCompanion()) {
+                    continue
+                }
+                collectProperties(objectDeclaration.declarations.filterIsInstance<KtProperty>(), scope, extensions, seen)
+            }
+        }
+    }
+
+    private fun collectProperties(
+        properties: List<KtProperty>,
+        scope: GlobalSearchScope,
+        extensions: MutableList<ArmeriaJUnitServerExtension>,
+        seen: MutableSet<String>,
+    ) {
+        for (property in properties) {
+            from(property, scope)?.let { ArmeriaJUnitServerExtensionCollector.add(it, extensions, seen) }
         }
     }
 

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaKotlinJUnitServerExtensionLineMarkerProvider.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaKotlinJUnitServerExtensionLineMarkerProvider.kt
@@ -1,0 +1,33 @@
+package com.linecorp.intellij.plugins.armeria.test
+
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.codeInsight.daemon.LineMarkerProviderDescriptor
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.editor.markup.GutterIconRenderer
+import com.intellij.psi.PsiElement
+import com.intellij.psi.search.GlobalSearchScope
+import com.linecorp.intellij.plugins.armeria.message
+import org.jetbrains.kotlin.psi.KtProperty
+
+class ArmeriaKotlinJUnitServerExtensionLineMarkerProvider : LineMarkerProviderDescriptor() {
+    override fun getName(): String = message("test.support.lineMarker.name")
+
+    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
+        val property = element as? KtProperty ?: return null
+        if (element != property.nameIdentifier && element != property) {
+            return null
+        }
+        val scope = GlobalSearchScope.projectScope(property.project)
+        if (ArmeriaJUnitServerExtensionSupport.serverExtensionFromKotlinProperty(property, scope) == null) {
+            return null
+        }
+        return LineMarkerInfo(
+            property,
+            property.textRange,
+            AllIcons.RunConfigurations.Junit,
+            { message("test.support.lineMarker.tooltip", property.name.orEmpty()) },
+            null,
+            GutterIconRenderer.Alignment.CENTER,
+        )
+    }
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaTestMetadata.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaTestMetadata.kt
@@ -1,0 +1,12 @@
+package com.linecorp.intellij.plugins.armeria.test
+
+import com.intellij.openapi.module.ModuleUtilCore
+import com.intellij.psi.PsiElement
+import com.linecorp.intellij.plugins.armeria.message
+
+internal object ArmeriaTestMetadata {
+    fun moduleName(element: PsiElement): String {
+        return ModuleUtilCore.findModuleForPsiElement(element)?.name
+            ?: message("route.explorer.module.unassigned")
+    }
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaTestMethodGenerator.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaTestMethodGenerator.kt
@@ -1,0 +1,121 @@
+package com.linecorp.intellij.plugins.armeria.test
+
+import com.intellij.psi.PsiMethod
+import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRoute
+import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteSupport
+import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaTimeoutSupport
+import com.linecorp.intellij.plugins.armeria.explorer.RouteMatch
+import com.linecorp.intellij.plugins.armeria.message
+import java.util.Locale
+
+enum class ArmeriaTestLanguage {
+    JAVA,
+    KOTLIN,
+}
+
+internal object ArmeriaTestMethodGenerator {
+    fun supports(route: ArmeriaRoute): Boolean {
+        return when (route.routeMatch) {
+            RouteMatch.ANNOTATED_HTTP -> route.httpMethod.isNotBlank()
+            RouteMatch.SERVICE, RouteMatch.SERVICE_UNDER -> true
+            else -> false
+        }
+    }
+
+    fun requiresBlockingClient(route: ArmeriaRoute): Boolean {
+        if (route.executionHints.contains(message("route.explorer.execution.blocking"))) {
+            return true
+        }
+        val method = route.pointer.element as? PsiMethod ?: return false
+        return ArmeriaTimeoutSupport.collectExecutionHints(method)
+            .contains(message("route.explorer.execution.blocking"))
+    }
+
+    fun suggestMethodName(route: ArmeriaRoute): String {
+        val pathPart = pathToCamelCase(route.path)
+        return when (httpMethod(route).uppercase(Locale.ROOT)) {
+            "GET" -> if (pathPart.isEmpty()) "rootReturnsSuccess" else "${pathPart}ReturnsSuccess"
+            "POST" -> "post${capitalize(pathPart)}"
+            else -> "${httpMethod(route).lowercase(Locale.ROOT)}${capitalize(pathPart)}"
+        }
+    }
+
+    fun generateTestMethod(
+        route: ArmeriaRoute,
+        serverVariableName: String,
+        language: ArmeriaTestLanguage,
+    ): String {
+        val methodName = suggestMethodName(route)
+        val call = httpMethod(route).lowercase(Locale.ROOT)
+        val path = ArmeriaRouteSupport.normalizePath(route.path)
+        val blocking = requiresBlockingClient(route)
+        return when (language) {
+            ArmeriaTestLanguage.JAVA -> if (blocking) {
+                """
+                @org.junit.jupiter.api.Test
+                void $methodName() {
+                    ${ArmeriaJUnitServerExtensionSupport.BLOCKING_WEB_CLIENT_CLASS} client = $serverVariableName.blockingWebClient();
+                    com.linecorp.armeria.common.AggregatedHttpResponse response = client.$call("$path").aggregate().join();
+                    org.junit.jupiter.api.Assertions.assertEquals(200, response.status().code());
+                }
+                """.trimIndent()
+            } else {
+                """
+                @org.junit.jupiter.api.Test
+                void $methodName() {
+                    ${ArmeriaJUnitServerExtensionSupport.WEB_CLIENT_CLASS} client = ${ArmeriaJUnitServerExtensionSupport.WEB_CLIENT_CLASS}.of($serverVariableName.httpUri());
+                    com.linecorp.armeria.common.AggregatedHttpResponse response = client.$call("$path").aggregate().join();
+                    org.junit.jupiter.api.Assertions.assertEquals(200, response.status().code());
+                }
+                """.trimIndent()
+            }
+            ArmeriaTestLanguage.KOTLIN -> if (blocking) {
+                """
+                @Test
+                fun $methodName() {
+                    val client = $serverVariableName.blockingWebClient()
+                    val response = client.$call("$path").aggregate().join()
+                    assertEquals(200, response.status().code())
+                }
+                """.trimIndent()
+            } else {
+                """
+                @Test
+                fun $methodName() {
+                    val client = WebClient.of($serverVariableName.httpUri())
+                    val response = client.$call("$path").aggregate().join()
+                    assertEquals(200, response.status().code())
+                }
+                """.trimIndent()
+            }
+        }
+    }
+
+    private fun httpMethod(route: ArmeriaRoute): String {
+        return when (route.routeMatch) {
+            RouteMatch.ANNOTATED_HTTP -> route.httpMethod
+            RouteMatch.SERVICE, RouteMatch.SERVICE_UNDER -> "GET"
+            else -> error("Unsupported route match: ${route.routeMatch}")
+        }
+    }
+
+    private fun pathToCamelCase(path: String): String {
+        return path.trim('/')
+            .split('/')
+            .filter { it.isNotBlank() && !it.startsWith("{") }
+            .joinToString("") {
+                it.split(Regex("[^a-zA-Z0-9]"))
+                    .filter(String::isNotBlank)
+                    .joinToString("") { segment -> capitalize(segment.lowercase(Locale.ROOT)) }
+            }
+            .replaceFirstChar { if (it.isUpperCase()) it.lowercase(Locale.ROOT) else it.toString() }
+    }
+
+    private fun capitalize(value: String): String {
+        return if (value.isEmpty()) {
+            value
+        } else {
+            value.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString() }
+        }
+    }
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaTestMethodGenerator.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaTestMethodGenerator.kt
@@ -1,9 +1,7 @@
 package com.linecorp.intellij.plugins.armeria.test
 
-import com.intellij.psi.PsiMethod
 import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRoute
 import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRouteSupport
-import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaTimeoutSupport
 import com.linecorp.intellij.plugins.armeria.explorer.RouteMatch
 import com.linecorp.intellij.plugins.armeria.message
 import java.util.Locale
@@ -23,12 +21,7 @@ internal object ArmeriaTestMethodGenerator {
     }
 
     fun requiresBlockingClient(route: ArmeriaRoute): Boolean {
-        if (route.executionHints.contains(message("route.explorer.execution.blocking"))) {
-            return true
-        }
-        val method = route.pointer.element as? PsiMethod ?: return false
-        return ArmeriaTimeoutSupport.collectExecutionHints(method)
-            .contains(message("route.explorer.execution.blocking"))
+        return route.executionHints.contains(message("route.explorer.execution.blocking"))
     }
 
     fun suggestMethodName(route: ArmeriaRoute): String {

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaTestMethodInserter.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaTestMethodInserter.kt
@@ -1,0 +1,105 @@
+package com.linecorp.intellij.plugins.armeria.test
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.ScrollType
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElementFactory
+import com.intellij.psi.PsiJavaFile
+import com.intellij.psi.PsiManager
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.codeStyle.JavaCodeStyleManager
+import com.intellij.psi.util.PsiTreeUtil
+import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRoute
+import com.linecorp.intellij.plugins.armeria.message
+
+internal object ArmeriaTestMethodInserter {
+    fun insertFromRouteExplorer(project: Project, route: ArmeriaRoute): Boolean {
+        val targetClass = resolveTargetClass(project, route) ?: run {
+            Messages.showWarningDialog(
+                project,
+                message("test.support.insert.noTarget"),
+                message("test.support.insert.title"),
+            )
+            return false
+        }
+        val language = if (targetClass.containingFile is PsiJavaFile) {
+            ArmeriaTestLanguage.JAVA
+        } else {
+            ArmeriaTestLanguage.KOTLIN
+        }
+        val extension = ArmeriaJUnitServerExtensionCollector.extensionsInClass(project, targetClass).firstOrNull() ?: run {
+            Messages.showWarningDialog(
+                project,
+                message("test.support.insert.noServerExtension"),
+                message("test.support.insert.title"),
+            )
+            return false
+        }
+        val methodText = ArmeriaTestMethodGenerator.generateTestMethod(route, extension.variableName, language)
+        ApplicationManager.getApplication().invokeLater {
+            if (project.isDisposed) {
+                return@invokeLater
+            }
+            WriteCommandAction.runWriteCommandAction(
+                project,
+                message("route.explorer.action.generateTestMethod"),
+                null,
+                {
+                    if (language == ArmeriaTestLanguage.JAVA) {
+                        insertJavaMethod(project, targetClass, methodText)
+                    } else {
+                        insertKotlinMethod(project, targetClass, methodText)
+                    }
+                },
+            )
+        }
+        return true
+    }
+
+    private fun insertJavaMethod(project: Project, targetClass: PsiClass, methodText: String) {
+        val anchor = targetClass.methods.lastOrNull() ?: targetClass
+        val added = targetClass.addAfter(
+            PsiElementFactory.getInstance(project).createMethodFromText(methodText, targetClass),
+            anchor,
+        ) as PsiMethod
+        JavaCodeStyleManager.getInstance(project).shortenClassReferences(added)
+        val editor = targetClass.containingFile.virtualFile
+            ?.let { FileEditorManager.getInstance(project).openFile(it, true).firstOrNull() as? Editor }
+        editor?.caretModel?.moveToOffset(added.textRange.startOffset)
+        editor?.scrollingModel?.scrollToCaret(ScrollType.CENTER)
+    }
+
+    private fun insertKotlinMethod(project: Project, targetClass: PsiClass, methodText: String) {
+        val rBrace = targetClass.rBrace ?: return
+        val document = PsiDocumentManager.getInstance(project).getDocument(targetClass.containingFile) ?: return
+        document.insertString(rBrace.textRange.startOffset, "\n\n$methodText\n")
+        PsiDocumentManager.getInstance(project).commitDocument(document)
+    }
+
+    private fun resolveTargetClass(project: Project, route: ArmeriaRoute): PsiClass? {
+        val selectedFile = FileEditorManager.getInstance(project).selectedFiles.firstOrNull()
+        val selectedClass = selectedFile?.let { virtualFile ->
+            PsiTreeUtil.getChildOfType(
+                PsiManager.getInstance(project).findFile(virtualFile),
+                PsiClass::class.java,
+            )
+        }
+        if (selectedClass != null &&
+            ArmeriaJUnitServerExtensionCollector.extensionsInClass(project, selectedClass).isNotEmpty()
+        ) {
+            return selectedClass
+        }
+        val extensions = ArmeriaJUnitServerExtensionCollector.collect(project)
+        val pointer = extensions.firstOrNull {
+            it.moduleName == route.moduleName ||
+                route.moduleName == message("route.explorer.module.unassigned")
+        }?.pointer ?: extensions.firstOrNull()?.pointer
+        return pointer?.element?.let { PsiTreeUtil.getParentOfType(it, PsiClass::class.java) }
+    }
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaTestMethodInserter.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaTestMethodInserter.kt
@@ -17,6 +17,11 @@ import com.intellij.psi.codeStyle.JavaCodeStyleManager
 import com.intellij.psi.util.PsiTreeUtil
 import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRoute
 import com.linecorp.intellij.plugins.armeria.message
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.resolve.ImportPath
 
 internal object ArmeriaTestMethodInserter {
     fun insertFromRouteExplorer(project: Project, route: ArmeriaRoute): Boolean {
@@ -76,10 +81,41 @@ internal object ArmeriaTestMethodInserter {
     }
 
     private fun insertKotlinMethod(project: Project, targetClass: PsiClass, methodText: String) {
-        val rBrace = targetClass.rBrace ?: return
-        val document = PsiDocumentManager.getInstance(project).getDocument(targetClass.containingFile) ?: return
-        document.insertString(rBrace.textRange.startOffset, "\n\n$methodText\n")
-        PsiDocumentManager.getInstance(project).commitDocument(document)
+        val ktClass = targetClass as? KtClass ?: return
+        val anchor = ktClass.body?.rBrace ?: return
+        val factory = KtPsiFactory(project)
+        val function = factory.createFunction(methodText)
+        val added = ktClass.addBefore(function, anchor)
+        val ktFile = ktClass.containingKtFile
+        insertKotlinImport(project, ktFile, "org.junit.jupiter.api.Test")
+        insertKotlinImport(project, ktFile, "org.junit.jupiter.api.Assertions.assertEquals")
+        if (methodText.contains("WebClient")) {
+            insertKotlinImport(project, ktFile, ArmeriaJUnitServerExtensionSupport.WEB_CLIENT_CLASS)
+        }
+        val editor = ktFile.virtualFile
+            ?.let { FileEditorManager.getInstance(project).openFile(it, true).firstOrNull() as? Editor }
+        editor?.caretModel?.moveToOffset(added.textRange.startOffset)
+        editor?.scrollingModel?.scrollToCaret(ScrollType.CENTER)
+    }
+
+    private fun insertKotlinImport(project: Project, ktFile: KtFile, fqName: String) {
+        val path = FqName(fqName)
+        if (ktFile.importDirectives.any { it.importedFqName == path }) {
+            return
+        }
+        val factory = KtPsiFactory(project)
+        val directive = factory.createImportDirective(ImportPath.fromString(fqName))
+        val importList = ktFile.importList
+        if (importList != null) {
+            importList.add(directive)
+            return
+        }
+        val packageDirective = ktFile.packageDirective
+        if (packageDirective != null) {
+            ktFile.addAfter(directive, packageDirective)
+        } else {
+            ktFile.add(directive)
+        }
     }
 
     private fun resolveTargetClass(project: Project, route: ArmeriaRoute): PsiClass? {

--- a/plugin/src/main/resources/META-INF/kotlin-integration.xml
+++ b/plugin/src/main/resources/META-INF/kotlin-integration.xml
@@ -19,6 +19,15 @@
                          enabledByDefault="true"
                          level="WARNING"
                          implementationClass="com.linecorp.intellij.plugins.armeria.inspection.ArmeriaDuplicateRegistrationKotlinInspection" />
+        <localInspection language="kotlin"
+                         bundle="messages.ArmeriaBundle"
+                         key="inspection.blocking.client.kotlin.display.name"
+                         groupBundle="messages.ArmeriaBundle"
+                         groupKey="inspection.group.armeria"
+                         shortName="ArmeriaBlockingClientKotlin"
+                         enabledByDefault="true"
+                         level="WARNING"
+                         implementationClass="com.linecorp.intellij.plugins.armeria.test.ArmeriaBlockingClientKotlinInspection" />
         <codeInsight.lineMarkerProvider language="kotlin"
                                         implementationClass="com.linecorp.intellij.plugins.armeria.marker.ArmeriaKotlinRouteLineMarkerProvider"/>
     </extensions>

--- a/plugin/src/main/resources/META-INF/kotlin-integration.xml
+++ b/plugin/src/main/resources/META-INF/kotlin-integration.xml
@@ -30,5 +30,7 @@
                          implementationClass="com.linecorp.intellij.plugins.armeria.test.ArmeriaBlockingClientKotlinInspection" />
         <codeInsight.lineMarkerProvider language="kotlin"
                                         implementationClass="com.linecorp.intellij.plugins.armeria.marker.ArmeriaKotlinRouteLineMarkerProvider"/>
+        <codeInsight.lineMarkerProvider language="kotlin"
+                                        implementationClass="com.linecorp.intellij.plugins.armeria.test.ArmeriaKotlinJUnitServerExtensionLineMarkerProvider" />
     </extensions>
 </idea-plugin>

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -54,6 +54,18 @@
         <!-- Run configuration -->
         <configurationType implementation="com.linecorp.intellij.plugins.armeria.run.ArmeriaRunConfigurationType" />
         <runConfigurationProducer implementation="com.linecorp.intellij.plugins.armeria.run.ArmeriaRunConfigurationProducer" />
+
+        <localInspection language="JAVA"
+                         bundle="messages.ArmeriaBundle"
+                         key="inspection.blocking.client.display.name"
+                         groupBundle="messages.ArmeriaBundle"
+                         groupKey="inspection.group.armeria"
+                         shortName="ArmeriaBlockingClient"
+                         enabledByDefault="true"
+                         level="WARNING"
+                         implementationClass="com.linecorp.intellij.plugins.armeria.test.ArmeriaBlockingClientInspection" />
+        <codeInsight.lineMarkerProvider language="JAVA"
+                                        implementationClass="com.linecorp.intellij.plugins.armeria.test.ArmeriaJUnitServerExtensionLineMarkerProvider" />
     </extensions>
 
     <actions>

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaKotlinJUnitServerExtensionCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaKotlinJUnitServerExtensionCollectorTest.kt
@@ -1,0 +1,31 @@
+package com.linecorp.intellij.plugins.armeria.test
+
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+
+class ArmeriaKotlinJUnitServerExtensionCollectorTest : LightJavaCodeInsightFixtureTestCase() {
+    fun testCollectsRegisterExtensionFromCompanionObject() {
+        myFixture.configureByText(
+            "ExampleServiceTest.kt",
+            """
+            package example
+
+            import org.junit.jupiter.api.extension.RegisterExtension
+            import com.linecorp.armeria.testing.junit5.server.ServerExtension
+
+            class ExampleServiceTest {
+                companion object {
+                    @RegisterExtension
+                    @JvmField
+                    val server: ServerExtension = object : ServerExtension() {}
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val extensions = ArmeriaJUnitServerExtensionCollector.collect(project)
+
+        assertEquals(1, extensions.size)
+        assertEquals("server", extensions.single().variableName)
+        assertEquals("example.ExampleServiceTest", extensions.single().containingClassName)
+    }
+}

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaTestMethodGeneratorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaTestMethodGeneratorTest.kt
@@ -1,0 +1,76 @@
+package com.linecorp.intellij.plugins.armeria.test
+
+import com.linecorp.intellij.plugins.armeria.explorer.ArmeriaRoute
+import com.linecorp.intellij.plugins.armeria.explorer.RouteMatch
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.SmartPsiElementPointer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ArmeriaTestMethodGeneratorTest {
+    @Test
+    fun supportsAnnotatedHttpRoute() {
+        assertTrue(ArmeriaTestMethodGenerator.supports(route(httpMethod = "GET")))
+    }
+
+    @Test
+    fun supportsServiceRoute() {
+        assertTrue(ArmeriaTestMethodGenerator.supports(route(routeMatch = RouteMatch.SERVICE, httpMethod = "")))
+    }
+
+    @Test
+    fun rejectsNonHttpRoute() {
+        assertFalse(ArmeriaTestMethodGenerator.supports(route(routeMatch = RouteMatch.NON_HTTP, httpMethod = "")))
+    }
+
+    @Test
+    fun suggestMethodNameForGetPath() {
+        val name = ArmeriaTestMethodGenerator.suggestMethodName(route(path = "/users/{id}"))
+        assertEquals("usersReturnsSuccess", name)
+    }
+
+    @Test
+    fun generateJavaTestMethodUsesBlockingClientWhenRouteIsBlocking() {
+        val generated = ArmeriaTestMethodGenerator.generateTestMethod(
+            route = route(path = "/slow", executionHints = listOf("Blocking")),
+            serverVariableName = "server",
+            language = ArmeriaTestLanguage.JAVA,
+        )
+        assertTrue(generated.contains("blockingWebClient"))
+    }
+
+    private fun route(
+        httpMethod: String = "GET",
+        path: String = "/api",
+        routeMatch: RouteMatch = RouteMatch.ANNOTATED_HTTP,
+        executionHints: List<String> = emptyList(),
+    ): ArmeriaRoute = ArmeriaRoute(
+        protocol = "HTTP",
+        httpMethod = httpMethod,
+        path = path,
+        target = "Handler",
+        routeMatch = routeMatch,
+        moduleName = "app",
+        targetUnresolved = false,
+        isDocService = false,
+        decorators = emptyList(),
+        exceptionHandlers = emptyList(),
+        executionHints = executionHints,
+        pointer = EmptyPointer,
+    )
+
+    private object EmptyPointer : SmartPsiElementPointer<PsiElement> {
+        override fun getElement(): PsiElement? = null
+        override fun getContainingFile(): PsiFile? = null
+        override fun getRange(): TextRange? = null
+        override fun getProject(): Project = throw UnsupportedOperationException()
+        override fun getVirtualFile(): VirtualFile = throw UnsupportedOperationException()
+        override fun getPsiRange(): TextRange? = null
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds IDE support for Armeria JUnit 5 integration tests.

## Changes

- Detect `@RegisterExtension` `ServerExtension` fields with a gutter marker
- Inspection warns when async `WebClient` is used against `@Blocking` routes in tests
- Generate Test Method toolbar action in Route Explorer
- Unit tests for `ArmeriaTestMethodGenerator`

## Test plan

- [x] `./gradlew :plugin:test --tests "com.linecorp.intellij.plugins.armeria.test.ArmeriaTestMethodGeneratorTest"`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2f83-3c3e-7f3f-b835-be2c90fec8ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2f83-3c3e-7f3f-b835-be2c90fec8ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

