### PR TITLE
docs: prefer Gradle TAPI MCP for agent Gradle tasks

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,70 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-readonly GRADLE_TAPI_MCP_VERSION="0.3.3"
-readonly GRADLE_TAPI_MCP_SHA256="e1229dded987b0fe97a51a449646487d4688172f2b4b44855bf0ace3b24d2417"
-readonly INSTALL_DIR="${HOME}/.local/share/gradle-tapi-mcp-server"
-readonly VERSIONED_JAR_NAME="gradle-tapi-mcp-server-${GRADLE_TAPI_MCP_VERSION}.jar"
-readonly VERSIONED_JAR_PATH="${INSTALL_DIR}/${VERSIONED_JAR_NAME}"
-readonly STABLE_JAR_PATH="${INSTALL_DIR}/gradle-tapi-mcp-server.jar"
-readonly MAX_DOWNLOAD_ATTEMPTS=2
-
-verify_jar_sha256() {
-  local jar_path="$1"
-  local actual
-  actual="$(sha256sum "${jar_path}" | awk '{print $1}')"
-  if [[ "${actual}" != "${GRADLE_TAPI_MCP_SHA256}" ]]; then
-    echo "SHA-256 mismatch for ${jar_path}" >&2
-    echo "Expected: ${GRADLE_TAPI_MCP_SHA256}" >&2
-    echo "Actual:   ${actual}" >&2
-    return 1
-  fi
-}
-
-download_jar() {
-  mkdir -p "${INSTALL_DIR}"
-  local tmp
-  tmp="$(mktemp "${INSTALL_DIR}/.${VERSIONED_JAR_NAME}.XXXXXX")"
-
-  if ! curl -fsSL -o "${tmp}" \
-    "https://github.com/nise-nabe/gradle-tapi-mcp-server/releases/download/v${GRADLE_TAPI_MCP_VERSION}/${VERSIONED_JAR_NAME}"; then
-    rm -f "${tmp}"
-    echo "curl failed to download ${VERSIONED_JAR_NAME}" >&2
-    return 1
-  fi
-
-  mv -f "${tmp}" "${VERSIONED_JAR_PATH}"
-}
-
-remove_jar_artifacts() {
-  rm -f "${VERSIONED_JAR_PATH}" "${STABLE_JAR_PATH}"
-}
-
-ensure_jar() {
-  if [[ -f "${VERSIONED_JAR_PATH}" ]] && verify_jar_sha256 "${VERSIONED_JAR_PATH}"; then
-    return 0
-  fi
-
-  if [[ -f "${VERSIONED_JAR_PATH}" ]]; then
-    echo "Removing corrupted MCP server JAR for re-download..." >&2
-  fi
-  remove_jar_artifacts
-
-  local attempt
-  for attempt in $(seq 1 "${MAX_DOWNLOAD_ATTEMPTS}"); do
-    if download_jar && verify_jar_sha256 "${VERSIONED_JAR_PATH}"; then
-      return 0
-    fi
-    echo "Download attempt ${attempt}/${MAX_DOWNLOAD_ATTEMPTS} failed." >&2
-    remove_jar_artifacts
-  done
-
-  echo "Failed to download a valid MCP server JAR after ${MAX_DOWNLOAD_ATTEMPTS} attempts." >&2
-  return 1
-}
-
-ensure_jar
-ln -sfn "${VERSIONED_JAR_NAME}" "${STABLE_JAR_PATH}"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+"${repo_root}/.github/scripts/install-gradle-tapi-mcp.sh"
 
 setup_gh_cli() {
   local gh_source="/exec-daemon/gh"

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-"${repo_root}/.github/scripts/install-gradle-tapi-mcp.sh"
+bash "${repo_root}/.github/scripts/install-gradle-tapi-mcp.sh"
 
 setup_gh_cli() {
   local gh_source="/exec-daemon/gh"

--- a/.cursor/rules/cloud-github.mdc
+++ b/.cursor/rules/cloud-github.mdc
@@ -20,6 +20,6 @@ When a skill requires `gh` (CI checks, PR comments, API calls):
 
 1. Resolve: `command -v gh` or `/exec-daemon/gh`
 2. Verify: `gh auth status`
-3. If either step fails, stop — do not loop on missing `gh`. Use ManagePullRequest for PRs or `./gradlew build` for local verification.
+3. If either step fails, stop — do not loop on missing `gh`. Use ManagePullRequest for PRs or Gradle MCP (`gradle_run_tasks` `["build"]`) for local verification.
 
 Do not install `gh` in agent sessions. See `.cursor/skills/cloud-github/SKILL.md`.

--- a/.cursor/rules/gradle-mcp.mdc
+++ b/.cursor/rules/gradle-mcp.mdc
@@ -1,0 +1,35 @@
+---
+description: Prefer Gradle Tooling API MCP server for Gradle tasks; shell ./gradlew is fallback only
+alwaysApply: true
+---
+
+# Gradle tasks via MCP
+
+For **all Gradle task execution and build verification** in this repository, prefer the `gradle` MCP server (`nise-nabe/gradle-tapi-mcp-server` v0.3.3) over shell `./gradlew`.
+
+## Before running tasks
+
+1. `gradle_connection_status` — confirm `connectedAny: true`
+2. If not connected, `gradle_connect` with the repository root (or rely on `GRADLE_PROJECT_DIR` from `.cursor/mcp.json` / `.github/scripts/gradle-mcp-server.sh`)
+
+Read `.cursor/skills/gradle-tapi-mcp/SKILL.md` for the full workflow.
+
+## Default tools
+
+| Goal | MCP tool |
+|------|----------|
+| Environment / versions | `gradle_get_build_environment` |
+| Module tree | `gradle_get_project_overview` |
+| Compile | `gradle_run_tasks` with `[":plugin:compileKotlin"]` |
+| Tests (one class/method) | `gradle_run_tests` with `background: true` + poll |
+| Full verify | `gradle_run_tasks` with `["build"]`, `background: true` + poll |
+
+Use `background: true` and poll `gradle_get_build_status` for anything that may exceed ~30s (cold start, `:plugin:test`, `build`).
+
+## Shell fallback only when
+
+- MCP tools time out or the server is unresponsive (poll `gradle_list_builds` / read `.gradle/mcp-builds/<buildId>/mcp-result.json` first)
+- `BUILD_ALREADY_RUNNING` and you cannot cancel the in-flight MCP build
+- PR / CI parity requires `./gradlew build` after MCP verification passes
+
+Do **not** run MCP `gradle_run_tests` and shell `./gradlew :plugin:test` on the same checkout concurrently.

--- a/.cursor/skills/cloud-github/SKILL.md
+++ b/.cursor/skills/cloud-github/SKILL.md
@@ -43,7 +43,7 @@ Before calling `gh`:
 2. Resolve the binary: `command -v gh` → prefer that path; fall back to `/exec-daemon/gh`.
 3. Confirm auth: `gh auth status` (or the resolved path above).
 4. If auth fails, stop retrying `gh` and either use ManagePullRequest for PR work or
-   verify locally with `./gradlew build`.
+   verify locally with Gradle MCP (`gradle_run_tasks` `["build"]` + background/poll).
 
 Do not install `gh` via apt, brew, or curl in agent sessions.
 
@@ -52,9 +52,8 @@ Do not install `gh` via apt, brew, or curl in agent sessions.
 GitHub Actions runs `./gradlew build` (see `.github/workflows/main.yml`).
 For agent-side verification, prefer:
 
-1. `./gradlew build` or `./gradlew --no-daemon :plugin:compileKotlin :plugin:test` — matches CI; reliable for long IntelliJ tests
-2. MCP `gradle_run_tasks` with `[":plugin:compileKotlin"]` for fast compile checks (see `gradle-tapi-mcp` skill)
-3. MCP `gradle_run_tasks` / `gradle_run_tests` with `background: true` only when the MCP client stays responsive; fall back to shell on timeout or unresponsive MCP server
+1. **Gradle MCP** — `gradle_connection_status`, then `gradle_run_tasks` / `gradle_run_tests` with `background: true` + poll (see `gradle-tapi-mcp` skill)
+2. Shell `./gradlew build` only when MCP is unresponsive, returns `BUILD_ALREADY_RUNNING` that cannot be cancelled, or for final CI parity after MCP passes
 
 Use `gh pr checks` only when you need GitHub-attached check status and `gh auth status` succeeds.
 

--- a/.cursor/skills/gradle-tapi-mcp/SKILL.md
+++ b/.cursor/skills/gradle-tapi-mcp/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: gradle-tapi-mcp
 description: >-
-  Use the gradle MCP server for token-efficient build verification in this repo.
-  Prefer lightweight Tooling API queries before running tasks.
+  Use the gradle MCP server for all Gradle task execution and build verification
+  in this repo. Prefer MCP over shell ./gradlew; use lightweight Tooling API
+  queries before running tasks.
 ---
 
 # Gradle Tooling API MCP
 
-This repository configures [nise-nabe/gradle-tapi-mcp-server](https://github.com/nise-nabe/gradle-tapi-mcp-server) v0.3.3 in `.cursor/mcp.json`. The JAR is installed by `.cursor/install.sh` to `~/.local/share/gradle-tapi-mcp-server/gradle-tapi-mcp-server.jar`. At MCP server launch, `.cursor/mcp.json` sets `GRADLE_PROJECT_DIR=${workspaceFolder}`.
+This repository configures [nise-nabe/gradle-tapi-mcp-server](https://github.com/nise-nabe/gradle-tapi-mcp-server) v0.3.3 in `.cursor/mcp.json` (Cursor) and `.github/mcp.json` (Copilot). The JAR is installed by `.cursor/install.sh` or `.github/scripts/install-gradle-tapi-mcp.sh` to `~/.local/share/gradle-tapi-mcp-server/gradle-tapi-mcp-server.jar`. At MCP server launch, `GRADLE_PROJECT_DIR` is set to the workspace/git root.
 
 The MCP server may report `loading` for a few seconds on first use; call `gradle_connection_status` before other tools.
 
@@ -48,14 +49,14 @@ There is no `projectPath` filter on model tools — they return the project tree
 
 | Scenario | Prefer |
 |----------|--------|
+| Any Gradle task (default) | **MCP** `gradle_run_tasks` / `gradle_run_tests` |
 | Compile check (`:plugin:compileKotlin`), daemon warm | MCP `gradle_run_tasks` foreground — sub-second to ~2s, clean JSON |
-| Compile check, cold start (first MCP build in session) | MCP `gradle_run_tasks` with `background: true` + poll, or shell — foreground often hits MCP client timeout (~60s) while Gradle still runs |
-| Full `build` or `:plugin:test` in Cloud | **Shell** `./gradlew` — IntelliJ tests are long-running and MCP clients often time out (~60s) |
+| Compile check, cold start (first MCP build in session) | MCP `gradle_run_tasks` with `background: true` + poll |
+| Full `build` or `:plugin:test` | MCP with `background: true` + poll `gradle_get_build_status` |
 | Single test class (daemon + sandbox warm) | MCP `gradle_run_tests` with **one** class, `background: true` + polling — often ~5s |
-| Single test class (cold sandbox / first run) | Expect several minutes; use MCP background + poll or shell |
 | Single test method | MCP `gradle_run_tests` with `testMethods: { "ClassName": ["methodName"] }`, or `testClasses: ["ClassName.methodName"]` (auto-normalized) |
-| MCP server unresponsive / all tools timeout | **Shell** `./gradlew`; Gradle daemon may still be IDLE while MCP is stuck |
-| PR / CI parity check | `./gradlew build` or `./gradlew --no-daemon :plugin:compileKotlin :plugin:test` |
+| MCP server unresponsive / all tools timeout | **Shell** `./gradlew` after `gradle_list_builds` / disk recovery |
+| PR / CI parity check (after MCP verify) | Shell `./gradlew build` when you need exact CI command parity |
 
 The server rejects a second MCP build on the same `projectDirectory` with `BUILD_ALREADY_RUNNING`. Do **not** run MCP `gradle_run_tests` and shell `./gradlew :plugin:test` at the same time — both spawn IntelliJ Platform test workers against the same sandbox and can appear hung for many minutes with no log output.
 
@@ -160,15 +161,15 @@ If every MCP call times out but `./gradlew` still works:
 
 ### Verification commands
 
-| Goal | MCP tool | Example |
-|------|----------|---------|
-| Full verify | shell (preferred) | `./gradlew build` |
-| All plugin tests | shell (preferred) or MCP background | `./gradlew :plugin:test` |
-| Single test class | `gradle_run_tests` + background, or shell | See running builds section |
-| Single test method | `gradle_run_tests` with `testMethods`, or shell | See running builds section |
-| Fast compile gate | `gradle_run_tasks` | `{ "tasks": [":plugin:compileKotlin"] }` — use `background: true` on cold start |
+| Goal | MCP tool (preferred) | Shell fallback |
+|------|---------------------|----------------|
+| Full verify | `gradle_run_tasks` `["build"]` + background/poll | `./gradlew build` |
+| All plugin tests | `gradle_run_tasks` `[":plugin:test"]` + background/poll | `./gradlew :plugin:test` |
+| Single test class | `gradle_run_tests` + background/poll | `./gradlew :plugin:test --tests 'FQCN'` |
+| Single test method | `gradle_run_tests` with `testMethods` + background/poll | `./gradlew :plugin:test --tests 'FQCN.method'` |
+| Fast compile gate | `gradle_run_tasks` `{ "tasks": [":plugin:compileKotlin"] }` | `./gradlew :plugin:compileKotlin` |
 
-Prefer shell for full `:plugin:test` and `build` in Cursor Cloud. Use MCP for lightweight queries, compile checks, and **one test class or method at a time** after compile passes.
+Prefer MCP for all verification. Use shell only when MCP is unresponsive or for final CI parity before merge.
 
 ### Recommended agent workflow (IntelliJ plugin changes)
 
@@ -178,7 +179,7 @@ Prefer shell for full `:plugin:test` and `build` in Cursor Cloud. Use MCP for li
    - `gradle_run_tests` with one FQCN in `testClasses` (or `testMethods` for a single method), `background: true`
    - Poll `gradle_get_build_status` with `includeOutput: true` on failure
    - Wait for the MCP run to finish or cancel before starting shell `./gradlew :plugin:test`
-4. Before opening a PR, run `./gradlew build` in shell for CI parity (or at minimum `:plugin:test` if time allows).
+4. Before opening a PR, run `gradle_run_tasks` with `["build"]` and `background: true`, poll to completion, then optionally shell `./gradlew build` for exact CI parity if MCP already passed.
 
 ### JDK / toolchain debugging
 

--- a/.cursor/skills/gradle-tapi-mcp/SKILL.md
+++ b/.cursor/skills/gradle-tapi-mcp/SKILL.md
@@ -163,10 +163,10 @@ If every MCP call times out but `./gradlew` still works:
 
 | Goal | MCP tool (preferred) | Shell fallback |
 |------|---------------------|----------------|
-| Full verify | `gradle_run_tasks` `["build"]` + background/poll | `./gradlew build` |
-| All plugin tests | `gradle_run_tasks` `[":plugin:test"]` + background/poll | `./gradlew :plugin:test` |
-| Single test class | `gradle_run_tests` + background/poll | `./gradlew :plugin:test --tests 'FQCN'` |
-| Single test method | `gradle_run_tests` with `testMethods` + background/poll | `./gradlew :plugin:test --tests 'FQCN.method'` |
+| Full verify | `gradle_run_tasks` `{ "tasks": ["build"], "background": true }` | `./gradlew build` |
+| All plugin tests | `gradle_run_tasks` `{ "tasks": [":plugin:test"], "background": true }` | `./gradlew :plugin:test` |
+| Single test class | `gradle_run_tests` `{ "testClasses": ["FQCN"], "background": true }` | `./gradlew :plugin:test --tests 'FQCN'` |
+| Single test method | `gradle_run_tests` `{ "testMethods": { "FQCN": ["method"] }, "background": true }` | `./gradlew :plugin:test --tests 'FQCN.method'` |
 | Fast compile gate | `gradle_run_tasks` `{ "tasks": [":plugin:compileKotlin"] }` | `./gradlew :plugin:compileKotlin` |
 
 Prefer MCP for all verification. Use shell only when MCP is unresponsive or for final CI parity before merge.

--- a/.cursor/skills/release/SKILL.md
+++ b/.cursor/skills/release/SKILL.md
@@ -69,9 +69,15 @@ pluginVersion=0.2.0
 
 Then patch the changelog (moves `[Unreleased]` content into a new version section and recreates the template):
 
-```bash
-./gradlew :plugin:patchChangelog -Prelease.version=0.2.0
+Prefer Gradle MCP:
+
+```json
+{ "tasks": [":plugin:patchChangelog"], "arguments": ["-Prelease.version=0.2.0"] }
 ```
+
+→ `gradle_run_tasks` (use `background: true` + poll if cold start)
+
+Shell fallback: `./gradlew :plugin:patchChangelog -Prelease.version=0.2.0`
 
 Review `plugin/CHANGELOG.md`:
 
@@ -80,9 +86,13 @@ Review `plugin/CHANGELOG.md`:
 
 ### 4. Verify
 
-```bash
-./gradlew build :plugin:buildPlugin
+Prefer Gradle MCP (`gradle_run_tasks` with `background: true` + poll):
+
+```json
+{ "tasks": ["build", ":plugin:buildPlugin"], "background": true }
 ```
+
+Shell fallback: `./gradlew build :plugin:buildPlugin`
 
 Confirm the artifact exists:
 
@@ -90,11 +100,13 @@ Confirm the artifact exists:
 ls plugin/build/distributions/plugin-<version>.zip
 ```
 
-Optional sanity check:
+Optional sanity check — MCP:
 
-```bash
-./gradlew :plugin:getChangelog --unreleased
+```json
+{ "tasks": [":plugin:getChangelog"], "arguments": ["--unreleased"] }
 ```
+
+→ `gradle_run_tasks`
 
 ### 5. Merge to `main`
 
@@ -123,7 +135,7 @@ Tag the merge commit on `main`, not the feature-branch tip.
 
 ### 7. Publish GitHub Release
 
-Rebuild on `main` so the ZIP matches the tagged commit:
+Rebuild on `main` so the ZIP matches the tagged commit (prefer MCP `gradle_run_tasks` `{ "tasks": [":plugin:buildPlugin"], "background": true }`; shell fallback below):
 
 ```bash
 ./gradlew :plugin:buildPlugin

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,5 +6,6 @@
 - Prefer small, focused changes in the existing feature areas: module/project generation, route explorer, inspections, and run configuration support.
 - Route user-visible strings through `message(...)` and add the corresponding keys to `plugin/src/main/resources/messages/ArmeriaBundle.properties` instead of hard-coding UI text.
 - Reuse existing IntelliJ PSI and platform APIs already used in the plugin instead of introducing parallel abstractions.
-- Validate changes with `./gradlew --no-daemon :plugin:compileKotlin :plugin:test`.
+- **Gradle tasks:** prefer the `gradle` MCP server (`nise-nabe/gradle-tapi-mcp-server` v0.3.3) configured in `.github/mcp.json`. Read `.github/skills/gradle-tapi-mcp/SKILL.md` for workflows. Use `gradle_run_tasks` / `gradle_run_tests` with `background: true` and poll `gradle_get_build_status` for long runs. Fall back to `./gradlew` only when MCP is unavailable.
+- Validate changes with MCP: `gradle_run_tasks` `[":plugin:compileKotlin", ":plugin:compileTestKotlin"]`, then `gradle_run_tests` for changed test classes (one at a time, background + poll). Before finishing, run `gradle_run_tasks` `["build"]` with `background: true` (or shell `./gradlew build` if MCP times out).
 - The build targets IntelliJ IDEA Ultimate `2026.1.3` and uses the Java 21 JetBrains toolchain, so keep new code compatible with that environment.

--- a/.github/mcp.json
+++ b/.github/mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "gradle": {
-      "type": "local",
+      "type": "stdio",
       "command": "bash",
       "args": [".github/scripts/gradle-mcp-server.sh"],
       "tools": ["*"]

--- a/.github/mcp.json
+++ b/.github/mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "gradle": {
+      "type": "local",
+      "command": "bash",
+      "args": [".github/scripts/gradle-mcp-server.sh"],
+      "tools": ["*"]
+    }
+  }
+}

--- a/.github/scripts/gradle-mcp-server.sh
+++ b/.github/scripts/gradle-mcp-server.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly INSTALL_DIR="${HOME}/.local/share/gradle-tapi-mcp-server"
+readonly STABLE_JAR_PATH="${INSTALL_DIR}/gradle-tapi-mcp-server.jar"
+
+if [[ ! -f "${STABLE_JAR_PATH}" ]]; then
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  "${repo_root}/.github/scripts/install-gradle-tapi-mcp.sh"
+fi
+
+if [[ -z "${GRADLE_PROJECT_DIR:-}" ]]; then
+  if git rev-parse --show-toplevel >/dev/null 2>&1; then
+    export GRADLE_PROJECT_DIR="$(git rev-parse --show-toplevel)"
+  else
+    export GRADLE_PROJECT_DIR="$(pwd)"
+  fi
+fi
+
+exec java -jar "${STABLE_JAR_PATH}"

--- a/.github/scripts/gradle-mcp-server.sh
+++ b/.github/scripts/gradle-mcp-server.sh
@@ -6,7 +6,7 @@ readonly STABLE_JAR_PATH="${INSTALL_DIR}/gradle-tapi-mcp-server.jar"
 
 if [[ ! -f "${STABLE_JAR_PATH}" ]]; then
   repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-  "${repo_root}/.github/scripts/install-gradle-tapi-mcp.sh"
+  bash "${repo_root}/.github/scripts/install-gradle-tapi-mcp.sh"
 fi
 
 if [[ -z "${GRADLE_PROJECT_DIR:-}" ]]; then

--- a/.github/scripts/install-gradle-tapi-mcp.sh
+++ b/.github/scripts/install-gradle-tapi-mcp.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly GRADLE_TAPI_MCP_VERSION="0.3.3"
+readonly GRADLE_TAPI_MCP_SHA256="e1229dded987b0fe97a51a449646487d4688172f2b4b44855bf0ace3b24d2417"
+readonly INSTALL_DIR="${HOME}/.local/share/gradle-tapi-mcp-server"
+readonly VERSIONED_JAR_NAME="gradle-tapi-mcp-server-${GRADLE_TAPI_MCP_VERSION}.jar"
+readonly VERSIONED_JAR_PATH="${INSTALL_DIR}/${VERSIONED_JAR_NAME}"
+readonly STABLE_JAR_PATH="${INSTALL_DIR}/gradle-tapi-mcp-server.jar"
+readonly MAX_DOWNLOAD_ATTEMPTS=2
+
+verify_jar_sha256() {
+  local jar_path="$1"
+  local actual
+  actual="$(sha256sum "${jar_path}" | awk '{print $1}')"
+  if [[ "${actual}" != "${GRADLE_TAPI_MCP_SHA256}" ]]; then
+    echo "SHA-256 mismatch for ${jar_path}" >&2
+    echo "Expected: ${GRADLE_TAPI_MCP_SHA256}" >&2
+    echo "Actual:   ${actual}" >&2
+    return 1
+  fi
+}
+
+download_jar() {
+  mkdir -p "${INSTALL_DIR}"
+  local tmp
+  tmp="$(mktemp "${INSTALL_DIR}/.${VERSIONED_JAR_NAME}.XXXXXX")"
+
+  if ! curl -fsSL -o "${tmp}" \
+    "https://github.com/nise-nabe/gradle-tapi-mcp-server/releases/download/v${GRADLE_TAPI_MCP_VERSION}/${VERSIONED_JAR_NAME}"; then
+    rm -f "${tmp}"
+    echo "curl failed to download ${VERSIONED_JAR_NAME}" >&2
+    return 1
+  fi
+
+  mv -f "${tmp}" "${VERSIONED_JAR_PATH}"
+}
+
+remove_jar_artifacts() {
+  rm -f "${VERSIONED_JAR_PATH}" "${STABLE_JAR_PATH}"
+}
+
+ensure_jar() {
+  if [[ -f "${VERSIONED_JAR_PATH}" ]] && verify_jar_sha256 "${VERSIONED_JAR_PATH}"; then
+    return 0
+  fi
+
+  if [[ -f "${VERSIONED_JAR_PATH}" ]]; then
+    echo "Removing corrupted MCP server JAR for re-download..." >&2
+  fi
+  remove_jar_artifacts
+
+  local attempt
+  for attempt in $(seq 1 "${MAX_DOWNLOAD_ATTEMPTS}"); do
+    if download_jar && verify_jar_sha256 "${VERSIONED_JAR_PATH}"; then
+      return 0
+    fi
+    echo "Download attempt ${attempt}/${MAX_DOWNLOAD_ATTEMPTS} failed." >&2
+    remove_jar_artifacts
+  done
+
+  echo "Failed to download a valid MCP server JAR after ${MAX_DOWNLOAD_ATTEMPTS} attempts." >&2
+  return 1
+}
+
+ensure_jar
+ln -sfn "${VERSIONED_JAR_NAME}" "${STABLE_JAR_PATH}"

--- a/.github/skills/gradle-tapi-mcp/SKILL.md
+++ b/.github/skills/gradle-tapi-mcp/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: gradle-tapi-mcp
+description: >-
+  Use the gradle MCP server for all Gradle task execution and build verification
+  in this repo. Prefer MCP over shell ./gradlew. Configured in .github/mcp.json;
+  JAR installed by copilot-setup-steps or .github/scripts/install-gradle-tapi-mcp.sh.
+---
+
+# Gradle Tooling API MCP (Copilot / GitHub Agents)
+
+This repository configures [nise-nabe/gradle-tapi-mcp-server](https://github.com/nise-nabe/gradle-tapi-mcp-server) v0.3.3:
+
+| Environment | Config | Install |
+|-------------|--------|---------|
+| GitHub Copilot CLI / cloud agent | `.github/mcp.json` | `.github/workflows/copilot-setup-steps.yml` or `.github/scripts/install-gradle-tapi-mcp.sh` |
+| Cursor Cloud Agents | `.cursor/mcp.json` | `.cursor/install.sh` |
+
+The wrapper `.github/scripts/gradle-mcp-server.sh` sets `GRADLE_PROJECT_DIR` to the git root before starting the MCP server.
+
+**Use MCP for all Gradle tasks.** Fall back to shell `./gradlew` only when MCP is unresponsive or returns `BUILD_ALREADY_RUNNING` that cannot be cancelled.
+
+## Workflow
+
+1. `gradle_connection_status` — confirm `connectedAny: true`; if not, `gradle_connect` with the repository root
+2. `gradle_get_build_environment` — resolved Gradle/Java versions
+3. `gradle_get_project_overview` — module hierarchy (`build-logic`, `plugin`)
+4. `gradle_run_tasks` / `gradle_run_tests` for verification
+
+Use `background: true` and poll `gradle_get_build_status` for runs that may exceed ~30s (`build`, `:plugin:test`, cold start).
+
+## Common tasks (this repo)
+
+| Goal | MCP |
+|------|-----|
+| Compile | `gradle_run_tasks` `{ "tasks": [":plugin:compileKotlin", ":plugin:compileTestKotlin"] }` |
+| One test class | `gradle_run_tests` `{ "testClasses": ["fully.qualified.ClassName"], "background": true }` |
+| All tests | `gradle_run_tasks` `{ "tasks": [":plugin:test"], "background": true }` |
+| Full verify | `gradle_run_tasks` `{ "tasks": ["build"], "background": true }` |
+
+## Constraints
+
+- One MCP build per `projectDirectory` at a time (`BUILD_ALREADY_RUNNING` on overlap)
+- Do **not** run MCP `gradle_run_tests` and shell `./gradlew :plugin:test` concurrently (IntelliJ test sandbox contention)
+- On MCP timeout: `gradle_list_builds` or read `.gradle/mcp-builds/<buildId>/mcp-result.json`, then shell fallback
+
+Full reference: `.cursor/skills/gradle-tapi-mcp/SKILL.md`

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -28,4 +28,7 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
 
+      - name: Install Gradle Tooling API MCP server
+        run: bash .github/scripts/install-gradle-tapi-mcp.sh
+
       - run: ./gradlew assemble

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,19 +8,22 @@ IntelliJ Platform plugin for Armeria. Gradle multi-project build (`build-logic` 
 
 - **Gradle daemon JVM**: Adoptium 25 (pinned in `gradle/gradle-daemon-jvm.properties`; Foojay resolver downloads it). The running daemon may report a different Java until it restarts and applies the pin — see `gradle_get_build_environment`.
 - **Compile toolchain**: Java 21 JetBrains (configured in `build-logic/src/main/kotlin/com.linecorp.intellij.platform-plugin.gradle.kts` and inherited by `plugin/`).
-- Gradle wrapper (`./gradlew`) downloads the distribution and dependencies on first use.
+- Gradle wrapper (`./gradlew`) remains available as a **fallback** when MCP is unavailable.
 
-### MCP: Gradle Tooling API
+### MCP: Gradle Tooling API (default for Gradle tasks)
 
 The `gradle` MCP server (`nise-nabe/gradle-tapi-mcp-server` v0.3.3) is configured in `.cursor/mcp.json`. The install script downloads the release JAR to `~/.local/share/gradle-tapi-mcp-server/`, verifies its SHA-256, and exposes it via a stable `gradle-tapi-mcp-server.jar` symlink. `GRADLE_PROJECT_DIR` is set to the workspace root.
 
-Prefer token-efficient MCP workflows documented in `.cursor/skills/gradle-tapi-mcp/SKILL.md`:
+**Use MCP for all Gradle task execution and verification** unless MCP is unresponsive or returns `BUILD_ALREADY_RUNNING` that cannot be cancelled. See `.cursor/rules/gradle-mcp.mdc` and `.cursor/skills/gradle-tapi-mcp/SKILL.md`.
 
-1. `gradle_get_build_environment` for resolved Gradle/Java versions
-2. `gradle_get_project_overview` for module hierarchy
-3. `gradle_run_tasks` with `[":plugin:compileKotlin"]` for fast compile checks
+Default workflow:
 
-For **`:plugin:test` and `build`**, prefer `./gradlew` in Cursor Cloud — IntelliJ tests are long-running and MCP clients often time out (~60s). Use `background: true` and poll `gradle_get_build_status` for MCP builds; the server rejects a second MCP build on the same project with `BUILD_ALREADY_RUNNING`. Do not run MCP `gradle_run_tests` and shell `./gradlew :plugin:test` at the same time (sandbox contention). Cold-start compile may also timeout in foreground while Gradle still succeeds — use background + poll or `gradle_list_builds`. If MCP stops responding, poll with `gradle_get_build_status` (merges disk progress from `.gradle/mcp-builds/<buildId>/`) or read `mcp-result.json` and fall back to shell. Task discovery: see `gradle-tapi-mcp` skill (`gradle_get_build_invocations` / `gradle_get_project_model`).
+1. `gradle_connection_status` — confirm connected (`connectedAny: true`)
+2. `gradle_get_build_environment` for resolved Gradle/Java versions
+3. `gradle_get_project_overview` for module hierarchy
+4. `gradle_run_tasks` / `gradle_run_tests` for verification (`background: true` + poll `gradle_get_build_status` when a run may exceed ~30s)
+
+Shell `./gradlew` is fallback only: MCP client timeout, unresponsive server, or final CI parity before merge. Do not run MCP `gradle_run_tests` and shell `./gradlew :plugin:test` at the same time (sandbox contention). If MCP stops responding, poll with `gradle_get_build_status` (merges disk progress from `.gradle/mcp-builds/<buildId>/`) or read `mcp-result.json`, then fall back to shell. Task discovery: `gradle_get_build_invocations` / `gradle_get_project_model` (see `gradle-tapi-mcp` skill).
 
 ### GitHub and pull requests (Cursor Cloud)
 
@@ -33,10 +36,10 @@ Do not rely on bare `gh` commands without checking availability. `.cursor/instal
 |------|-------------------|
 | Create or update a PR | Built-in **ManagePullRequest** tool (`create_pr` / `update_pr`); body format in `.cursor/rules/pr-description-format.mdc` |
 | Edit PR labels | **EditPullRequestLabels** tool |
-| Verify changes locally | `./gradlew build` (preferred for tests); MCP for compile checks — see `gradle-tapi-mcp` skill |
+| Verify changes locally | **Gradle MCP** (`gradle_run_tasks` / `gradle_run_tests`); shell `./gradlew build` for CI parity fallback — see `gradle-tapi-mcp` skill |
 | PR check status / CI logs | `gh` only after `gh auth status` succeeds (see `.cursor/skills/cloud-github/SKILL.md`) |
 
-If `gh` is not found or auth fails, use ManagePullRequest for PR work and Gradle for build
+If `gh` is not found or auth fails, use ManagePullRequest for PR work and Gradle MCP for build
 verification instead of retrying `gh`. Set `GH_TOKEN` in Cursor Cloud Secrets when the GitHub App
 token lacks required scopes.
 
@@ -48,20 +51,21 @@ release workflow — tag and `gh release create` after merging a version-bump PR
 
 ### Build, test, lint
 
-| Goal | Command |
-|------|---------|
-| Full verify | `./gradlew build` |
-| Compile plugin | `./gradlew :plugin:compileKotlin` |
-| Platform PSI fixture tests | `./gradlew :plugin:test` |
-| Pure unit tests (`src/fastTest`) | `./gradlew :plugin:fastTest` |
-| All plugin tests | `./gradlew :plugin:check` (or `build`) |
-| Run IDE sandbox | `./gradlew :plugin:runIde` |
-| Fast compile + platform tests | `./gradlew --no-daemon :plugin:compileKotlin :plugin:test` |
-| Fix stale test sandbox | `.cursor/clean-test-sandbox.sh` |
+Prefer **Gradle MCP** for the tasks below. Use `background: true` and poll `gradle_get_build_status` for long runs. Fall back to shell `./gradlew` only when MCP is unavailable.
+
+| Goal | MCP (preferred) | Shell fallback |
+|------|---------------|----------------|
+| Full verify | `gradle_run_tasks` `["build"]` + background/poll | `./gradlew build` |
+| Compile plugin | `gradle_run_tasks` `[":plugin:compileKotlin"]` | `./gradlew :plugin:compileKotlin` |
+| Platform PSI fixture tests | `gradle_run_tasks` `[":plugin:test"]` or `gradle_run_tests` per class + background/poll | `./gradlew :plugin:test` |
+| Pure unit tests (`src/fastTest`) | `gradle_run_tasks` `[":plugin:fastTest"]` + background/poll | `./gradlew :plugin:fastTest` |
+| All plugin tests | `gradle_run_tasks` `[":plugin:check"]` + background/poll | `./gradlew :plugin:check` |
+| Run IDE sandbox | `gradle_run_tasks` `[":plugin:runIde"]` | `./gradlew :plugin:runIde` |
+| Fix stale test sandbox | — | `.cursor/clean-test-sandbox.sh` |
 
 `:plugin:test` runs only platform fixture tests under `src/test`. `:plugin:fastTest` runs pure unit tests under `src/fastTest` (still on the IntelliJ Platform test runtime, but without PSI fixtures). Use `check` or `build` to run both suites.
 
-There is no separate lint task; `./gradlew build` is the compile/test gate.
+There is no separate lint task; `build` is the compile/test gate.
 
 ### Project layout
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Coding agents in this repository should use the Gradle Tooling API MCP server (`nise-nabe/gradle-tapi-mcp-server` v0.3.3) as the default way to run Gradle tasks, with shell `./gradlew` reserved for fallback and CI parity.

This updates Cursor Cloud, GitHub Copilot, and shared skills/rules so agents consistently reach for `gradle_run_tasks` / `gradle_run_tests` instead of shelling out first.

## Changes

- Add always-applied `.cursor/rules/gradle-mcp.mdc` and rewrite `AGENTS.md` build/verify tables to MCP-first
- Extract `.github/scripts/install-gradle-tapi-mcp.sh` (shared by `.cursor/install.sh` and Copilot setup)
- Add `.github/mcp.json` and `.github/scripts/gradle-mcp-server.sh` wrapper (sets `GRADLE_PROJECT_DIR` from git root) for Copilot CLI / cloud agent
- Install MCP JAR in `copilot-setup-steps.yml`
- Update `.github/copilot-instructions.md`, `.github/skills/gradle-tapi-mcp/SKILL.md`, `.cursor/skills/gradle-tapi-mcp/SKILL.md`, `cloud-github`, and `release` skills to match

## Test plan

- [x] `bash .github/scripts/install-gradle-tapi-mcp.sh` downloads and verifies the JAR
- [ ] Cursor agent loads `.cursor/rules/gradle-mcp.mdc` and uses MCP for compile/test verification
- [ ] Copilot setup workflow installs the MCP JAR before `assemble`
- [ ] Copilot cloud agent MCP settings can copy from `.github/mcp.json` (repo admin action if not auto-loaded)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3578-f563-7d47-9cce-3d790ef8f139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3578-f563-7d47-9cce-3d790ef8f139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

