### PR TITLE
fix(route-analysis): address Thermo-nuclear review for GH-202

### DIFF
--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaBuilderCallHeuristics.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaBuilderCallHeuristics.kt
@@ -1,0 +1,202 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.psi.PsiReferenceExpression
+import com.intellij.psi.PsiVariable
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtConstructor
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.KtParenthesizedExpression
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtTypeAlias
+import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.KtUnaryExpression
+import org.jetbrains.kotlin.psi.KtUserType
+import org.jetbrains.kotlin.psi.KtValueArgument
+import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
+
+internal object ArmeriaBuilderCallHeuristics {
+
+    private val IMPLICIT_RECEIVER_SCOPE_METHODS = setOf("apply", "run")
+    private val EXPLICIT_PARAMETER_SCOPE_METHODS = setOf("also", "let")
+    private val BUILDER_SCOPE_METHOD_NAMES = IMPLICIT_RECEIVER_SCOPE_METHODS + EXPLICIT_PARAMETER_SCOPE_METHODS
+
+    fun looksLikeJavaBuilderCall(expression: PsiMethodCallExpression): Boolean {
+        if (resolvesToArmeriaServerBuilder(expression)) {
+            return true
+        }
+        val qualifierText = expression.methodExpression.qualifierExpression?.text ?: return false
+        return ArmeriaRouteSupport.looksLikeServerBuilderReceiverText(qualifierText) ||
+            qualifierText.contains("routeDecorator")
+    }
+
+    fun looksLikeKotlinBuilderCall(call: KtCallExpression): Boolean {
+        if (resolvesKotlinCallToArmeriaServerBuilder(call)) {
+            return true
+        }
+        val dotQualified = when (val callee = call.calleeExpression) {
+            is KtDotQualifiedExpression -> callee
+            else -> call.parent as? KtDotQualifiedExpression
+        }
+        if (dotQualified != null && isKotlinServerBuilderReceiver(dotQualified.receiverExpression)) {
+            return true
+        }
+        val receiverText = dotQualified?.receiverExpression?.text.orEmpty()
+        if (receiverText.contains("routeDecorator")) {
+            return true
+        }
+        return hasKotlinServerBuilderImplicitReceiver(call)
+    }
+
+    private fun resolvesToArmeriaServerBuilder(expression: PsiMethodCallExpression): Boolean {
+        ArmeriaRouteCollectionMetrics.current()?.resolveCount?.incrementAndGet()
+        val resolvedClass = expression.resolveMethod()?.containingClass?.qualifiedName
+        return resolvedClass?.startsWith(ArmeriaRouteSupport.ARMERIA_SERVER_PACKAGE_PREFIX) == true
+    }
+
+    private fun resolvesKotlinCallToArmeriaServerBuilder(call: KtCallExpression): Boolean {
+        ArmeriaRouteCollectionMetrics.current()?.resolveCount?.incrementAndGet()
+        val dotQualified = call.parent as? KtDotQualifiedExpression
+        if (dotQualified != null) {
+            for (reference in dotQualified.references) {
+                if (isArmeriaServerBuilderMethod(reference.resolve())) {
+                    return true
+                }
+            }
+        }
+        val callee = call.calleeExpression ?: return false
+        val references = when (callee) {
+            is KtNameReferenceExpression -> callee.references.toList()
+            is KtDotQualifiedExpression -> callee.references.toList()
+            else -> emptyList()
+        }
+        return references.any { isArmeriaServerBuilderMethod(it.resolve()) }
+    }
+
+    private fun isArmeriaServerBuilderMethod(resolved: PsiElement?): Boolean {
+        return resolved is PsiMethod &&
+            resolved.containingClass?.qualifiedName?.startsWith(ArmeriaRouteSupport.ARMERIA_SERVER_PACKAGE_PREFIX) == true
+    }
+
+    private fun isKotlinServerBuilderReceiver(receiver: KtExpression): Boolean {
+        val receiverExpression = unwrapKotlinReceiverExpression(receiver)
+        val receiverText = receiverExpression.text
+        if (ArmeriaRouteSupport.looksLikeServerBuilderReceiverText(receiverText)) {
+            return true
+        }
+        if (receiverExpression is KtNameReferenceExpression) {
+            when (val resolved = receiverExpression.references.firstOrNull()?.resolve()) {
+                is PsiVariable -> {
+                    if (ArmeriaRouteSupport.isServerBuilderType(resolved.type.canonicalText)) {
+                        return true
+                    }
+                }
+                is KtProperty -> {
+                    val typeText = resolveKotlinTypeReferenceText(resolved.typeReference)
+                    if (typeText != null && ArmeriaRouteSupport.isServerBuilderType(typeText)) {
+                        return true
+                    }
+                }
+            }
+        }
+        return false
+    }
+
+    private fun resolveKotlinTypeReferenceText(typeReference: KtTypeReference?): String? {
+        if (typeReference == null) {
+            return null
+        }
+        val userType = typeReference.typeElement as? KtUserType
+        val resolved = userType?.referenceExpression?.references?.firstOrNull()?.resolve()
+        return when (resolved) {
+            is KtTypeAlias -> resolved.getTypeReference()?.text ?: typeReference.text
+            is KtClassOrObject -> resolved.fqName?.asString() ?: typeReference.text
+            else -> typeReference.text
+        }
+    }
+
+    private fun unwrapKotlinReceiverExpression(receiver: KtExpression): KtExpression {
+        return when (receiver) {
+            is KtUnaryExpression -> receiver.baseExpression?.let(::unwrapKotlinReceiverExpression) ?: receiver
+            is KtParenthesizedExpression -> receiver.expression?.let(::unwrapKotlinReceiverExpression) ?: receiver
+            else -> receiver
+        }
+    }
+
+    private fun hasKotlinServerBuilderImplicitReceiver(call: KtCallExpression): Boolean {
+        val lambda = call.getParentOfType<KtLambdaExpression>(strict = true) ?: return false
+        val lambdaArgument = lambda.parent as? KtValueArgument ?: return false
+        val scopeCall = lambdaArgument.parent as? KtCallExpression ?: return false
+        val scopeMethod = resolveKotlinCallName(scopeCall) ?: return false
+        if (scopeMethod !in BUILDER_SCOPE_METHOD_NAMES) {
+            return false
+        }
+        val scopeReceiver = when (val callee = scopeCall.calleeExpression) {
+            is KtDotQualifiedExpression -> callee.receiverExpression
+            else -> (scopeCall.parent as? KtDotQualifiedExpression)?.receiverExpression
+        } ?: return false
+        if (!isKotlinServerBuilderReceiver(scopeReceiver) && !kotlinReceiverChainContainsServerBuilder(scopeReceiver)) {
+            return false
+        }
+        return when (scopeMethod) {
+            in IMPLICIT_RECEIVER_SCOPE_METHODS -> true
+            in EXPLICIT_PARAMETER_SCOPE_METHODS -> isKotlinRegistrationOnScopeLambdaParameter(call, lambda)
+            else -> false
+        }
+    }
+
+    private fun isKotlinRegistrationOnScopeLambdaParameter(
+        call: KtCallExpression,
+        scopeLambda: KtLambdaExpression,
+    ): Boolean {
+        val dotQualified = when (val callee = call.calleeExpression) {
+            is KtDotQualifiedExpression -> callee
+            else -> call.parent as? KtDotQualifiedExpression
+        } ?: return false
+
+        val receiver = dotQualified.receiverExpression
+        if (isKotlinServerBuilderReceiver(receiver)) {
+            return true
+        }
+        val receiverName = (receiver as? KtNameReferenceExpression)?.getReferencedName() ?: return false
+        if (scopeLambda.valueParameters.any { it.name == receiverName }) {
+            return true
+        }
+        return scopeLambda.valueParameters.isEmpty() && receiverName == "it"
+    }
+
+    private fun kotlinReceiverChainContainsServerBuilder(receiver: KtExpression): Boolean {
+        var current: KtExpression? = receiver
+        while (current != null) {
+            if (isKotlinServerBuilderReceiver(current)) {
+                return true
+            }
+            current = when (current) {
+                is KtDotQualifiedExpression -> current.receiverExpression
+                is KtCallExpression -> {
+                    when (val callee = current.calleeExpression) {
+                        is KtDotQualifiedExpression -> callee.receiverExpression
+                        else -> (current.parent as? KtDotQualifiedExpression)?.receiverExpression
+                    }
+                }
+                else -> null
+            }
+        }
+        return false
+    }
+
+    private fun resolveKotlinCallName(call: KtCallExpression): String? {
+        val callee = call.calleeExpression ?: return null
+        return when (callee) {
+            is KtDotQualifiedExpression -> callee.selectorExpression?.text
+            else -> callee.text
+        }
+    }
+}

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollector.kt
@@ -28,6 +28,15 @@ internal object ArmeriaExtendedRegistrationCollector {
         })
     }
 
+    fun visitMethodCallExpression(
+        expression: PsiMethodCallExpression,
+        routes: MutableList<ArmeriaRoute>,
+        seenRegistrations: MutableSet<String>,
+    ) {
+        collectFromMethodCall(expression, routes, seenRegistrations)
+        tryCollectFluentRoute(expression, routes, seenRegistrations)
+    }
+
     fun collectFromMethodCall(
         expression: PsiMethodCallExpression,
         routes: MutableList<ArmeriaRoute>,
@@ -38,7 +47,7 @@ internal object ArmeriaExtendedRegistrationCollector {
         if (methodName !in ServiceRegistrationMethod.EXTENDED_METHOD_NAMES) {
             return
         }
-        if (requireBuilderCall && !looksLikeArmeriaBuilderCall(expression)) {
+        if (requireBuilderCall && !ArmeriaBuilderCallHeuristics.looksLikeJavaBuilderCall(expression)) {
             return
         }
         when (ServiceRegistrationMethod.fromMethodName(methodName)) {
@@ -109,24 +118,23 @@ internal object ArmeriaExtendedRegistrationCollector {
         seenRegistrations: MutableSet<String>,
     ) {
         val key = registrationKey(expression) ?: return
-        if (!seenRegistrations.add(key)) {
-            return
-        }
         val hostname = extractString(expression.argumentList.expressions.firstOrNull())
             ?: expression.argumentList.expressions.firstOrNull()?.text
             ?: message("route.explorer.target.virtualHost")
-        routes += ArmeriaRoute.create(
-            element = expression,
-            protocol = RouteProtocol.HTTP.presentableName(),
-            httpMethod = "",
-            path = "/",
-            target = hostname,
-            routeMatch = RouteMatch.VIRTUAL_HOST,
-            virtualHostName = hostname,
-            decorators = ArmeriaDecoratorSupport.collectProgrammaticDecorators(expression, "/"),
-            timeoutHints = ArmeriaTimeoutSupport.collectBuilderTimeoutHints(expression),
-        )
-        collectNestedRegistrations(expression, routes, seenRegistrations, hostname)
+        if (seenRegistrations.add(key)) {
+            routes += ArmeriaRoute.create(
+                element = expression,
+                protocol = RouteProtocol.HTTP.presentableName(),
+                httpMethod = "",
+                path = "/",
+                target = hostname,
+                routeMatch = RouteMatch.VIRTUAL_HOST,
+                virtualHostName = hostname,
+                decorators = ArmeriaDecoratorSupport.collectProgrammaticDecorators(expression, "/"),
+                timeoutHints = ArmeriaTimeoutSupport.collectBuilderTimeoutHints(expression),
+            )
+        }
+        collectVirtualHostScopedRegistrations(expression, routes, seenRegistrations, hostname)
     }
 
     private fun addDecoratorUnder(
@@ -166,12 +174,7 @@ internal object ArmeriaExtendedRegistrationCollector {
             .filter { it.methodExpression.referenceName == "build" }
             .firstOrNull { extractFluentRouteChain(it, requireRouteAnchor = false) != null }
             ?: return
-        val chainInfo = extractFluentRouteChain(buildCall, requireRouteAnchor = false) ?: return
-        val key = registrationKey(buildCall) ?: return
-        if (!seenRegistrations.add(key)) {
-            return
-        }
-        routes += createFluentRoute(buildCall, chainInfo)
+        addFluentRouteFromBuild(buildCall, routes, seenRegistrations, requireRouteAnchor = false)
     }
 
     private fun tryCollectFluentRoute(
@@ -186,10 +189,19 @@ internal object ArmeriaExtendedRegistrationCollector {
         if (buildCall.argumentList.expressionCount == 0) {
             return
         }
-        if (requireBuilderCall && !looksLikeArmeriaBuilderCall(buildCall)) {
+        if (requireBuilderCall && !ArmeriaBuilderCallHeuristics.looksLikeJavaBuilderCall(buildCall)) {
             return
         }
-        val chainInfo = extractFluentRouteChain(buildCall, requireRouteAnchor = true) ?: return
+        addFluentRouteFromBuild(buildCall, routes, seenRegistrations, requireRouteAnchor = true)
+    }
+
+    private fun addFluentRouteFromBuild(
+        buildCall: PsiMethodCallExpression,
+        routes: MutableList<ArmeriaRoute>,
+        seenRegistrations: MutableSet<String>,
+        requireRouteAnchor: Boolean,
+    ) {
+        val chainInfo = extractFluentRouteChain(buildCall, requireRouteAnchor) ?: return
         val key = registrationKey(buildCall) ?: return
         if (!seenRegistrations.add(key)) {
             return
@@ -214,13 +226,6 @@ internal object ArmeriaExtendedRegistrationCollector {
         )
     }
 
-    private data class FluentRouteChainInfo(
-        val httpMethod: String,
-        val path: String,
-        val pathType: PathType,
-        val target: String,
-    )
-
     private fun extractFluentRouteChain(
         buildCall: PsiMethodCallExpression,
         requireRouteAnchor: Boolean,
@@ -228,78 +233,19 @@ internal object ArmeriaExtendedRegistrationCollector {
         if (buildCall.methodExpression.referenceName != "build") {
             return null
         }
+        val steps = mutableListOf<RegistrationChainStep>()
         var current = previousMethodCallInChain(buildCall)
-        var httpMethod = ""
-        var path = "/"
-        var pathType = PathType.EXACT
-        var foundRoute = false
-        var foundPath = false
         while (current != null) {
-            when (current.methodExpression.referenceName) {
-                "route" -> {
-                    foundRoute = true
-                    break
-                }
-                in ServiceRegistrationMethod.FLUENT_ROUTE_HTTP_METHODS -> {
-                    httpMethod = current.methodExpression.referenceName!!.uppercase()
-                    parsePathFromCall(current)?.let { parsed ->
-                        path = parsed.second
-                        pathType = parsed.first
-                        foundPath = true
-                    }
-                }
-                "path" -> parsePathFromCall(current)?.let { parsed ->
-                    path = parsed.second
-                    pathType = parsed.first
-                    foundPath = true
-                }
-                "pathPrefix" -> {
-                    val raw = extractString(current.argumentList.expressions.firstOrNull()) ?: path
-                    val parsed = ArmeriaRouteSupport.parsePathType("prefix:$raw")
-                    pathType = parsed.first
-                    path = parsed.second
-                    foundPath = true
-                }
-                "pathRegex" -> {
-                    val raw = extractString(current.argumentList.expressions.firstOrNull()) ?: path
-                    val parsed = ArmeriaRouteSupport.parsePathType("regex:$raw")
-                    pathType = parsed.first
-                    path = parsed.second
-                    foundPath = true
-                }
-                "pathGlob" -> {
-                    val raw = extractString(current.argumentList.expressions.firstOrNull()) ?: path
-                    val parsed = ArmeriaRouteSupport.parsePathType("glob:$raw")
-                    pathType = parsed.first
-                    path = parsed.second
-                    foundPath = true
-                }
-                "methods", "method" -> {
-                    httpMethod = current.argumentList.expressions.joinToString(", ") { argument ->
-                        argument.text.removePrefix("HttpMethod.").uppercase()
-                    }
-                }
-            }
+            steps += toChainStep(current)
             current = previousMethodCallInChain(current)
         }
-        if (requireRouteAnchor && !foundRoute) {
-            return null
-        }
-        if (!requireRouteAnchor && !foundPath) {
-            return null
-        }
         val handlerArg = buildCall.argumentList.expressions.firstOrNull()?.text
-        return FluentRouteChainInfo(
-            httpMethod = httpMethod,
-            path = path,
-            pathType = pathType,
-            target = handlerArg ?: message("route.explorer.target.fluentRoute"),
+        return ArmeriaRegistrationChainReducer.reduceFluentRouteChain(
+            stepsFromBuildUpward = steps,
+            requireRouteAnchor = requireRouteAnchor,
+            handlerTarget = handlerArg,
+            defaultTarget = message("route.explorer.target.fluentRoute"),
         )
-    }
-
-    private fun parsePathFromCall(call: PsiMethodCallExpression): Pair<PathType, String>? {
-        val raw = extractString(call.argumentList.expressions.firstOrNull()) ?: return null
-        return ArmeriaRouteSupport.parsePathType(raw)
     }
 
     private fun addRouteDecorator(
@@ -325,169 +271,173 @@ internal object ArmeriaExtendedRegistrationCollector {
         )
     }
 
-    private fun collectNestedRegistrations(
+    private fun collectVirtualHostScopedRegistrations(
         virtualHostCall: PsiMethodCallExpression,
         routes: MutableList<ArmeriaRoute>,
         seenRegistrations: MutableSet<String>,
         hostname: String,
     ) {
-        var current = previousMethodCallInChain(virtualHostCall)
-        while (current != null) {
-            val methodName = current.methodExpression.referenceName
-            if (methodName in ServiceRegistrationMethod.METHOD_NAMES - ServiceRegistrationMethod.EXTENDED_METHOD_NAMES &&
-                looksLikeArmeriaBuilderCall(current)
-            ) {
-                val added = ArmeriaRouteCollector.addServiceRegistrationFromCall(current, routes, seenRegistrations)
-                annotateRouteWithVirtualHost(routes, current, hostname, added)
-            }
-            if (methodName in ServiceRegistrationMethod.EXTENDED_METHOD_NAMES &&
-                methodName != ServiceRegistrationMethod.VIRTUAL_HOST.methodName
-            ) {
-                val beforeSize = routes.size
-                collectFromMethodCall(current, routes, seenRegistrations)
-                annotateRouteWithVirtualHost(routes, current, hostname, routes.size > beforeSize)
-            }
-            current = previousMethodCallInChain(current)
+        val scopedKeys = linkedSetOf<String>()
+        collectForwardChainedRegistrations(virtualHostCall, routes, seenRegistrations, hostname, scopedKeys)
+        for (argument in virtualHostCall.argumentList.expressions) {
+            val lambdaBody = (argument as? PsiLambdaExpression)?.body ?: continue
+            collectRegistrationsInVirtualHostScope(
+                lambdaBody,
+                virtualHostCall,
+                routes,
+                seenRegistrations,
+                hostname,
+                scopedKeys,
+            )
         }
-        annotatePrecedingRoutesInStatement(virtualHostCall, routes, hostname)
-        PsiTreeUtil.findChildrenOfType(virtualHostCall, PsiMethodCallExpression::class.java).forEach { nested ->
-            if (nested == virtualHostCall) {
-                return@forEach
-            }
-            annotateNestedVirtualHostRegistration(nested, routes, seenRegistrations, hostname)
+        annotateRoutesByKeys(routes, scopedKeys, hostname) { route ->
+            val element = route.pointer.element as? PsiMethodCallExpression ?: return@annotateRoutesByKeys null
+            registrationKey(element)
         }
     }
 
-    private fun annotateNestedVirtualHostRegistration(
-        nested: PsiMethodCallExpression,
+    private fun annotateRoutesByKeys(
+        routes: MutableList<ArmeriaRoute>,
+        registrationKeys: Set<String>,
+        hostname: String,
+        routeKey: (ArmeriaRoute) -> String?,
+    ) {
+        if (registrationKeys.isEmpty()) {
+            return
+        }
+        for (index in routes.indices) {
+            val key = routeKey(routes[index]) ?: continue
+            if (key in registrationKeys) {
+                ArmeriaRouteVirtualHostAnnotator.annotateRouteAt(routes, index, hostname)
+            }
+        }
+    }
+
+    private fun collectForwardChainedRegistrations(
+        virtualHostCall: PsiMethodCallExpression,
         routes: MutableList<ArmeriaRoute>,
         seenRegistrations: MutableSet<String>,
         hostname: String,
+        scopedKeys: MutableSet<String>,
     ) {
-        when (nested.methodExpression.referenceName) {
-            "build" -> {
-                val beforeSize = routes.size
-                tryCollectFluentRoute(nested, routes, seenRegistrations, requireBuilderCall = false)
-                annotateRouteWithVirtualHost(routes, nested, hostname, routes.size > beforeSize)
+        var current = findImmediateNextChainedCall(virtualHostCall)
+        while (current != null) {
+            val methodName = current.methodExpression.referenceName
+            if (methodName == "build" && current.argumentList.expressionCount == 0) {
+                break
             }
-            in ServiceRegistrationMethod.CORE_METHOD_NAMES -> {
-                val added = ArmeriaRouteCollector.addServiceRegistrationFromCall(nested, routes, seenRegistrations)
-                annotateRouteWithVirtualHost(routes, nested, hostname, added)
+            processVirtualHostScopedCall(current, routes, seenRegistrations, hostname, scopedKeys)
+            current = findImmediateNextChainedCall(current)
+        }
+    }
+
+    private fun collectRegistrationsInVirtualHostScope(
+        root: PsiElement,
+        outerVirtualHostCall: PsiMethodCallExpression,
+        routes: MutableList<ArmeriaRoute>,
+        seenRegistrations: MutableSet<String>,
+        hostname: String,
+        scopedKeys: MutableSet<String>,
+    ) {
+        val methodCalls = buildList {
+            if (root is PsiMethodCallExpression) {
+                add(root)
             }
-            in ServiceRegistrationMethod.EXTENDED_METHOD_NAMES -> {
-                if (nested.methodExpression.referenceName == ServiceRegistrationMethod.VIRTUAL_HOST.methodName) {
-                    return
-                }
-                val beforeSize = routes.size
-                collectFromMethodCall(nested, routes, seenRegistrations, requireBuilderCall = false)
-                annotateRouteWithVirtualHost(routes, nested, hostname, routes.size > beforeSize)
+            addAll(PsiTreeUtil.findChildrenOfType(root, PsiMethodCallExpression::class.java))
+        }
+        methodCalls.forEach { nested ->
+            if (nested == outerVirtualHostCall || isInsideInnerVirtualHost(nested, outerVirtualHostCall)) {
+                return@forEach
+            }
+            processVirtualHostScopedCall(nested, routes, seenRegistrations, hostname, scopedKeys)
+        }
+    }
+
+    private fun isInsideInnerVirtualHost(
+        element: PsiElement,
+        outerVirtualHostCall: PsiMethodCallExpression,
+    ): Boolean {
+        var parent = element.parent
+        while (parent != null && parent != outerVirtualHostCall) {
+            if (parent is PsiMethodCallExpression &&
+                parent.methodExpression.referenceName == ServiceRegistrationMethod.VIRTUAL_HOST.methodName &&
+                parent != outerVirtualHostCall
+            ) {
+                return true
+            }
+            parent = parent.parent
+        }
+        return false
+    }
+
+    private fun processVirtualHostScopedCall(
+        call: PsiMethodCallExpression,
+        routes: MutableList<ArmeriaRoute>,
+        seenRegistrations: MutableSet<String>,
+        hostname: String,
+        scopedKeys: MutableSet<String>,
+    ) {
+        val methodName = call.methodExpression.referenceName ?: return
+        when {
+            methodName == ServiceRegistrationMethod.VIRTUAL_HOST.methodName -> {
+                addVirtualHost(call, routes, seenRegistrations)
+            }
+            methodName == "build" -> {
+                val sizeBefore = routes.size
+                tryCollectFluentRoute(call, routes, seenRegistrations, requireBuilderCall = false)
+                registrationKey(call)?.let(scopedKeys::add)
+                annotateVirtualHostForCall(call, routes, sizeBefore, hostname)
+            }
+            methodName in CoreServiceRegistrationMethod.METHOD_NAMES -> {
+                val sizeBefore = routes.size
+                ArmeriaRouteCollector.addServiceRegistrationFromCall(call, routes, seenRegistrations)
+                registrationKey(call)?.let(scopedKeys::add)
+                annotateVirtualHostForCall(call, routes, sizeBefore, hostname)
+            }
+            methodName in ServiceRegistrationMethod.EXTENDED_METHOD_NAMES -> {
+                val sizeBefore = routes.size
+                collectFromMethodCall(call, routes, seenRegistrations, requireBuilderCall = false)
+                registrationKey(call)?.let(scopedKeys::add)
+                annotateVirtualHostForCall(call, routes, sizeBefore, hostname)
             }
         }
     }
 
-    private fun annotatePrecedingRoutesInStatement(
-        anchorCall: PsiMethodCallExpression,
+    private fun annotateVirtualHostForCall(
+        call: PsiMethodCallExpression,
         routes: MutableList<ArmeriaRoute>,
+        sizeBefore: Int,
         hostname: String,
     ) {
-        if (anchorCall.methodExpression.referenceName != ServiceRegistrationMethod.VIRTUAL_HOST.methodName) {
-            return
-        }
-        val virtualFile = anchorCall.containingFile.virtualFile ?: return
-        val statement = PsiTreeUtil.getParentOfType(anchorCall, PsiStatement::class.java) ?: return
-        for (index in routes.indices) {
-            val route = routes[index]
-            if (route.virtualHostName.isNotEmpty() || route.routeMatch == RouteMatch.VIRTUAL_HOST) {
-                continue
+        val key = registrationKey(call)
+        if (key != null) {
+            ArmeriaRouteVirtualHostAnnotator.annotateByKey(routes, key, hostname) { route ->
+                val element = route.pointer.element as? PsiMethodCallExpression ?: return@annotateByKey null
+                registrationKey(element)
             }
-            val element = route.pointer.element ?: continue
-            if (element.containingFile.virtualFile != virtualFile) {
-                continue
-            }
-            if (PsiTreeUtil.getParentOfType(element, PsiStatement::class.java) != statement) {
-                continue
-            }
-            routes[index] = route.copy(virtualHostName = hostname)
+        } else {
+            ArmeriaRouteVirtualHostAnnotator.annotateRoutesAddedSince(routes, sizeBefore, hostname)
         }
     }
-
-    private fun annotateRouteWithVirtualHost(
-        routes: MutableList<ArmeriaRoute>,
-        registrationCall: PsiMethodCallExpression,
-        hostname: String,
-        addedNewRoute: Boolean,
-    ) {
-        if (addedNewRoute) {
-            annotateLastRouteWithVirtualHost(routes, hostname)
-            return
-        }
-        val registrationCallKey = registrationKey(registrationCall) ?: return
-        val index = routes.indexOfLast { route ->
-            val element = route.pointer.element as? PsiMethodCallExpression ?: return@indexOfLast false
-            registrationKey(element) == registrationCallKey
-        }
-        if (index < 0) {
-            return
-        }
-        val route = routes[index]
-        if (route.virtualHostName.isEmpty() && route.routeMatch != RouteMatch.VIRTUAL_HOST) {
-            routes[index] = route.copy(virtualHostName = hostname)
-        }
-    }
-
-    private fun annotateLastRouteWithVirtualHost(routes: MutableList<ArmeriaRoute>, hostname: String) {
-        val last = routes.lastOrNull() ?: return
-        if (last.virtualHostName.isNotEmpty() || last.routeMatch == RouteMatch.VIRTUAL_HOST) {
-            return
-        }
-        routes[routes.lastIndex] = last.copy(virtualHostName = hostname)
-    }
-
-    private data class RouteDecoratorChainInfo(
-        val pathPattern: String,
-        val pathType: PathType,
-        val methods: String,
-        val decoratorLabel: String,
-    )
 
     private fun extractRouteDecoratorChain(routeDecoratorCall: PsiMethodCallExpression): RouteDecoratorChainInfo {
         val outerBuild = findForwardChainedCall(routeDecoratorCall) { call ->
             call.methodExpression.referenceName == "build" && call.argumentList.expressionCount == 0
         }
         val chainCalls = methodCallsBetweenInStatement(routeDecoratorCall, outerBuild)
-        var pathPattern = "/**"
-        var pathType = PathType.GLOB
-        var methods = ""
-        var decoratorLabel = message("route.explorer.target.routeDecorator")
-        for (methodCall in chainCalls) {
-            when (methodCall.methodExpression.referenceName) {
-                "path", "pathPrefix", "pathRegex", "pathGlob" -> {
-                    val raw = extractString(methodCall.argumentList.expressions.firstOrNull()) ?: pathPattern
-                    val parsed = ArmeriaRouteSupport.parsePathType(
-                        when (methodCall.methodExpression.referenceName) {
-                            "pathPrefix" -> "prefix:$raw"
-                            "pathRegex" -> "regex:$raw"
-                            "pathGlob" -> "glob:$raw"
-                            else -> raw
-                        },
-                    )
-                    pathType = parsed.first
-                    pathPattern = parsed.second
-                }
-                "methods", "method" -> {
-                    methods = methodCall.argumentList.expressions.joinToString(", ") { argument ->
-                        argument.text.removePrefix("HttpMethod.").uppercase()
-                    }
-                }
-                "build" -> {
-                    val decoratorArg = methodCall.argumentList.expressions.firstOrNull()
-                    if (decoratorArg != null) {
-                        decoratorLabel = ArmeriaDecoratorSupport.labelDecorator(decoratorArg.text)
-                    }
-                }
-            }
-        }
-        return RouteDecoratorChainInfo(pathPattern, pathType, methods, decoratorLabel)
+        val steps = chainCalls.map(::toChainStep)
+        return ArmeriaRegistrationChainReducer.reduceRouteDecoratorChain(
+            steps = steps,
+            defaultDecoratorLabel = message("route.explorer.target.routeDecorator"),
+        )
+    }
+
+    private fun toChainStep(call: PsiMethodCallExpression): RegistrationChainStep {
+        return RegistrationChainStep(
+            methodName = call.methodExpression.referenceName.orEmpty(),
+            firstStringArg = extractString(call.argumentList.expressions.firstOrNull()),
+            rawMethodArgs = call.argumentList.expressions.map { it.text },
+        )
     }
 
     private fun methodCallsBetweenInStatement(
@@ -528,6 +478,31 @@ internal object ArmeriaExtendedRegistrationCollector {
         return null
     }
 
+    private fun findImmediateNextChainedCall(call: PsiMethodCallExpression): PsiMethodCallExpression? {
+        var element: PsiElement? = call
+        while (element != null) {
+            val parent = element.parent ?: return null
+            when (parent) {
+                is PsiReferenceExpression -> {
+                    val grandParent = parent.parent
+                    if (grandParent is PsiMethodCallExpression &&
+                        grandParent.methodExpression == parent &&
+                        grandParent !== call
+                    ) {
+                        return grandParent
+                    }
+                }
+                is PsiMethodCallExpression -> {
+                    if (parent.methodExpression.qualifierExpression == element && parent !== call) {
+                        return parent
+                    }
+                }
+            }
+            element = parent
+        }
+        return null
+    }
+
     private fun findNextChainedMethodCall(call: PsiMethodCallExpression): PsiMethodCallExpression? {
         var element: PsiElement? = call
         while (element != null) {
@@ -563,16 +538,6 @@ internal object ArmeriaExtendedRegistrationCollector {
             expression.textRange,
             methodName,
         )
-    }
-
-    private fun looksLikeArmeriaBuilderCall(expression: PsiMethodCallExpression): Boolean {
-        val resolvedClass = expression.resolveMethod()?.containingClass?.qualifiedName
-        if (resolvedClass?.startsWith(ArmeriaRouteSupport.ARMERIA_SERVER_PACKAGE_PREFIX) == true) {
-            return true
-        }
-        val qualifierText = expression.methodExpression.qualifierExpression?.text ?: return false
-        return ArmeriaRouteSupport.looksLikeServerBuilderReceiverText(qualifierText) ||
-            qualifierText.contains("routeDecorator")
     }
 
     private fun extractString(expression: PsiExpression?): String? {

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinExtendedRegistrationCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinExtendedRegistrationCollector.kt
@@ -1,14 +1,10 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiStatement
 import com.intellij.psi.util.PsiTreeUtil
-import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiManager
-import com.intellij.psi.search.FileTypeIndex
-import com.intellij.psi.search.GlobalSearchScope
 import com.linecorp.intellij.plugins.armeria.message
 import com.linecorp.intellij.plugins.armeria.psi.forEachDescendant
-import org.jetbrains.kotlin.idea.KotlinFileType
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtExpression
@@ -19,22 +15,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 
 internal object ArmeriaKotlinExtendedRegistrationCollector {
 
-    fun collect(
-        project: Project,
-        scope: GlobalSearchScope,
-        routes: MutableList<ArmeriaRoute>,
-        seenRegistrations: MutableSet<String>,
-    ) {
-        for (virtualFile in FileTypeIndex.getFiles(KotlinFileType.INSTANCE, scope)) {
-            val ktFile = PsiManager.getInstance(project).findFile(virtualFile) as? KtFile ?: continue
-            if (!ArmeriaKotlinRouteCollector.referencesArmeriaKotlinContent(ktFile)) {
-                continue
-            }
-            collectFromFile(ktFile, routes, seenRegistrations)
-        }
-    }
-
-    private fun collectFromFile(
+    fun collectFromFile(
         file: KtFile,
         routes: MutableList<ArmeriaRoute>,
         seenRegistrations: MutableSet<String>,
@@ -48,7 +29,7 @@ internal object ArmeriaKotlinExtendedRegistrationCollector {
             if (methodName !in ServiceRegistrationMethod.EXTENDED_METHOD_NAMES) {
                 return@forEachDescendant
             }
-            if (!ArmeriaKotlinRouteCollector.looksLikeArmeriaBuilderCall(call)) {
+            if (!ArmeriaBuilderCallHeuristics.looksLikeKotlinBuilderCall(call)) {
                 return@forEachDescendant
             }
             collectFromKotlinCall(call, methodName, routes, seenRegistrations)
@@ -151,24 +132,23 @@ internal object ArmeriaKotlinExtendedRegistrationCollector {
         seenRegistrations: MutableSet<String>,
     ) {
         val key = registrationKey(call) ?: return
-        if (!seenRegistrations.add(key)) {
-            return
-        }
         val pathArg = call.valueArguments.firstOrNull()?.getArgumentExpression()
         val hostname = extractKotlinString(pathArg) ?: pathArg?.text
             ?: message("route.explorer.target.virtualHost")
-        routes += ArmeriaRoute.create(
-            element = call,
-            protocol = RouteProtocol.HTTP.presentableName(),
-            httpMethod = "",
-            path = "/",
-            target = hostname,
-            routeMatch = RouteMatch.VIRTUAL_HOST,
-            virtualHostName = hostname,
-            decorators = ArmeriaKotlinDecoratorSupport.collectProgrammaticDecorators(call, "/"),
-            timeoutHints = ArmeriaKotlinTimeoutSupport.collectBuilderTimeoutHints(call),
-        )
-        collectNestedRegistrations(call, routes, seenRegistrations, hostname)
+        if (seenRegistrations.add(key)) {
+            routes += ArmeriaRoute.create(
+                element = call,
+                protocol = RouteProtocol.HTTP.presentableName(),
+                httpMethod = "",
+                path = "/",
+                target = hostname,
+                routeMatch = RouteMatch.VIRTUAL_HOST,
+                virtualHostName = hostname,
+                decorators = ArmeriaKotlinDecoratorSupport.collectProgrammaticDecorators(call, "/"),
+                timeoutHints = ArmeriaKotlinTimeoutSupport.collectBuilderTimeoutHints(call),
+            )
+        }
+        collectVirtualHostScopedRegistrations(call, routes, seenRegistrations, hostname)
     }
 
     private fun addWithRoute(
@@ -184,12 +164,7 @@ internal object ArmeriaKotlinExtendedRegistrationCollector {
         val buildCall = findFluentRouteBuildInLambda(lambdaBody)
             ?: findFluentRouteBuildAfterCall(call)
             ?: return
-        val chainInfo = extractFluentRouteChain(buildCall, requireRouteAnchor = false) ?: return
-        val key = registrationKey(buildCall) ?: return
-        if (!seenRegistrations.add(key)) {
-            return
-        }
-        routes += createFluentRoute(buildCall, chainInfo)
+        addFluentRouteFromBuild(buildCall, routes, seenRegistrations, requireRouteAnchor = false)
     }
 
     private fun tryCollectFluentRoute(
@@ -204,10 +179,19 @@ internal object ArmeriaKotlinExtendedRegistrationCollector {
         if (buildCall.valueArguments.isEmpty()) {
             return
         }
-        val chainInfo = extractFluentRouteChain(buildCall, requireRouteAnchor = true) ?: return
-        if (requireBuilderCall && !ArmeriaKotlinRouteCollector.looksLikeArmeriaBuilderCall(buildCall)) {
+        if (requireBuilderCall && !ArmeriaBuilderCallHeuristics.looksLikeKotlinBuilderCall(buildCall)) {
             return
         }
+        addFluentRouteFromBuild(buildCall, routes, seenRegistrations, requireRouteAnchor = true)
+    }
+
+    private fun addFluentRouteFromBuild(
+        buildCall: KtCallExpression,
+        routes: MutableList<ArmeriaRoute>,
+        seenRegistrations: MutableSet<String>,
+        requireRouteAnchor: Boolean,
+    ) {
+        val chainInfo = extractFluentRouteChain(buildCall, requireRouteAnchor) ?: return
         val key = registrationKey(buildCall) ?: return
         if (!seenRegistrations.add(key)) {
             return
@@ -232,13 +216,6 @@ internal object ArmeriaKotlinExtendedRegistrationCollector {
         )
     }
 
-    private data class FluentRouteChainInfo(
-        val httpMethod: String,
-        val path: String,
-        val pathType: PathType,
-        val target: String,
-    )
-
     private fun extractFluentRouteChain(
         buildCall: KtCallExpression,
         requireRouteAnchor: Boolean,
@@ -246,126 +223,194 @@ internal object ArmeriaKotlinExtendedRegistrationCollector {
         if (resolveCallName(buildCall) != "build") {
             return null
         }
+        val steps = mutableListOf<RegistrationChainStep>()
         var current: KtCallExpression? = parentCallExpression(buildCall)
-        var httpMethod = ""
-        var path = "/"
-        var pathType = PathType.EXACT
-        var foundRoute = false
-        var foundPath = false
         while (current != null) {
-            when (resolveCallName(current)) {
-                "route" -> {
-                    foundRoute = true
-                    break
-                }
-                in ServiceRegistrationMethod.FLUENT_ROUTE_HTTP_METHODS -> {
-                    httpMethod = resolveCallName(current)!!.uppercase()
-                    parsePathFromCall(current)?.let { parsed ->
-                        path = parsed.second
-                        pathType = parsed.first
-                        foundPath = true
-                    }
-                }
-                "path" -> parsePathFromCall(current)?.let { parsed ->
-                    path = parsed.second
-                    pathType = parsed.first
-                    foundPath = true
-                }
-                "pathPrefix" -> {
-                    val raw = extractKotlinString(current.valueArguments.firstOrNull()?.getArgumentExpression()) ?: path
-                    val parsed = ArmeriaRouteSupport.parsePathType("prefix:$raw")
-                    pathType = parsed.first
-                    path = parsed.second
-                    foundPath = true
-                }
-                "pathRegex" -> {
-                    val raw = extractKotlinString(current.valueArguments.firstOrNull()?.getArgumentExpression()) ?: path
-                    val parsed = ArmeriaRouteSupport.parsePathType("regex:$raw")
-                    pathType = parsed.first
-                    path = parsed.second
-                    foundPath = true
-                }
-                "pathGlob" -> {
-                    val raw = extractKotlinString(current.valueArguments.firstOrNull()?.getArgumentExpression()) ?: path
-                    val parsed = ArmeriaRouteSupport.parsePathType("glob:$raw")
-                    pathType = parsed.first
-                    path = parsed.second
-                    foundPath = true
-                }
-                "methods", "method" -> {
-                    httpMethod = current.valueArguments.joinToString(", ") { argument ->
-                        argument.getArgumentExpression()?.text?.removePrefix("HttpMethod.")?.uppercase().orEmpty()
-                    }
-                }
-            }
+            steps += toChainStep(current)
             current = parentCallExpression(current)
         }
-        if (requireRouteAnchor && !foundRoute) {
-            return null
-        }
-        if (!requireRouteAnchor && !foundPath) {
-            return null
-        }
         val handlerArg = buildCall.valueArguments.firstOrNull()?.getArgumentExpression()?.text
-        return FluentRouteChainInfo(
-            httpMethod = httpMethod,
-            path = path,
-            pathType = pathType,
-            target = handlerArg ?: message("route.explorer.target.fluentRoute"),
+        return ArmeriaRegistrationChainReducer.reduceFluentRouteChain(
+            stepsFromBuildUpward = steps,
+            requireRouteAnchor = requireRouteAnchor,
+            handlerTarget = handlerArg,
+            defaultTarget = message("route.explorer.target.fluentRoute"),
         )
     }
-
-    private fun parsePathFromCall(call: KtCallExpression): Pair<PathType, String>? {
-        val raw = extractKotlinString(call.valueArguments.firstOrNull()?.getArgumentExpression()) ?: return null
-        return ArmeriaRouteSupport.parsePathType(raw)
-    }
-
-    private data class RouteDecoratorChainInfo(
-        val pathPattern: String,
-        val pathType: PathType,
-        val methods: String,
-        val decoratorLabel: String,
-    )
 
     private fun extractRouteDecoratorChain(routeDecoratorCall: KtCallExpression): RouteDecoratorChainInfo {
         val outerBuild = findForwardChainedCall(routeDecoratorCall) { call ->
             resolveCallName(call) == "build" && call.valueArguments.isEmpty()
         }
         val chainCalls = methodCallsBetweenInStatement(routeDecoratorCall, outerBuild)
-        var pathPattern = "/**"
-        var pathType = PathType.GLOB
-        var methods = ""
-        var decoratorLabel = message("route.explorer.target.routeDecorator")
-        for (call in chainCalls) {
-            when (resolveCallName(call)) {
-                "path", "pathPrefix", "pathRegex", "pathGlob" -> {
-                    val raw = extractKotlinString(call.valueArguments.firstOrNull()?.getArgumentExpression())
-                        ?: pathPattern
-                    val parsed = ArmeriaRouteSupport.parsePathType(
-                        when (resolveCallName(call)) {
-                            "pathPrefix" -> "prefix:$raw"
-                            "pathRegex" -> "regex:$raw"
-                            "pathGlob" -> "glob:$raw"
-                            else -> raw
-                        },
-                    )
-                    pathType = parsed.first
-                    pathPattern = parsed.second
-                }
-                "methods", "method" -> {
-                    methods = call.valueArguments.joinToString(", ") { argument ->
-                        argument.getArgumentExpression()?.text?.removePrefix("HttpMethod.")?.uppercase().orEmpty()
-                    }
-                }
-                "build" -> {
-                    val decoratorArg = call.valueArguments.firstOrNull()?.getArgumentExpression()
-                    if (decoratorArg != null && call.valueArguments.isNotEmpty()) {
-                        decoratorLabel = ArmeriaDecoratorSupport.labelDecorator(decoratorArg.text)
-                    }
-                }
+        val steps = chainCalls.map(::toChainStep)
+        return ArmeriaRegistrationChainReducer.reduceRouteDecoratorChain(
+            steps = steps,
+            defaultDecoratorLabel = message("route.explorer.target.routeDecorator"),
+        )
+    }
+
+    private fun collectVirtualHostScopedRegistrations(
+        virtualHostCall: KtCallExpression,
+        routes: MutableList<ArmeriaRoute>,
+        seenRegistrations: MutableSet<String>,
+        hostname: String,
+    ) {
+        val scopedKeys = linkedSetOf<String>()
+        collectForwardChainedRegistrations(virtualHostCall, routes, seenRegistrations, hostname, scopedKeys)
+        for (argument in virtualHostCall.valueArguments) {
+            val argumentExpression = argument.getArgumentExpression() ?: continue
+            val lambdaBody = (argumentExpression as? KtLambdaExpression
+                ?: argumentExpression.getParentOfType<KtLambdaExpression>(strict = false))
+                ?.bodyExpression
+                ?: continue
+            collectRegistrationsInVirtualHostScope(
+                lambdaBody,
+                virtualHostCall,
+                routes,
+                seenRegistrations,
+                hostname,
+                scopedKeys,
+            )
+        }
+        annotateRoutesByKeys(routes, scopedKeys, hostname) { route ->
+            val element = route.pointer.element as? KtCallExpression ?: return@annotateRoutesByKeys null
+            registrationKey(element)
+        }
+    }
+
+    private fun annotateRoutesByKeys(
+        routes: MutableList<ArmeriaRoute>,
+        registrationKeys: Set<String>,
+        hostname: String,
+        routeKey: (ArmeriaRoute) -> String?,
+    ) {
+        if (registrationKeys.isEmpty()) {
+            return
+        }
+        for (index in routes.indices) {
+            val key = routeKey(routes[index]) ?: continue
+            if (key in registrationKeys) {
+                ArmeriaRouteVirtualHostAnnotator.annotateRouteAt(routes, index, hostname)
             }
         }
-        return RouteDecoratorChainInfo(pathPattern, pathType, methods, decoratorLabel)
+    }
+
+    private fun collectForwardChainedRegistrations(
+        virtualHostCall: KtCallExpression,
+        routes: MutableList<ArmeriaRoute>,
+        seenRegistrations: MutableSet<String>,
+        hostname: String,
+        scopedKeys: MutableSet<String>,
+    ) {
+        var current = findNextChainedCall(virtualHostCall)
+        while (current != null) {
+            val methodName = resolveCallName(current)
+            if (methodName == "build" && current.valueArguments.isEmpty()) {
+                break
+            }
+            processVirtualHostScopedCall(current, routes, seenRegistrations, hostname, scopedKeys)
+            current = findNextChainedCall(current)
+        }
+    }
+
+    private fun collectRegistrationsInVirtualHostScope(
+        root: KtExpression,
+        outerVirtualHostCall: KtCallExpression,
+        routes: MutableList<ArmeriaRoute>,
+        seenRegistrations: MutableSet<String>,
+        hostname: String,
+        scopedKeys: MutableSet<String>,
+    ) {
+        val calls = buildList {
+            if (root is KtCallExpression) {
+                add(root)
+            }
+            root.forEachDescendant { element ->
+                (element as? KtCallExpression)?.let(::add)
+            }
+        }
+        calls.forEach { nested ->
+            if (nested == outerVirtualHostCall || isInsideInnerVirtualHost(nested, outerVirtualHostCall)) {
+                return@forEach
+            }
+            processVirtualHostScopedCall(nested, routes, seenRegistrations, hostname, scopedKeys)
+        }
+    }
+
+    private fun isInsideInnerVirtualHost(
+        element: PsiElement,
+        outerVirtualHostCall: KtCallExpression,
+    ): Boolean {
+        var parent = element.parent
+        while (parent != null && parent != outerVirtualHostCall) {
+            if (parent is KtCallExpression &&
+                resolveCallName(parent) == ServiceRegistrationMethod.VIRTUAL_HOST.methodName &&
+                parent != outerVirtualHostCall
+            ) {
+                return true
+            }
+            parent = parent.parent
+        }
+        return false
+    }
+
+    private fun processVirtualHostScopedCall(
+        call: KtCallExpression,
+        routes: MutableList<ArmeriaRoute>,
+        seenRegistrations: MutableSet<String>,
+        hostname: String,
+        scopedKeys: MutableSet<String>,
+    ) {
+        val methodName = resolveCallName(call) ?: return
+        when {
+            methodName == ServiceRegistrationMethod.VIRTUAL_HOST.methodName -> {
+                addVirtualHost(call, routes, seenRegistrations)
+            }
+            methodName == "build" -> {
+                val sizeBefore = routes.size
+                tryCollectFluentRoute(call, routes, seenRegistrations, requireBuilderCall = false)
+                registrationKey(call)?.let(scopedKeys::add)
+                annotateVirtualHostForCall(call, routes, sizeBefore, hostname)
+            }
+            methodName in CoreServiceRegistrationMethod.METHOD_NAMES -> {
+                val sizeBefore = routes.size
+                ArmeriaKotlinRouteCollector.addServiceRegistrationFromCall(call, routes, seenRegistrations)
+                registrationKey(call)?.let(scopedKeys::add)
+                annotateVirtualHostForCall(call, routes, sizeBefore, hostname)
+            }
+            methodName in ServiceRegistrationMethod.EXTENDED_METHOD_NAMES -> {
+                val sizeBefore = routes.size
+                collectFromKotlinCall(call, methodName, routes, seenRegistrations)
+                registrationKey(call)?.let(scopedKeys::add)
+                annotateVirtualHostForCall(call, routes, sizeBefore, hostname)
+            }
+        }
+    }
+
+    private fun annotateVirtualHostForCall(
+        call: KtCallExpression,
+        routes: MutableList<ArmeriaRoute>,
+        sizeBefore: Int,
+        hostname: String,
+    ) {
+        val key = registrationKey(call)
+        if (key != null) {
+            ArmeriaRouteVirtualHostAnnotator.annotateByKey(routes, key, hostname) { route ->
+                val element = route.pointer.element as? KtCallExpression ?: return@annotateByKey null
+                registrationKey(element)
+            }
+        } else {
+            ArmeriaRouteVirtualHostAnnotator.annotateRoutesAddedSince(routes, sizeBefore, hostname)
+        }
+    }
+
+    private fun toChainStep(call: KtCallExpression): RegistrationChainStep {
+        return RegistrationChainStep(
+            methodName = resolveCallName(call).orEmpty(),
+            firstStringArg = extractKotlinString(call.valueArguments.firstOrNull()?.getArgumentExpression()),
+            rawMethodArgs = call.valueArguments.mapNotNull { it.getArgumentExpression()?.text },
+        )
     }
 
     private fun methodCallsBetweenInStatement(
@@ -385,128 +430,6 @@ internal object ArmeriaKotlinExtendedRegistrationCollector {
         return calls.sortedBy { it.textRange.startOffset }
     }
 
-    private fun collectNestedRegistrations(
-        virtualHostCall: KtCallExpression,
-        routes: MutableList<ArmeriaRoute>,
-        seenRegistrations: MutableSet<String>,
-        hostname: String,
-    ) {
-        var current: KtCallExpression? = previousCallInChain(virtualHostCall)
-        while (current != null) {
-            val methodName = resolveCallName(current) ?: break
-            if (methodName in ServiceRegistrationMethod.METHOD_NAMES - ServiceRegistrationMethod.EXTENDED_METHOD_NAMES &&
-                ArmeriaKotlinRouteCollector.looksLikeArmeriaBuilderCall(current)
-            ) {
-                val beforeSize = routes.size
-                ArmeriaKotlinRouteCollector.collectServiceRegistrationsInScope(current, routes, seenRegistrations)
-                annotateRouteWithVirtualHost(routes, current, hostname, routes.size > beforeSize)
-            }
-            if (methodName in ServiceRegistrationMethod.EXTENDED_METHOD_NAMES &&
-                methodName != ServiceRegistrationMethod.VIRTUAL_HOST.methodName
-            ) {
-                val beforeSize = routes.size
-                collectFromKotlinCall(current, methodName, routes, seenRegistrations)
-                annotateRouteWithVirtualHost(routes, current, hostname, routes.size > beforeSize)
-            }
-            current = previousCallInChain(current)
-        }
-        annotatePrecedingRoutesInStatement(virtualHostCall, routes, hostname)
-        virtualHostCall.forEachDescendant { element ->
-            val nested = element as? KtCallExpression ?: return@forEachDescendant
-            if (nested == virtualHostCall) {
-                return@forEachDescendant
-            }
-            annotateNestedVirtualHostRegistration(nested, routes, seenRegistrations, hostname)
-        }
-    }
-
-    private fun annotateNestedVirtualHostRegistration(
-        nested: KtCallExpression,
-        routes: MutableList<ArmeriaRoute>,
-        seenRegistrations: MutableSet<String>,
-        hostname: String,
-    ) {
-        when (resolveCallName(nested)) {
-            "build" -> {
-                val beforeSize = routes.size
-                tryCollectFluentRoute(nested, routes, seenRegistrations, requireBuilderCall = false)
-                annotateRouteWithVirtualHost(routes, nested, hostname, routes.size > beforeSize)
-            }
-            in ServiceRegistrationMethod.CORE_METHOD_NAMES -> {
-                val beforeSize = routes.size
-                ArmeriaKotlinRouteCollector.collectServiceRegistrationsInScope(nested, routes, seenRegistrations)
-                annotateRouteWithVirtualHost(routes, nested, hostname, routes.size > beforeSize)
-            }
-            in ServiceRegistrationMethod.EXTENDED_METHOD_NAMES -> {
-                if (resolveCallName(nested) == ServiceRegistrationMethod.VIRTUAL_HOST.methodName) {
-                    return
-                }
-                val methodName = resolveCallName(nested) ?: return
-                val beforeSize = routes.size
-                collectFromKotlinCall(nested, methodName, routes, seenRegistrations)
-                annotateRouteWithVirtualHost(routes, nested, hostname, routes.size > beforeSize)
-            }
-        }
-    }
-
-    private fun annotatePrecedingRoutesInStatement(
-        anchorCall: KtCallExpression,
-        routes: MutableList<ArmeriaRoute>,
-        hostname: String,
-    ) {
-        if (resolveCallName(anchorCall) != ServiceRegistrationMethod.VIRTUAL_HOST.methodName) {
-            return
-        }
-        val virtualFile = anchorCall.containingKtFile.virtualFile ?: return
-        val statement = anchorCall.getParentOfType<PsiStatement>(strict = false) ?: return
-        for (index in routes.indices) {
-            val route = routes[index]
-            if (route.virtualHostName.isNotEmpty() || route.routeMatch == RouteMatch.VIRTUAL_HOST) {
-                continue
-            }
-            val element = route.pointer.element ?: continue
-            if (element.containingFile.virtualFile != virtualFile) {
-                continue
-            }
-            if (PsiTreeUtil.getParentOfType(element, PsiStatement::class.java) != statement) {
-                continue
-            }
-            routes[index] = route.copy(virtualHostName = hostname)
-        }
-    }
-
-    private fun annotateRouteWithVirtualHost(
-        routes: MutableList<ArmeriaRoute>,
-        registrationCall: KtCallExpression,
-        hostname: String,
-        addedNewRoute: Boolean,
-    ) {
-        if (addedNewRoute) {
-            annotateLastRouteWithVirtualHost(routes, hostname)
-            return
-        }
-        val registrationCallKey = registrationKey(registrationCall) ?: return
-        val index = routes.indexOfLast { route ->
-            val element = route.pointer.element as? KtCallExpression ?: return@indexOfLast false
-            registrationKey(element) == registrationCallKey
-        }
-        if (index < 0) {
-            return
-        }
-        val route = routes[index]
-        if (route.virtualHostName.isEmpty() && route.routeMatch != RouteMatch.VIRTUAL_HOST) {
-            routes[index] = route.copy(virtualHostName = hostname)
-        }
-    }
-
-    private fun annotateLastRouteWithVirtualHost(routes: MutableList<ArmeriaRoute>, hostname: String) {
-        val last = routes.lastOrNull() ?: return
-        if (last.virtualHostName.isNotEmpty() || last.routeMatch == RouteMatch.VIRTUAL_HOST) {
-            return
-        }
-        routes[routes.lastIndex] = last.copy(virtualHostName = hostname)
-    }
-
     private fun parentCallExpression(call: KtCallExpression): KtCallExpression? {
         val parent = call.parent
         return when (parent) {
@@ -517,20 +440,6 @@ internal object ArmeriaKotlinExtendedRegistrationCollector {
                     else -> null
                 }
             }
-            else -> null
-        }
-    }
-
-    private fun parentReceiverExpression(call: KtCallExpression): KtExpression? {
-        val parent = call.parent as? KtDotQualifiedExpression ?: return null
-        return parent.receiverExpression
-    }
-
-    private fun previousCallInChain(call: KtCallExpression): KtCallExpression? {
-        val receiver = parentReceiverExpression(call) ?: return null
-        return when (receiver) {
-            is KtCallExpression -> receiver
-            is KtDotQualifiedExpression -> receiver.selectorExpression as? KtCallExpression
             else -> null
         }
     }

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollector.kt
@@ -16,23 +16,14 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtParenthesizedExpression
-import org.jetbrains.kotlin.psi.KtUnaryExpression
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
-import org.jetbrains.kotlin.psi.KtTypeAlias
-import org.jetbrains.kotlin.psi.KtTypeReference
-import org.jetbrains.kotlin.psi.KtUserType
 import org.jetbrains.kotlin.psi.KtValueArgument
-import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 import com.linecorp.intellij.plugins.armeria.psi.forEachDescendant
 
 object ArmeriaKotlinRouteCollector {
-    private val IMPLICIT_RECEIVER_SCOPE_METHODS = setOf("apply", "run")
-    private val EXPLICIT_PARAMETER_SCOPE_METHODS = setOf("also", "let")
-    private val BUILDER_SCOPE_METHOD_NAMES = IMPLICIT_RECEIVER_SCOPE_METHODS + EXPLICIT_PARAMETER_SCOPE_METHODS
 
     fun referencesArmeriaKotlinContent(file: KtFile): Boolean {
         val hasArmeriaImports = file.importList?.imports?.any { import ->
@@ -75,10 +66,10 @@ object ArmeriaKotlinRouteCollector {
             val call = element as? KtCallExpression ?: return@forEachDescendant
             ArmeriaRouteCollectionMetrics.current()?.methodCallsVisited?.incrementAndGet()
             val methodName = resolveCallName(call) ?: return@forEachDescendant
-            if (methodName !in ServiceRegistrationMethod.METHOD_NAMES - ServiceRegistrationMethod.EXTENDED_METHOD_NAMES) {
+            if (methodName !in CoreServiceRegistrationMethod.METHOD_NAMES) {
                 return@forEachDescendant
             }
-            if (!looksLikeArmeriaBuilderCall(call)) {
+            if (!ArmeriaBuilderCallHeuristics.looksLikeKotlinBuilderCall(call)) {
                 return@forEachDescendant
             }
             addKotlinServiceRegistration(call, methodName, routes, seenServiceRegistrations)
@@ -91,6 +82,7 @@ object ArmeriaKotlinRouteCollector {
         seenServiceRegistrations: MutableSet<String>,
     ) {
         collectServiceRegistrationsInScope(file, routes, seenServiceRegistrations)
+        ArmeriaKotlinExtendedRegistrationCollector.collectFromFile(file, routes, seenServiceRegistrations)
     }
 
     private fun resolveCallName(call: KtCallExpression): String? {
@@ -101,153 +93,21 @@ object ArmeriaKotlinRouteCollector {
         }
     }
 
-    internal fun looksLikeArmeriaBuilderCall(call: KtCallExpression): Boolean {
-        if (resolvesToArmeriaServerBuilder(call)) {
-            return true
-        }
-        val dotQualified = when (val callee = call.calleeExpression) {
-            is KtDotQualifiedExpression -> callee
-            else -> call.parent as? KtDotQualifiedExpression
-        }
-        if (dotQualified != null && isServerBuilderReceiver(dotQualified.receiverExpression)) {
-            return true
-        }
-        val receiverText = dotQualified?.receiverExpression?.text.orEmpty()
-        if (receiverText.contains("routeDecorator")) {
-            return true
-        }
-        return hasServerBuilderImplicitReceiver(call)
-    }
+    internal fun looksLikeArmeriaBuilderCall(call: KtCallExpression): Boolean =
+        ArmeriaBuilderCallHeuristics.looksLikeKotlinBuilderCall(call)
 
-    private fun resolvesToArmeriaServerBuilder(call: KtCallExpression): Boolean {
-        ArmeriaRouteCollectionMetrics.current()?.resolveCount?.incrementAndGet()
-        val dotQualified = call.parent as? KtDotQualifiedExpression
-        if (dotQualified != null) {
-            for (reference in dotQualified.references) {
-                if (isArmeriaServerBuilderMethod(reference.resolve())) {
-                    return true
-                }
-            }
-        }
-        val callee = call.calleeExpression ?: return false
-        val references = when (callee) {
-            is KtNameReferenceExpression -> callee.references.toList()
-            is KtDotQualifiedExpression -> callee.references.toList()
-            else -> emptyList()
-        }
-        return references.any { isArmeriaServerBuilderMethod(it.resolve()) }
-    }
-
-    private fun isArmeriaServerBuilderMethod(resolved: PsiElement?): Boolean {
-        return resolved is PsiMethod &&
-            resolved.containingClass?.qualifiedName?.startsWith(ArmeriaRouteSupport.ARMERIA_SERVER_PACKAGE_PREFIX) == true
-    }
-
-    private fun isServerBuilderReceiver(receiver: KtExpression): Boolean {
-        val receiverExpression = unwrapReceiverExpression(receiver)
-        val receiverText = receiverExpression.text
-        if (ArmeriaRouteSupport.looksLikeServerBuilderReceiverText(receiverText)) {
-            return true
-        }
-        if (receiverExpression is KtNameReferenceExpression) {
-            when (val resolved = receiverExpression.references.firstOrNull()?.resolve()) {
-                is PsiVariable -> {
-                    if (ArmeriaRouteSupport.isServerBuilderType(resolved.type.canonicalText)) {
-                        return true
-                    }
-                }
-                is KtProperty -> {
-                    val typeText = resolveKotlinTypeReferenceText(resolved.typeReference)
-                    if (typeText != null && ArmeriaRouteSupport.isServerBuilderType(typeText)) {
-                        return true
-                    }
-                }
-            }
-        }
-        return false
-    }
-
-    private fun resolveKotlinTypeReferenceText(typeReference: KtTypeReference?): String? {
-        if (typeReference == null) {
-            return null
-        }
-        val userType = typeReference.typeElement as? KtUserType
-        val resolved = userType?.referenceExpression?.references?.firstOrNull()?.resolve()
-        return when (resolved) {
-            is KtTypeAlias -> resolved.getTypeReference()?.text ?: typeReference.text
-            is KtClass -> resolved.fqName?.asString() ?: typeReference.text
-            else -> typeReference.text
-        }
-    }
-
-    private fun unwrapReceiverExpression(receiver: KtExpression): KtExpression {
-        return when (receiver) {
-            is KtUnaryExpression -> receiver.baseExpression?.let(::unwrapReceiverExpression) ?: receiver
-            is KtParenthesizedExpression -> receiver.expression?.let(::unwrapReceiverExpression) ?: receiver
-            else -> receiver
-        }
-    }
-
-    private fun hasServerBuilderImplicitReceiver(call: KtCallExpression): Boolean {
-        val lambda = call.getParentOfType<KtLambdaExpression>(strict = true) ?: return false
-        val lambdaArgument = lambda.parent as? KtValueArgument ?: return false
-        val scopeCall = lambdaArgument.parent as? KtCallExpression ?: return false
-        val scopeMethod = resolveCallName(scopeCall) ?: return false
-        if (scopeMethod !in BUILDER_SCOPE_METHOD_NAMES) {
-            return false
-        }
-        val scopeReceiver = when (val callee = scopeCall.calleeExpression) {
-            is KtDotQualifiedExpression -> callee.receiverExpression
-            else -> (scopeCall.parent as? KtDotQualifiedExpression)?.receiverExpression
-        } ?: return false
-        if (!isServerBuilderReceiver(scopeReceiver) && !receiverChainContainsServerBuilder(scopeReceiver)) {
-            return false
-        }
-        return when (scopeMethod) {
-            in IMPLICIT_RECEIVER_SCOPE_METHODS -> true
-            in EXPLICIT_PARAMETER_SCOPE_METHODS -> isRegistrationOnScopeLambdaParameter(call, lambda)
-            else -> false
-        }
-    }
-
-    private fun isRegistrationOnScopeLambdaParameter(
+    internal fun addServiceRegistrationFromCall(
         call: KtCallExpression,
-        scopeLambda: KtLambdaExpression,
+        routes: MutableList<ArmeriaRoute>,
+        seenServiceRegistrations: MutableSet<String>,
     ): Boolean {
-        val dotQualified = when (val callee = call.calleeExpression) {
-            is KtDotQualifiedExpression -> callee
-            else -> call.parent as? KtDotQualifiedExpression
-        } ?: return false
-
-        val receiver = dotQualified.receiverExpression
-        if (isServerBuilderReceiver(receiver)) {
-            return true
+        val methodName = resolveCallName(call) ?: return false
+        if (methodName !in CoreServiceRegistrationMethod.METHOD_NAMES) {
+            return false
         }
-        val receiverName = (receiver as? KtNameReferenceExpression)?.getReferencedName() ?: return false
-        if (scopeLambda.valueParameters.any { it.name == receiverName }) {
-            return true
-        }
-        return scopeLambda.valueParameters.isEmpty() && receiverName == "it"
-    }
-
-    private fun receiverChainContainsServerBuilder(receiver: KtExpression): Boolean {
-        var current: KtExpression? = receiver
-        while (current != null) {
-            if (isServerBuilderReceiver(current)) {
-                return true
-            }
-            current = when (current) {
-                is KtDotQualifiedExpression -> current.receiverExpression
-                is KtCallExpression -> {
-                    when (val callee = current.calleeExpression) {
-                        is KtDotQualifiedExpression -> callee.receiverExpression
-                        else -> (current.parent as? KtDotQualifiedExpression)?.receiverExpression
-                    }
-                }
-                else -> null
-            }
-        }
-        return false
+        val sizeBefore = routes.size
+        addKotlinServiceRegistration(call, methodName, routes, seenServiceRegistrations)
+        return routes.size > sizeBefore
     }
 
     private fun addKotlinServiceRegistration(
@@ -284,21 +144,13 @@ object ArmeriaKotlinRouteCollector {
     }
 
     private fun resolveServiceExpression(methodName: String, arguments: List<KtValueArgument>): KtExpression? {
-        return when (ServiceRegistrationMethod.fromMethodName(methodName)) {
-            ServiceRegistrationMethod.ANNOTATED_SERVICE ->
+        return when (CoreServiceRegistrationMethod.fromMethodName(methodName)) {
+            CoreServiceRegistrationMethod.ANNOTATED_SERVICE ->
                 findArgumentExpression(arguments, "service", 1)
                     ?: findArgumentExpression(arguments, "service", 0)
-            ServiceRegistrationMethod.SERVICE, ServiceRegistrationMethod.SERVICE_UNDER ->
+            CoreServiceRegistrationMethod.SERVICE, CoreServiceRegistrationMethod.SERVICE_UNDER ->
                 findArgumentExpression(arguments, "service", 1)
-            ServiceRegistrationMethod.FILE_SERVICE,
-            ServiceRegistrationMethod.HEALTH_CHECK_SERVICE,
-            ServiceRegistrationMethod.VIRTUAL_HOST,
-            ServiceRegistrationMethod.ROUTE_DECORATOR,
-            ServiceRegistrationMethod.ROUTE,
-            ServiceRegistrationMethod.WITH_ROUTE,
-            ServiceRegistrationMethod.DECORATOR_UNDER,
-            null,
-            -> null
+            null -> null
         }
     }
 
@@ -319,27 +171,19 @@ object ArmeriaKotlinRouteCollector {
     }
 
     private fun extractRegistrationPath(methodName: String, arguments: List<KtValueArgument>): String? {
-        return when (ServiceRegistrationMethod.fromMethodName(methodName)) {
-            ServiceRegistrationMethod.SERVICE ->
+        return when (CoreServiceRegistrationMethod.fromMethodName(methodName)) {
+            CoreServiceRegistrationMethod.SERVICE ->
                 extractKotlinString(findArgumentExpression(arguments, "path", 0))
-            ServiceRegistrationMethod.SERVICE_UNDER ->
+            CoreServiceRegistrationMethod.SERVICE_UNDER ->
                 extractKotlinString(findPathPrefixArgument(arguments, 0))
-            ServiceRegistrationMethod.ANNOTATED_SERVICE -> {
+            CoreServiceRegistrationMethod.ANNOTATED_SERVICE -> {
                 if (arguments.size > 1) {
                     extractKotlinString(findPathPrefixArgument(arguments, 0))
                 } else {
                     "/"
                 }
             }
-            ServiceRegistrationMethod.FILE_SERVICE,
-            ServiceRegistrationMethod.HEALTH_CHECK_SERVICE,
-            ServiceRegistrationMethod.VIRTUAL_HOST,
-            ServiceRegistrationMethod.ROUTE_DECORATOR,
-            ServiceRegistrationMethod.ROUTE,
-            ServiceRegistrationMethod.WITH_ROUTE,
-            ServiceRegistrationMethod.DECORATOR_UNDER,
-            null,
-            -> null
+            null -> null
         }
     }
 

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRegistrationChainReducer.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRegistrationChainReducer.kt
@@ -1,0 +1,140 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+internal data class RegistrationChainStep(
+    val methodName: String,
+    val firstStringArg: String?,
+    val rawMethodArgs: List<String>,
+)
+
+internal data class FluentRouteChainInfo(
+    val httpMethod: String,
+    val path: String,
+    val pathType: PathType,
+    val target: String,
+)
+
+internal data class RouteDecoratorChainInfo(
+    val pathPattern: String,
+    val pathType: PathType,
+    val methods: String,
+    val decoratorLabel: String,
+)
+
+internal object ArmeriaRegistrationChainReducer {
+
+    fun reduceFluentRouteChain(
+        stepsFromBuildUpward: List<RegistrationChainStep>,
+        requireRouteAnchor: Boolean,
+        handlerTarget: String?,
+        defaultTarget: String,
+    ): FluentRouteChainInfo? {
+        var httpMethod = ""
+        var path = "/"
+        var pathType = PathType.EXACT
+        var foundRoute = false
+        var foundPath = false
+        for (step in stepsFromBuildUpward) {
+            when (step.methodName) {
+                "route" -> {
+                    foundRoute = true
+                    break
+                }
+                in ServiceRegistrationMethod.FLUENT_ROUTE_HTTP_METHODS -> {
+                    httpMethod = step.methodName.uppercase()
+                    parsePathFromStep(step)?.let { parsed ->
+                        path = parsed.second
+                        pathType = parsed.first
+                        foundPath = true
+                    }
+                }
+                "path" -> parsePathFromStep(step)?.let { parsed ->
+                    path = parsed.second
+                    pathType = parsed.first
+                    foundPath = true
+                }
+                "pathPrefix" -> {
+                    val raw = step.firstStringArg ?: path
+                    val parsed = ArmeriaRouteSupport.parsePathType("prefix:$raw")
+                    pathType = parsed.first
+                    path = parsed.second
+                    foundPath = true
+                }
+                "pathRegex" -> {
+                    val raw = step.firstStringArg ?: path
+                    val parsed = ArmeriaRouteSupport.parsePathType("regex:$raw")
+                    pathType = parsed.first
+                    path = parsed.second
+                    foundPath = true
+                }
+                "pathGlob" -> {
+                    val raw = step.firstStringArg ?: path
+                    val parsed = ArmeriaRouteSupport.parsePathType("glob:$raw")
+                    pathType = parsed.first
+                    path = parsed.second
+                    foundPath = true
+                }
+                "methods", "method" -> {
+                    httpMethod = step.rawMethodArgs.joinToString(", ") { argument ->
+                        argument.removePrefix("HttpMethod.").uppercase()
+                    }
+                }
+            }
+        }
+        if (requireRouteAnchor && !foundRoute) {
+            return null
+        }
+        if (!requireRouteAnchor && !foundPath) {
+            return null
+        }
+        return FluentRouteChainInfo(
+            httpMethod = httpMethod,
+            path = path,
+            pathType = pathType,
+            target = handlerTarget ?: defaultTarget,
+        )
+    }
+
+    fun reduceRouteDecoratorChain(
+        steps: List<RegistrationChainStep>,
+        defaultDecoratorLabel: String,
+    ): RouteDecoratorChainInfo {
+        var pathPattern = "/**"
+        var pathType = PathType.GLOB
+        var methods = ""
+        var decoratorLabel = defaultDecoratorLabel
+        for (step in steps) {
+            when (step.methodName) {
+                "path", "pathPrefix", "pathRegex", "pathGlob" -> {
+                    val raw = step.firstStringArg ?: pathPattern
+                    val parsed = ArmeriaRouteSupport.parsePathType(
+                        when (step.methodName) {
+                            "pathPrefix" -> "prefix:$raw"
+                            "pathRegex" -> "regex:$raw"
+                            "pathGlob" -> "glob:$raw"
+                            else -> raw
+                        },
+                    )
+                    pathType = parsed.first
+                    pathPattern = parsed.second
+                }
+                "methods", "method" -> {
+                    methods = step.rawMethodArgs.joinToString(", ") { argument ->
+                        argument.removePrefix("HttpMethod.").uppercase()
+                    }
+                }
+                "build" -> {
+                    val decoratorArg = step.rawMethodArgs.firstOrNull()
+                    if (decoratorArg != null) {
+                        decoratorLabel = ArmeriaDecoratorSupport.labelDecorator(decoratorArg)
+                    }
+                }
+            }
+        }
+        return RouteDecoratorChainInfo(pathPattern, pathType, methods, decoratorLabel)
+    }
+
+    private fun parsePathFromStep(step: RegistrationChainStep): Pair<PathType, String>? {
+        val raw = step.firstStringArg ?: return null
+        return ArmeriaRouteSupport.parsePathType(raw)
+    }
+}

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
@@ -25,6 +25,8 @@ import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.PsiModificationTracker
 import com.intellij.psi.util.PsiTreeUtil
 import com.linecorp.intellij.plugins.armeria.message
+import org.jetbrains.kotlin.idea.KotlinFileType
+import org.jetbrains.kotlin.psi.KtFile
 
 internal enum class RouteProtocol(private val messageKey: String) {
     HTTP("route.explorer.protocol.http"),
@@ -101,7 +103,7 @@ object ArmeriaRouteCollector {
         }
         ArmeriaGraphqlRouteCollector.collect(project, scope, routes)
         ArmeriaThriftRouteCollector.collect(project, scope, routes)
-        collectExtendedRegistrations(project, scope, routes, seenServiceRegistrations)
+        collectExtendedRegistrations(project, scope, routes, seenServiceRegistrations, fallbackScannedFiles)
 
         return CachedValueProvider.Result.create(
             routes.sortedWith(
@@ -128,8 +130,12 @@ object ArmeriaRouteCollector {
         scope: GlobalSearchScope,
         routes: MutableList<ArmeriaRoute>,
         seenRegistrations: MutableSet<String>,
+        alreadyScannedFiles: Set<VirtualFile>,
     ) {
         for (virtualFile in FileTypeIndex.getFiles(JavaFileType.INSTANCE, scope)) {
+            if (virtualFile in alreadyScannedFiles) {
+                continue
+            }
             val psiFile = PsiManager.getInstance(project).findFile(virtualFile) as? PsiJavaFile ?: continue
             if (!referencesArmeriaJavaContent(psiFile)) {
                 continue
@@ -137,7 +143,16 @@ object ArmeriaRouteCollector {
             ArmeriaExtendedRegistrationCollector.collectFromJavaFile(psiFile, routes, seenRegistrations)
         }
         if (isKotlinPluginAvailable()) {
-            ArmeriaKotlinExtendedRegistrationCollector.collect(project, scope, routes, seenRegistrations)
+            for (virtualFile in FileTypeIndex.getFiles(KotlinFileType.INSTANCE, scope)) {
+                if (virtualFile in alreadyScannedFiles) {
+                    continue
+                }
+                val ktFile = PsiManager.getInstance(project).findFile(virtualFile) as? KtFile ?: continue
+                if (!ArmeriaKotlinRouteCollector.referencesArmeriaKotlinContent(ktFile)) {
+                    continue
+                }
+                ArmeriaKotlinExtendedRegistrationCollector.collectFromFile(ktFile, routes, seenRegistrations)
+            }
         }
     }
 
@@ -207,7 +222,7 @@ object ArmeriaRouteCollector {
     ) {
         val psiFacade = JavaPsiFacade.getInstance(project)
         val builderClass = psiFacade.findClass(ArmeriaRouteSupport.SERVER_BUILDER_CLASS, scope) ?: return
-        for (methodName in ServiceRegistrationMethod.CORE_METHOD_NAMES) {
+        for (methodName in CoreServiceRegistrationMethod.METHOD_NAMES) {
             for (method in builderClass.findMethodsByName(methodName, false)) {
                 ReferencesSearch.search(method, scope).forEach { reference ->
                     val call = PsiTreeUtil.getParentOfType(reference.element, PsiMethodCallExpression::class.java)
@@ -263,6 +278,11 @@ object ArmeriaRouteCollector {
         file.accept(object : JavaRecursiveElementWalkingVisitor() {
             override fun visitMethodCallExpression(expression: PsiMethodCallExpression) {
                 collectServiceRegistrationFromMethodCall(expression, routes, seenServiceRegistrations)
+                ArmeriaExtendedRegistrationCollector.visitMethodCallExpression(
+                    expression,
+                    routes,
+                    seenServiceRegistrations,
+                )
                 super.visitMethodCallExpression(expression)
             }
         })
@@ -275,10 +295,10 @@ object ArmeriaRouteCollector {
     ) {
         ArmeriaRouteCollectionMetrics.current()?.methodCallsVisited?.incrementAndGet()
         val methodName = expression.methodExpression.referenceName
-        if (methodName !in ServiceRegistrationMethod.METHOD_NAMES - ServiceRegistrationMethod.EXTENDED_METHOD_NAMES) {
+        if (methodName !in CoreServiceRegistrationMethod.METHOD_NAMES) {
             return
         }
-        if (!looksLikeArmeriaBuilderCall(expression)) {
+        if (!ArmeriaBuilderCallHeuristics.looksLikeJavaBuilderCall(expression)) {
             return
         }
         addServiceRegistrationFromCall(expression, routes, seenServiceRegistrations)
@@ -293,18 +313,10 @@ object ArmeriaRouteCollector {
         val methodName = expression.methodExpression.referenceName ?: return false
         val arguments = expression.argumentList.expressions
         val path = extractRegistrationPath(methodName, arguments) ?: return false
-        val implementationExpression = when (ServiceRegistrationMethod.fromMethodName(methodName)) {
-            ServiceRegistrationMethod.ANNOTATED_SERVICE -> arguments.getOrNull(1) ?: arguments.getOrNull(0)
-            ServiceRegistrationMethod.SERVICE, ServiceRegistrationMethod.SERVICE_UNDER -> arguments.getOrNull(1)
-            ServiceRegistrationMethod.FILE_SERVICE,
-            ServiceRegistrationMethod.HEALTH_CHECK_SERVICE,
-            ServiceRegistrationMethod.VIRTUAL_HOST,
-            ServiceRegistrationMethod.ROUTE_DECORATOR,
-            ServiceRegistrationMethod.ROUTE,
-            ServiceRegistrationMethod.WITH_ROUTE,
-            ServiceRegistrationMethod.DECORATOR_UNDER,
-            null,
-            -> null
+        val implementationExpression = when (CoreServiceRegistrationMethod.fromMethodName(methodName)) {
+            CoreServiceRegistrationMethod.ANNOTATED_SERVICE -> arguments.getOrNull(1) ?: arguments.getOrNull(0)
+            CoreServiceRegistrationMethod.SERVICE, CoreServiceRegistrationMethod.SERVICE_UNDER -> arguments.getOrNull(1)
+            null -> null
         } ?: return false
         val target = ArmeriaRouteTargetExtractor.extractTarget(implementationExpression)
         return addServiceRegistrationRoute(
@@ -337,11 +349,11 @@ object ArmeriaRouteCollector {
         if (!seenServiceRegistrations.add(registrationKey)) {
             return false
         }
-        val registrationMethod = ServiceRegistrationMethod.fromMethodName(methodName) ?: return false
+        val registrationMethod = CoreServiceRegistrationMethod.fromMethodName(methodName) ?: return false
         val protocol = ArmeriaRouteTargetExtractor.detectProtocol(implementationText)
         val routeMatch = resolveRouteMatch(registrationMethod, protocol)
         val annotatedServiceHasPathPrefix =
-            registrationMethod == ServiceRegistrationMethod.ANNOTATED_SERVICE && argumentCount > 1
+            registrationMethod == CoreServiceRegistrationMethod.ANNOTATED_SERVICE && argumentCount > 1
         val normalizedPath = ArmeriaRouteSupport.normalizePath(path)
         val programmaticDecorators = decorators ?: collectProgrammaticDecorators(element, normalizedPath)
         val timeoutHints = collectBuilderTimeoutHints(element)
@@ -361,22 +373,14 @@ object ArmeriaRouteCollector {
         return true
     }
 
-    private fun resolveRouteMatch(registrationMethod: ServiceRegistrationMethod, protocol: RouteProtocol): RouteMatch {
+    private fun resolveRouteMatch(registrationMethod: CoreServiceRegistrationMethod, protocol: RouteProtocol): RouteMatch {
         if (protocol != RouteProtocol.HTTP) {
             return RouteMatch.NON_HTTP
         }
         return when (registrationMethod) {
-            ServiceRegistrationMethod.SERVICE -> RouteMatch.SERVICE
-            ServiceRegistrationMethod.ANNOTATED_SERVICE -> RouteMatch.ANNOTATED_SERVICE
-            ServiceRegistrationMethod.SERVICE_UNDER -> RouteMatch.SERVICE_UNDER
-            ServiceRegistrationMethod.FILE_SERVICE,
-            ServiceRegistrationMethod.HEALTH_CHECK_SERVICE,
-            ServiceRegistrationMethod.VIRTUAL_HOST,
-            ServiceRegistrationMethod.ROUTE_DECORATOR,
-            ServiceRegistrationMethod.ROUTE,
-            ServiceRegistrationMethod.WITH_ROUTE,
-            ServiceRegistrationMethod.DECORATOR_UNDER,
-            -> error("Extended registration handled separately: $registrationMethod")
+            CoreServiceRegistrationMethod.SERVICE -> RouteMatch.SERVICE
+            CoreServiceRegistrationMethod.ANNOTATED_SERVICE -> RouteMatch.ANNOTATED_SERVICE
+            CoreServiceRegistrationMethod.SERVICE_UNDER -> RouteMatch.SERVICE_UNDER
         }
     }
 
@@ -390,40 +394,18 @@ object ArmeriaRouteCollector {
         )
     }
 
-    private fun looksLikeArmeriaBuilderCall(expression: PsiMethodCallExpression): Boolean {
-        if (resolvesToArmeriaServerBuilder(expression)) {
-            return true
-        }
-        val qualifierText = expression.methodExpression.qualifierExpression?.text ?: return false
-        return ArmeriaRouteSupport.looksLikeServerBuilderReceiverText(qualifierText)
-    }
-
-    private fun resolvesToArmeriaServerBuilder(expression: PsiMethodCallExpression): Boolean {
-        ArmeriaRouteCollectionMetrics.current()?.resolveCount?.incrementAndGet()
-        val resolvedClass = expression.resolveMethod()?.containingClass?.qualifiedName
-        return resolvedClass?.startsWith(ArmeriaRouteSupport.ARMERIA_SERVER_PACKAGE_PREFIX) == true
-    }
-
     private fun buildMethodTarget(psiClass: PsiClass, method: PsiMethod): String {
         val className = psiClass.qualifiedName ?: psiClass.name ?: "<anonymous>"
         return "$className#${method.name}()"
     }
 
     private fun extractRegistrationPath(methodName: String, arguments: Array<PsiExpression>): String? {
-        return when (ServiceRegistrationMethod.fromMethodName(methodName)) {
-            ServiceRegistrationMethod.SERVICE, ServiceRegistrationMethod.SERVICE_UNDER ->
+        return when (CoreServiceRegistrationMethod.fromMethodName(methodName)) {
+            CoreServiceRegistrationMethod.SERVICE, CoreServiceRegistrationMethod.SERVICE_UNDER ->
                 extractString(arguments.getOrNull(0))
-            ServiceRegistrationMethod.ANNOTATED_SERVICE ->
+            CoreServiceRegistrationMethod.ANNOTATED_SERVICE ->
                 if (arguments.size > 1) extractString(arguments.getOrNull(0)) else "/"
-            ServiceRegistrationMethod.FILE_SERVICE,
-            ServiceRegistrationMethod.HEALTH_CHECK_SERVICE,
-            ServiceRegistrationMethod.VIRTUAL_HOST,
-            ServiceRegistrationMethod.ROUTE_DECORATOR,
-            ServiceRegistrationMethod.ROUTE,
-            ServiceRegistrationMethod.WITH_ROUTE,
-            ServiceRegistrationMethod.DECORATOR_UNDER,
-            null,
-            -> null
+            null -> null
         }
     }
 

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupport.kt
@@ -36,7 +36,7 @@ internal enum class ServiceRegistrationMethod(val methodName: String) {
             WITH_ROUTE.methodName,
             DECORATOR_UNDER.methodName,
         )
-        val CORE_METHOD_NAMES: Set<String> = METHOD_NAMES - EXTENDED_METHOD_NAMES
+        val CORE_METHOD_NAMES: Set<String> = CoreServiceRegistrationMethod.METHOD_NAMES
         val FLUENT_ROUTE_HTTP_METHODS: Set<String> = setOf(
             "get", "head", "post", "put", "delete", "options", "patch", "trace",
         )

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteVirtualHostAnnotator.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteVirtualHostAnnotator.kt
@@ -1,0 +1,38 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+internal object ArmeriaRouteVirtualHostAnnotator {
+
+    fun annotateRoutesAddedSince(
+        routes: MutableList<ArmeriaRoute>,
+        sizeBefore: Int,
+        hostname: String,
+    ) {
+        for (index in sizeBefore until routes.size) {
+            annotateRouteAt(routes, index, hostname)
+        }
+    }
+
+    fun annotateByKey(
+        routes: MutableList<ArmeriaRoute>,
+        registrationKey: String,
+        hostname: String,
+        routeKey: (ArmeriaRoute) -> String?,
+    ) {
+        val index = routes.indexOfLast { routeKey(it) == registrationKey }
+        annotateRouteAt(routes, index, hostname)
+    }
+
+    fun annotateRouteAt(
+        routes: MutableList<ArmeriaRoute>,
+        index: Int,
+        hostname: String,
+    ) {
+        if (index !in routes.indices) {
+            return
+        }
+        val route = routes[index]
+        if (route.virtualHostName.isEmpty() && route.routeMatch != RouteMatch.VIRTUAL_HOST) {
+            routes[index] = route.copy(virtualHostName = hostname)
+        }
+    }
+}

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/CoreServiceRegistrationMethod.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/CoreServiceRegistrationMethod.kt
@@ -1,0 +1,15 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+internal enum class CoreServiceRegistrationMethod(val methodName: String) {
+    SERVICE("service"),
+    SERVICE_UNDER("serviceUnder"),
+    ANNOTATED_SERVICE("annotatedService"),
+    ;
+
+    companion object {
+        val METHOD_NAMES: Set<String> = entries.mapTo(linkedSetOf()) { it.methodName }
+
+        fun fromMethodName(name: String): CoreServiceRegistrationMethod? =
+            entries.firstOrNull { it.methodName == name }
+    }
+}

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollectorTest.kt
@@ -184,7 +184,7 @@ class ArmeriaExtendedRegistrationCollectorTest : LightJavaCodeInsightFixtureTest
         assertEquals("api.example.com", virtualHostRoute.virtualHostName)
     }
 
-    fun testCollectChainedVirtualHostAnnotatesServiceRoute() {
+    fun testCollectChainedVirtualHostDoesNotAnnotatePrecedingServiceRoute() {
         myFixture.configureByText(
             "Main.java",
             """
@@ -208,7 +208,92 @@ class ArmeriaExtendedRegistrationCollectorTest : LightJavaCodeInsightFixtureTest
         val serviceRoute = routes.firstOrNull { it.routeMatch == RouteMatch.SERVICE }
         assertNotNull(serviceRoute)
         assertEquals("/api", serviceRoute!!.path)
+        assertEquals("", serviceRoute.virtualHostName)
+    }
+
+    fun testCollectVirtualHostThenServiceAnnotatesServiceRoute() {
+        myFixture.configureByText(
+            "Main.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.Server;
+
+            public class Main {
+                public static void main(String[] args) {
+                    Server.builder()
+                        .virtualHost("api.example.com")
+                        .service("/api", new ApiService())
+                        .build();
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass("package example; public class ApiService {}")
+
+        val routes = ArmeriaRouteCollector.collect(project)
+        val serviceRoute = routes.firstOrNull { it.routeMatch == RouteMatch.SERVICE }
+        assertNotNull(serviceRoute)
+        assertEquals("/api", serviceRoute!!.path)
         assertEquals("api.example.com", serviceRoute.virtualHostName)
+    }
+
+    fun testCollectVirtualHostChainAnnotatesOnlyPostVirtualHostService() {
+        myFixture.configureByText(
+            "Main.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.Server;
+
+            public class Main {
+                public static void main(String[] args) {
+                    Server.builder()
+                        .service("/default", new ApiService())
+                        .virtualHost("api.example.com")
+                        .service("/hosted", new ApiService())
+                        .build();
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass("package example; public class ApiService {}")
+
+        val routes = ArmeriaRouteCollector.collect(project)
+        val defaultRoute = routes.firstOrNull { it.path == "/default" }
+        val hostedRoute = routes.firstOrNull { it.path == "/hosted" }
+        assertNotNull(defaultRoute)
+        assertNotNull(hostedRoute)
+        assertEquals("", defaultRoute!!.virtualHostName)
+        assertEquals("api.example.com", hostedRoute!!.virtualHostName)
+    }
+
+    fun testCollectNestedVirtualHostLambdaUsesInnerHostname() {
+        myFixture.configureByText(
+            "Main.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.Server;
+
+            public class Main {
+                public static void main(String[] args) {
+                    Server.builder()
+                        .virtualHost("outer.example.com", outer -> outer
+                            .virtualHost("inner.example.com", inner -> inner
+                                .service("/api", new ApiService())))
+                        .build();
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass("package example; public class ApiService {}")
+
+        val routes = ArmeriaRouteCollector.collect(project)
+        val serviceRoute = routes.firstOrNull { it.routeMatch == RouteMatch.SERVICE }
+        assertNotNull(serviceRoute)
+        assertEquals("/api", serviceRoute!!.path)
+        assertEquals("inner.example.com", serviceRoute.virtualHostName)
     }
 
     fun testCollectRouteDecoratorDefaultPathTypeIsGlob() {

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinExtendedRegistrationCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinExtendedRegistrationCollectorTest.kt
@@ -56,7 +56,7 @@ class ArmeriaKotlinExtendedRegistrationCollectorTest : ArmeriaFixtureTestBase() 
         assertEquals("/api/items", fluentRoute.path)
     }
 
-    fun testCollectKotlinChainedVirtualHostAnnotatesServiceRoute() {
+    fun testCollectKotlinChainedVirtualHostDoesNotAnnotatePrecedingServiceRoute() {
         myFixture.configureByText(
             "Main.kt",
             """
@@ -78,7 +78,60 @@ class ArmeriaKotlinExtendedRegistrationCollectorTest : ArmeriaFixtureTestBase() 
         val serviceRoute = routes.firstOrNull { it.routeMatch == RouteMatch.SERVICE }
         assertNotNull(serviceRoute)
         assertEquals("/api", serviceRoute!!.path)
+        assertEquals("", serviceRoute.virtualHostName)
+    }
+
+    fun testCollectKotlinVirtualHostThenServiceAnnotatesServiceRoute() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder()
+                    .virtualHost("api.example.com")
+                    .service("/api", ApiService())
+                    .build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass("package example; public class ApiService {}")
+
+        val routes = ArmeriaRouteCollector.collect(project)
+        val serviceRoute = routes.firstOrNull { it.routeMatch == RouteMatch.SERVICE }
+        assertNotNull(serviceRoute)
+        assertEquals("/api", serviceRoute!!.path)
         assertEquals("api.example.com", serviceRoute.virtualHostName)
+    }
+
+    fun testCollectKotlinNestedVirtualHostLambdaUsesInnerHostname() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            fun main() {
+                Server.builder()
+                    .virtualHost("outer.example.com") { outer ->
+                        outer.virtualHost("inner.example.com") { inner ->
+                            inner.service("/api", ApiService())
+                        }
+                    }
+                    .build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass("package example; public class ApiService {}")
+
+        val routes = ArmeriaRouteCollector.collect(project)
+        val serviceRoute = routes.firstOrNull { it.routeMatch == RouteMatch.SERVICE }
+        assertNotNull(serviceRoute)
+        assertEquals("/api", serviceRoute!!.path)
+        assertEquals("inner.example.com", serviceRoute.virtualHostName)
     }
 
     fun testCollectKotlinDecoratorUnderRegistration() {

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndexTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndexTest.kt
@@ -475,8 +475,8 @@ class ArmeriaRouteDuplicateIndexTest : ArmeriaFixtureTestBase() {
             public class FirstMain {
                 public static void main(String[] args) {
                     Server.builder()
-                        .service("/api", new FirstService())
                         .virtualHost("a.example.com")
+                        .service("/api", new FirstService())
                         .build();
                 }
             }
@@ -491,8 +491,8 @@ class ArmeriaRouteDuplicateIndexTest : ArmeriaFixtureTestBase() {
             public class SecondMain {
                 public static void main(String[] args) {
                     Server.builder()
-                        .service("/api", new SecondService())
                         .virtualHost("b.example.com")
+                        .service("/api", new SecondService())
                         .build();
                 }
             }
@@ -501,6 +501,13 @@ class ArmeriaRouteDuplicateIndexTest : ArmeriaFixtureTestBase() {
         myFixture.addClass("package example; public class FirstService {}")
         myFixture.addClass("package example; public class SecondService {}")
 
+        val routes = ArmeriaRouteCollector.collect(project)
+        val serviceRoutes = routes.filter { it.routeMatch == RouteMatch.SERVICE && it.path == "/api" }
+        assertEquals(2, serviceRoutes.size)
+        assertEquals(
+            setOf("a.example.com", "b.example.com"),
+            serviceRoutes.map { it.virtualHostName }.toSet(),
+        )
         assertTrue(ArmeriaRouteDuplicateIndex.duplicateGroups(project).isEmpty())
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses Thermo-nuclear review findings for extended route registration detection (GH-202). Shared fluent-chain and virtualHost logic is extracted into reusable helpers, and virtualHost annotation now follows Armeria semantics: only routes registered after or inside a `virtualHost` call receive the hostname.

## Changes

- Add `ArmeriaRegistrationChainReducer`, `ArmeriaBuilderCallHeuristics`, `ArmeriaRouteVirtualHostAnnotator`, and `CoreServiceRegistrationMethod` to deduplicate Java/Kotlin collectors
- Rewrite virtualHost scoping to walk forward chained calls instead of scanning the whole statement; remove incorrect backward annotation
- Annotate routes by registration key and always run lambda/forward scoped collection even when the virtualHost key was already seen
- Collect expression-bodied lambda registrations by including the lambda body root in virtualHost scope scans
- Fix Kotlin virtualHost scoped service collection to register the target call directly instead of re-scanning descendants with builder heuristics
- Add regression tests for chained virtualHost, nested virtualHost lambdas, lambda fileService, and duplicate-index virtualHost separation

## Depends on

- #202 (`cursor/route-detection-expansion-c8ba`)

## Test plan

- [x] `./gradlew :plugin-route-analysis:check`
- [x] Verified virtualHost forward-chain, nested lambda, and duplicate-index scenarios
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f359d-6923-7643-a0f8-e9441b686d69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f359d-6923-7643-a0f8-e9441b686d69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

