### PR TITLE
test(route-analysis): add Kotlin routeDecorator chain regression tests

### DIFF
--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinExtendedRegistrationCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinExtendedRegistrationCollectorTest.kt
@@ -253,6 +253,31 @@ class ArmeriaKotlinExtendedRegistrationCollectorTest : ArmeriaFixtureTestBase() 
         assertEquals("api.example.com", virtualHostRoute!!.virtualHostName)
     }
 
+    fun testCollectKotlinRouteDecoratorDefaultPathTypeIsGlob() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+            import com.linecorp.armeria.server.logging.LoggingService
+
+            fun main() {
+                Server.builder()
+                    .routeDecorator()
+                    .build(LoggingService.newDecorator())
+                    .build()
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+        val decoratorRoute = routes.firstOrNull { it.routeMatch == RouteMatch.ROUTE_DECORATOR }
+        assertNotNull(decoratorRoute)
+        assertEquals(PathType.GLOB, decoratorRoute!!.pathType)
+        assertEquals("/**", decoratorRoute.path)
+    }
+
     fun testCollectKotlinRouteDecoratorRegistration() {
         myFixture.configureByText(
             "Main.kt",

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinExtendedRegistrationCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinExtendedRegistrationCollectorTest.kt
@@ -275,7 +275,34 @@ class ArmeriaKotlinExtendedRegistrationCollectorTest : ArmeriaFixtureTestBase() 
         val routes = ArmeriaRouteCollector.collect(project)
         val decoratorRoute = routes.firstOrNull { it.routeMatch == RouteMatch.ROUTE_DECORATOR }
         assertNotNull(decoratorRoute)
-        assertEquals("/decorated/**", decoratorRoute!!.path)
+        assertEquals(PathType.EXACT, decoratorRoute!!.pathType)
+        assertEquals("/decorated/**", decoratorRoute.path)
+    }
+
+    fun testCollectKotlinRouteDecoratorMethodsStripHttpMethodPrefix() {
+        myFixture.configureByText(
+            "Main.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.common.HttpMethod
+            import com.linecorp.armeria.server.Server
+            import com.linecorp.armeria.server.logging.LoggingService
+
+            fun main() {
+                Server.builder()
+                    .routeDecorator()
+                    .methods(HttpMethod.POST, HttpMethod.PUT)
+                    .build(LoggingService.newDecorator())
+                    .build()
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+        val decoratorRoute = routes.firstOrNull { it.routeMatch == RouteMatch.ROUTE_DECORATOR }
+        assertNotNull(decoratorRoute)
+        assertEquals("POST, PUT", decoratorRoute!!.httpMethod)
     }
 
     fun testCollectKotlinRouteDecoratorIgnoresPathCallsInsideDecoratorLambda() {
@@ -501,6 +528,10 @@ class ArmeriaKotlinExtendedRegistrationCollectorTest : ArmeriaFixtureTestBase() 
                     return this;
                 }
 
+                public ServerBuilder methods(Object... methods) {
+                    return this;
+                }
+
                 public ServerBuilder withRoute(java.util.function.Function<RouteBuilder, RouteBuilder> fn) {
                     return this;
                 }
@@ -577,6 +608,16 @@ class ArmeriaKotlinExtendedRegistrationCollectorTest : ArmeriaFixtureTestBase() 
                 public Object build() {
                     return null;
                 }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.common;
+
+            public final class HttpMethod {
+                public static final HttpMethod POST = null;
+                public static final HttpMethod PUT = null;
             }
             """.trimIndent(),
         )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Kotlin regression tests for `routeDecorator()` fluent-chain parsing in Route Explorer. The dot-qualified chain walk and reducer logic shipped in #202; this PR locks that behavior in with Kotlin/Java test parity so a future refactor cannot silently fall back to default path (`/**`) or empty HTTP methods.

## Changes

- Add `testCollectKotlinRouteDecoratorDefaultPathTypeIsGlob` (parity with Java default-glob case)
- Strengthen `testCollectKotlinRouteDecoratorRegistration` to assert `PathType.EXACT` and path `/decorated/**`
- Add `testCollectKotlinRouteDecoratorMethodsStripHttpMethodPrefix` for `HttpMethod.POST` / `HttpMethod.PUT` prefix stripping
- Extend Kotlin test stubs with `ServerBuilder.methods(Object...)` and `HttpMethod` constants

## Depends on

- #202 (Kotlin extended registration collector and chain traversal)

## Test plan

- [x] `:plugin-route-analysis:test` — `testCollectKotlinRouteDecoratorDefaultPathTypeIsGlob`, `testCollectKotlinRouteDecoratorRegistration`, `testCollectKotlinRouteDecoratorMethodsStripHttpMethodPrefix`
- [x] `:plugin-route-analysis:check`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f35e1-c369-7a64-ad99-efd7926a845c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f35e1-c369-7a64-ad99-efd7926a845c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

