### PR TITLE
fix(ci): make copilot-setup-steps succeed without full assemble

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -7,11 +7,17 @@ on:
     paths:
       - .github/workflows/copilot-setup-steps.yml
       - .github/scripts/install-kotlin-lsp.sh
+      - .github/scripts/install-gradle-tapi-mcp.sh
+      - .github/scripts/gradle-mcp-server.sh
+      - .github/mcp.json
       - .github/lsp.json
   pull_request:
     paths:
       - .github/workflows/copilot-setup-steps.yml
       - .github/scripts/install-kotlin-lsp.sh
+      - .github/scripts/install-gradle-tapi-mcp.sh
+      - .github/scripts/gradle-mcp-server.sh
+      - .github/mcp.json
       - .github/lsp.json
 
 
@@ -38,4 +44,13 @@ jobs:
       - name: Install JetBrains Kotlin language server
         run: bash .github/scripts/install-kotlin-lsp.sh
 
-      - run: ./gradlew assemble
+      - name: Verify Gradle Tooling API MCP server
+        run: test -f "${HOME}/.local/share/gradle-tapi-mcp-server/gradle-tapi-mcp-server.jar"
+
+      - name: Verify Kotlin language server
+        run: test -x "${HOME}/.local/bin/kotlin-lsp"
+
+      # Warm the Gradle daemon without requiring the checked-out branch to compile.
+      # Feature branches may be mid-change; assemble failures should not block Copilot setup.
+      - name: Warm Gradle daemon
+        run: ./gradlew --version


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`copilot-setup-steps` was failing on feature branches because the final `./gradlew assemble` step requires the checked-out code to compile. WIP branches with Kotlin errors blocked Copilot agent environment setup even though the install steps (Gradle TAPI MCP server, kotlin-lsp) succeeded.

## Changes

- Replace `./gradlew assemble` with explicit verification of installed MCP and kotlin-lsp artifacts
- Warm the Gradle daemon with `./gradlew --version` instead of a full compile
- Extend workflow path filters to include Gradle MCP install scripts and `.github/mcp.json`

## Test plan

- [x] `bash .github/scripts/install-gradle-tapi-mcp.sh` succeeds locally
- [x] `bash .github/scripts/install-kotlin-lsp.sh` succeeds locally
- [x] `./gradlew --version` succeeds locally
- [ ] `copilot-setup-steps` workflow passes on this PR after merge

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3d43-f1cb-7ce5-b341-49f545977c6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3d43-f1cb-7ce5-b341-49f545977c6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

