### PR TITLE
fix: keep DocService runtime routes across Route Explorer refresh

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 
 - Armeria run configuration discovery now resolves Kotlin top-level `fun main()` via the file facade (`MainKt`), matching New Project Wizard Kotlin templates.
+- Route Explorer Refresh no longer clears DocService-synced runtime routes; synced routes stay until the next sync replaces them.
 
 ### Security
 

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerPanel.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerPanel.kt
@@ -38,7 +38,6 @@ class ArmeriaRouteExplorerPanel(
     private var staticRoutes: List<ArmeriaRoute> = emptyList()
     private var runtimeRoutes: List<ArmeriaRoute> = emptyList()
     private var refreshGeneration = 0
-    private var runtimeApplyGeneration = 0
     private var selectedRoute: ArmeriaRoute? = null
     private var currentModuleOnly = false
     private var initialRefreshScheduled = false
@@ -165,9 +164,7 @@ class ArmeriaRouteExplorerPanel(
                     return@finishOnUiThread
                 }
                 staticRoutes = collectedRoutes
-                if (runtimeApplyGeneration < generation) {
-                    runtimeRoutes = emptyList()
-                }
+                // Keep DocService-synced runtime routes across static refreshes until the next sync.
                 rebuildTree()
                 updateStatusLabel()
                 updateDetailFootnote()
@@ -177,7 +174,6 @@ class ArmeriaRouteExplorerPanel(
     fun staticRoutes(): List<ArmeriaRoute> = staticRoutes
 
     fun applyRuntimeRoutes(routes: List<ArmeriaRoute>) {
-        runtimeApplyGeneration = refreshGeneration
         runtimeRoutes = routes
         rebuildTree()
         updateStatusLabel()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After syncing routes from DocService, clicking Refresh in Route Explorer dropped those runtime routes. Users had to sync again to restore them during normal exploration.

## Changes

- Keep DocService-synced runtime routes when refreshing static analysis results
- Remove the refresh-generation gate that cleared `runtimeRoutes` on every static refresh
- Runtime routes are still replaced when the user syncs again

## Test plan

- [ ] Open Route Explorer, sync from DocService, then click Refresh and confirm runtime routes remain
- [ ] Sync again with different results and confirm runtime routes are replaced
- [ ] Confirm static route refresh still updates the tree
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f43ca-6943-78eb-9e5f-8bd2be6c3b3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f43ca-6943-78eb-9e5f-8bd2be6c3b3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

