### PR TITLE
fix: dedupe GraphQL and Thrift routes in Route Explorer

### DIFF
--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGraphqlRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGraphqlRouteCollector.kt
@@ -18,16 +18,24 @@ internal object ArmeriaGraphqlRouteCollector {
         if (!ArmeriaIdlRouteSupport.isGraphqlOnClasspath(project, scope)) {
             return
         }
+        val seenGraphqlRoutes = mutableSetOf<String>()
         for (extension in GRAPHQL_EXTENSIONS) {
             for (virtualFile in FilenameIndex.getAllFilesByExt(project, extension, scope)) {
                 val psiFile = PsiManager.getInstance(project).findFile(virtualFile) ?: continue
                 for (operation in parseOperations(psiFile.text)) {
+                    val target = "${operation.operationType}.${operation.fieldName}"
+                    val dedupeKey =
+                        "${ArmeriaRouteMetadata.moduleName(psiFile)}:" +
+                            "${ArmeriaIdlRouteSupport.DEFAULT_GRAPHQL_MOUNT_PATH}:$target"
+                    if (!seenGraphqlRoutes.add(dedupeKey)) {
+                        continue
+                    }
                     routes += ArmeriaRoute.create(
                         element = psiFile,
                         protocol = RouteProtocol.GRAPHQL.presentableName(),
                         httpMethod = "",
                         path = ArmeriaIdlRouteSupport.DEFAULT_GRAPHQL_MOUNT_PATH,
-                        target = "${operation.operationType}.${operation.fieldName}",
+                        target = target,
                         routeMatch = RouteMatch.NON_HTTP,
                     )
                 }

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaThriftRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaThriftRouteCollector.kt
@@ -19,15 +19,22 @@ internal object ArmeriaThriftRouteCollector {
         if (!ArmeriaIdlRouteSupport.isThriftOnClasspath(project, scope)) {
             return
         }
+        val seenThriftRoutes = mutableSetOf<String>()
         for (virtualFile in FilenameIndex.getAllFilesByExt(project, "thrift", scope)) {
             val psiFile = PsiManager.getInstance(project).findFile(virtualFile) ?: continue
             for (operation in parseOperations(psiFile.text)) {
+                val path = "/${operation.serviceName}"
+                val target = "${operation.serviceName}.${operation.methodName}"
+                val dedupeKey = "${ArmeriaRouteMetadata.moduleName(psiFile)}:$path:$target"
+                if (!seenThriftRoutes.add(dedupeKey)) {
+                    continue
+                }
                 routes += ArmeriaRoute.create(
                     element = psiFile,
                     protocol = RouteProtocol.THRIFT.presentableName(),
                     httpMethod = "",
-                    path = "/${operation.serviceName}",
-                    target = "${operation.serviceName}.${operation.methodName}",
+                    path = path,
+                    target = target,
                     routeMatch = RouteMatch.NON_HTTP,
                 )
             }

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaIdlRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaIdlRouteCollectorTest.kt
@@ -172,6 +172,33 @@ class ArmeriaIdlRouteCollectorTest : ArmeriaFixtureTestBase() {
         assertEquals("Query.health", routes.single().target)
     }
 
+    fun testDuplicateGraphqlRoutesAreDeduplicated() {
+        registerArmeriaIdlStubs()
+        myFixture.configureByText(
+            "schema.graphql",
+            """
+            type Query {
+                user: User
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "schema.graphqls",
+            """
+            type Query {
+                user: User
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+            .filter { it.protocol == RouteProtocol.GRAPHQL.presentableName() }
+
+        assertEquals(1, routes.size)
+        assertEquals("Query.user", routes.single().target)
+        assertEquals(ArmeriaIdlRouteSupport.DEFAULT_GRAPHQL_MOUNT_PATH, routes.single().path)
+    }
+
     fun testCollectThriftRoutesWhenThriftOnClasspath() {
         registerArmeriaIdlStubs()
         myFixture.configureByText(
@@ -192,6 +219,33 @@ class ArmeriaIdlRouteCollectorTest : ArmeriaFixtureTestBase() {
         assertEquals("HelloService.sayHello", route.target)
         assertEquals(RouteMatch.NON_HTTP, route.routeMatch)
         assertTrue(route.httpMethod.isBlank())
+    }
+
+    fun testDuplicateThriftRoutesAreDeduplicated() {
+        registerArmeriaIdlStubs()
+        myFixture.configureByText(
+            "hello.thrift",
+            """
+            service HelloService {
+                string sayHello(1: string name),
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "hello-copy.thrift",
+            """
+            service HelloService {
+                string sayHello(1: string name),
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+            .filter { it.protocol == RouteProtocol.THRIFT.presentableName() }
+
+        assertEquals(1, routes.size)
+        assertEquals("/HelloService", routes.single().path)
+        assertEquals("HelloService.sayHello", routes.single().target)
     }
 
     fun testSkipIdlRoutesWhenProtocolNotOnClasspath() {

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 
 - Armeria run configuration discovery now resolves Kotlin top-level `fun main()` via the file facade (`MainKt`), matching New Project Wizard Kotlin templates.
+- Deduplicated GraphQL and Thrift IDL routes in Route Explorer when the same operation appears in multiple schema files.
 
 ### Security
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

GraphQL and Thrift route collectors appended one route per schema/IDL occurrence with no dedupe. The same operation appearing in multiple modules or files produced duplicate Route Explorer entries, unlike the gRPC collector which already dedupes.

## Changes

- Deduplicate GraphQL routes with a `module:/graphql:target` key
- Deduplicate Thrift routes with a `module:path:target` key
- Regression tests for duplicate GraphQL and Thrift schema/IDL inputs

## Test plan

- [ ] `:plugin-route-analysis:test --tests ArmeriaIdlRouteCollectorTest`
- [ ] Open a project with the same GraphQL schema in two modules and confirm Route Explorer shows each operation once per module key behavior as expected
- [ ] Confirm gRPC proto dedupe behavior is unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f43ca-6943-78eb-9e5f-8bd2be6c3b3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f43ca-6943-78eb-9e5f-8bd2be6c3b3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

