### PR TITLE
docs: align multi-module layout and fastTest task paths

### DIFF
--- a/.cursor/skills/gradle-tapi-mcp/SKILL.md
+++ b/.cursor/skills/gradle-tapi-mcp/SKILL.md
@@ -208,9 +208,9 @@ If every MCP call times out but `./gradlew` still works:
 | Route-analysis fixture tests | `gradle_run_tasks` `{ "tasks": [":plugin-route-analysis:test"], "background": true }` | `./gradlew :plugin-route-analysis:test` |
 | Fast unit tests | `gradle_run_tasks` `{ "tasks": [":plugin-route-analysis:fastTest"], "background": true }` | `./gradlew :plugin-route-analysis:fastTest` |
 | Route-analysis checks (fixture + fast) | `gradle_run_tasks` `{ "tasks": [":plugin-route-analysis:check"], "background": true }` | `./gradlew :plugin-route-analysis:check` |
-| Single test class | `gradle_run_tests` `{ "testClasses": ["FQCN"], "background": true }` | `./gradlew :plugin:test --tests 'FQCN'` |
-| Multiple test classes/methods | `gradle_run_tests` `{ "testMethods": { ... }, "background": true }` | `./gradlew :plugin:test --tests 'FQCN'` per class |
-| Single test method | `gradle_run_tests` `{ "testMethods": { "FQCN": ["method"] }, "background": true }` | `./gradlew :plugin:test --tests 'FQCN.method'` |
+| Single test class | `gradle_run_tests` `{ "taskPath": ":plugin-route-analysis:test", "testClasses": ["FQCN"], "background": true }` | `./gradlew :plugin-route-analysis:test --tests 'FQCN'` |
+| Multiple test classes/methods | `gradle_run_tests` `{ "taskPath": ":plugin-route-analysis:test", "testMethods": { ... }, "background": true }` | `./gradlew :plugin-route-analysis:test --tests 'FQCN'` per class |
+| Single test method | `gradle_run_tests` `{ "taskPath": ":plugin-route-analysis:test", "testMethods": { "FQCN": ["method"] }, "background": true }` | `./gradlew :plugin-route-analysis:test --tests 'FQCN.method'` |
 | Fast compile gate | `gradle_run_tasks` `{ "tasks": [":plugin:compileKotlin"] }` | `./gradlew :plugin:compileKotlin` |
 
 Prefer MCP for all verification. Use shell only when MCP is unresponsive or for final CI parity before merge.

--- a/.cursor/skills/gradle-tapi-mcp/SKILL.md
+++ b/.cursor/skills/gradle-tapi-mcp/SKILL.md
@@ -204,12 +204,13 @@ If every MCP call times out but `./gradlew` still works:
 | Goal | MCP tool (preferred) | Shell fallback |
 |------|---------------------|----------------|
 | Full verify | `gradle_run_tasks` `{ "tasks": ["build"], "background": true }` | `./gradlew build` |
-| All plugin tests | `gradle_run_tasks` `{ "tasks": [":plugin:test"], "background": true }` | `./gradlew :plugin:test` |
-| Fast unit tests | `gradle_run_tasks` `{ "tasks": [":plugin:fastTest"], "background": true }` | `./gradlew :plugin:fastTest` |
-| All checks (fixture + fast) | `gradle_run_tasks` `{ "tasks": [":plugin:check"], "background": true }` | `./gradlew :plugin:check` |
-| Single test class | `gradle_run_tests` `{ "taskPath": ":plugin:test", "testClasses": ["FQCN"], "background": true }` | `./gradlew :plugin:test --tests 'FQCN'` |
-| Multiple test classes/methods | `gradle_run_tests` `{ "taskPath": ":plugin:test", "testMethods": { ... }, "background": true }` | `./gradlew :plugin:test --tests 'FQCN'` per class |
-| Single test method | `gradle_run_tests` `{ "taskPath": ":plugin:test", "testMethods": { "FQCN": ["method"] }, "background": true }` | `./gradlew :plugin:test --tests 'FQCN.method'` |
+| Plugin fixture tests | `gradle_run_tasks` `{ "tasks": [":plugin:test"], "background": true }` | `./gradlew :plugin:test` |
+| Route-analysis fixture tests | `gradle_run_tasks` `{ "tasks": [":plugin-route-analysis:test"], "background": true }` | `./gradlew :plugin-route-analysis:test` |
+| Fast unit tests | `gradle_run_tasks` `{ "tasks": [":plugin-route-analysis:fastTest"], "background": true }` | `./gradlew :plugin-route-analysis:fastTest` |
+| Route-analysis checks (fixture + fast) | `gradle_run_tasks` `{ "tasks": [":plugin-route-analysis:check"], "background": true }` | `./gradlew :plugin-route-analysis:check` |
+| Single test class | `gradle_run_tests` `{ "testClasses": ["FQCN"], "background": true }` | `./gradlew :plugin:test --tests 'FQCN'` |
+| Multiple test classes/methods | `gradle_run_tests` `{ "testMethods": { ... }, "background": true }` | `./gradlew :plugin:test --tests 'FQCN'` per class |
+| Single test method | `gradle_run_tests` `{ "testMethods": { "FQCN": ["method"] }, "background": true }` | `./gradlew :plugin:test --tests 'FQCN.method'` |
 | Fast compile gate | `gradle_run_tasks` `{ "tasks": [":plugin:compileKotlin"] }` | `./gradlew :plugin:compileKotlin` |
 
 Prefer MCP for all verification. Use shell only when MCP is unresponsive or for final CI parity before merge.

--- a/.github/skills/gradle-tapi-mcp/SKILL.md
+++ b/.github/skills/gradle-tapi-mcp/SKILL.md
@@ -39,7 +39,7 @@ Do **not** run MCP `gradle_run_tests` and shell `./gradlew :plugin:test` concurr
 | Goal | MCP |
 |------|-----|
 | Compile | `gradle_run_tasks` `{ "tasks": [":plugin:compileKotlin", ":plugin:compileTestKotlin"] }` |
-| One or more test classes/methods | `gradle_run_tests` `{ "testMethods": { "FQCN": ["method"] }, "background": true }` — batch in one call |
+| One or more test classes/methods | `gradle_run_tests` `{ "taskPath": ":plugin-route-analysis:test", "testMethods": { "FQCN": ["method"] }, "background": true }` — batch in one call |
 | Plugin fixture tests | `gradle_run_tasks` `{ "tasks": [":plugin:test"], "background": true }` |
 | Route-analysis fixture tests | `gradle_run_tasks` `{ "tasks": [":plugin-route-analysis:test"], "background": true }` |
 | Fast unit tests | `gradle_run_tasks` `{ "tasks": [":plugin-route-analysis:fastTest"], "background": true }` |

--- a/.github/skills/gradle-tapi-mcp/SKILL.md
+++ b/.github/skills/gradle-tapi-mcp/SKILL.md
@@ -23,10 +23,10 @@ The wrapper `.github/scripts/gradle-mcp-server.sh` sets `GRADLE_PROJECT_DIR` to 
 
 1. `gradle_connection_status` — confirm `connectedAny: true`; if not, `gradle_connect` with the repository root
 2. `gradle_get_build_environment` — resolved Gradle/Java versions
-3. `gradle_get_project_overview` — module hierarchy (`build-logic`, `plugin`)
+3. `gradle_get_project_overview` — module hierarchy (`plugin-shared`, `plugin-route-analysis`, `plugin-wizard`, `plugin`)
 4. `gradle_run_tasks` / `gradle_run_tests` for verification
 
-Use `background: true` and poll `gradle_get_build_status` for runs that may exceed ~30s (`build`, `:plugin:test`, cold start).
+Use `background: true` and poll `gradle_get_build_status` for runs that may exceed ~30s (`build`, `:plugin:test`, `:plugin-route-analysis:test`, cold start).
 
 ## Concurrency
 
@@ -39,9 +39,10 @@ Do **not** run MCP `gradle_run_tests` and shell `./gradlew :plugin:test` concurr
 | Goal | MCP |
 |------|-----|
 | Compile | `gradle_run_tasks` `{ "tasks": [":plugin:compileKotlin", ":plugin:compileTestKotlin"] }` |
-| One or more test classes/methods | `gradle_run_tests` `{ "taskPath": ":plugin:test", "testMethods": { "FQCN": ["method"] }, "background": true }` — batch in one call |
-| All fixture tests | `gradle_run_tasks` `{ "tasks": [":plugin:test"], "background": true }` |
-| Fast unit tests | `gradle_run_tasks` `{ "tasks": [":plugin:fastTest"], "background": true }` |
+| One or more test classes/methods | `gradle_run_tests` `{ "testMethods": { "FQCN": ["method"] }, "background": true }` — batch in one call |
+| Plugin fixture tests | `gradle_run_tasks` `{ "tasks": [":plugin:test"], "background": true }` |
+| Route-analysis fixture tests | `gradle_run_tasks` `{ "tasks": [":plugin-route-analysis:test"], "background": true }` |
+| Fast unit tests | `gradle_run_tasks` `{ "tasks": [":plugin-route-analysis:fastTest"], "background": true }` |
 | Full verify | `gradle_run_tasks` `{ "tasks": ["build"], "background": true }` |
 
 If MCP is unresponsive: `gradle_list_builds` or poll `gradle_get_build_status` with the `buildId` (v0.4.2+ reconciles disk records automatically), then shell fallback.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Cursor Cloud specific instructions
 
-IntelliJ Platform plugin for Armeria. Gradle multi-project build: `build-logic` plus four subprojects — `plugin-shared`, `plugin-route-analysis`, `plugin-wizard`, and the aggregating `plugin` (see `settings.gradle.kts`). No web UI, standalone server, or Docker services; the deliverable is an IDE plugin, verified headlessly through the IntelliJ Platform test harness.
+IntelliJ Platform plugin for Armeria. Gradle multi-project build (`build-logic`, `plugin-shared`, `plugin-route-analysis`, `plugin-wizard`, `plugin`). No web UI or Docker services.
 
 ### Prerequisites
 
@@ -57,13 +57,14 @@ Prefer **Gradle MCP** for the tasks below. Use `background: true` and poll `grad
 |------|---------------|----------------|
 | Full verify | `gradle_run_tasks` `["build"]` + background/poll | `./gradlew build` |
 | Compile plugin | `gradle_run_tasks` `[":plugin:compileKotlin"]` | `./gradlew :plugin:compileKotlin` |
-| Platform PSI fixture tests | `gradle_run_tasks` `[":plugin:test"]` or `gradle_run_tests` per class + background/poll | `./gradlew :plugin:test` |
-| Pure unit tests (`src/fastTest`) | `gradle_run_tasks` `[":plugin:fastTest"]` + background/poll | `./gradlew :plugin:fastTest` |
-| All plugin tests | `gradle_run_tasks` `[":plugin:check"]` + background/poll | `./gradlew :plugin:check` |
+| Plugin fixture tests | `gradle_run_tasks` `[":plugin:test"]` or `gradle_run_tests` per class + background/poll | `./gradlew :plugin:test` |
+| Route-analysis fixture tests | `gradle_run_tasks` `[":plugin-route-analysis:test"]` + background/poll | `./gradlew :plugin-route-analysis:test` |
+| Pure unit tests (`plugin-route-analysis/src/fastTest`) | `gradle_run_tasks` `[":plugin-route-analysis:fastTest"]` + background/poll | `./gradlew :plugin-route-analysis:fastTest` |
+| All route-analysis tests (fixture + fast) | `gradle_run_tasks` `[":plugin-route-analysis:check"]` + background/poll | `./gradlew :plugin-route-analysis:check` |
 | Run IDE sandbox | `gradle_run_tasks` `[":plugin:runIde"]` | `./gradlew :plugin:runIde` |
 | Fix stale test sandbox | — | `.cursor/clean-test-sandbox.sh` |
 
-`:plugin:test` runs only platform fixture tests under `src/test`. `:plugin:fastTest` runs pure unit tests under `src/fastTest` (still on the IntelliJ Platform test runtime, but without PSI fixtures). Use `check` or `build` to run both suites.
+`:plugin:test` and `:plugin-route-analysis:test` run platform PSI fixture tests under each module's `src/test`. `:plugin-route-analysis:fastTest` runs pure unit tests under `plugin-route-analysis/src/fastTest` (still on the IntelliJ Platform test runtime, but without PSI fixtures). Use `build` to run the full suite across modules.
 
 There is no separate lint task; `build` is the compile/test gate.
 
@@ -71,15 +72,11 @@ There is no separate lint task; `build` is the compile/test gate.
 
 | Path | Role |
 |------|------|
-| `plugin/` | Aggregating plugin: `plugin.xml`, client tool window, run configs, resources, `CHANGELOG.md`; depends on the three modules below |
-| `plugin-shared/` | Shared PSI/util code and test fixtures used by the other modules |
-| `plugin-route-analysis/` | Route Explorer engine (`ArmeriaRouteCollector`, DocService/gRPC/Spring collectors); most `test` + `fastTest` suites live here |
-| `plugin-wizard/` | New-project / module wizard + file templates (`plugin-wizard:test`) |
+| `plugin-shared/` | Shared bundle, icons, and starters used by other modules |
+| `plugin-route-analysis/` | Route Explorer, inspections, and related analysis (`src/test`, `src/fastTest`) |
+| `plugin-wizard/` | New Project Wizard templates and verification |
+| `plugin/` | Aggregating plugin module, run config, Clients explorer, resources, `CHANGELOG.md` |
 | `build-logic/` | Shared IntelliJ Platform Gradle conventions |
 | `gradle/libs.versions.toml` | Version pins (Kotlin, IPGP, IDEA platform) |
 
-Main Kotlin code lives under `<module>/src/main/kotlin/com/linecorp/intellij/plugins/armeria/`. User-visible strings go through `message(...)` and `ArmeriaBundle.properties`. CI (`.github/workflows/main.yml`) runs per-module test tasks (`:plugin-wizard:test`, `:plugin-route-analysis:fastTest`, `:plugin-route-analysis:test`, `:plugin:test`) then `./gradlew build -x test` on Java 25.
-
-### Running the plugin (headless cloud caveat)
-
-`:plugin:runIde` launches **IntelliJ IDEA Ultimate** (`plugin/build.gradle.kts`) on the VNC display (`DISPLAY=:1`). In the offline cloud sandbox it hangs during startup awaiting `LicensingFacade` (AI-promo / Ultimate licensing) and never reaches the Welcome screen without a JetBrains license and network to JetBrains services. Disabling `org.jetbrains.completion.full.line` in the sandbox `config/disabled_plugins.txt` clears one promo stall but startup still blocks. For headless verification, exercise the plugin through the platform test suites (they run the real plugin code, e.g. `ArmeriaRouteCollector.collect` discovering routes from Java/Kotlin PSI) instead of the GUI.
+Main Kotlin packages live under each module's `src/main/kotlin/com/linecorp/intellij/plugins/armeria/`. User-visible strings go through `message(...)` and `ArmeriaBundle.properties`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,4 +79,8 @@ There is no separate lint task; `build` is the compile/test gate.
 | `build-logic/` | Shared IntelliJ Platform Gradle conventions |
 | `gradle/libs.versions.toml` | Version pins (Kotlin, IPGP, IDEA platform) |
 
-Main Kotlin packages live under each module's `src/main/kotlin/com/linecorp/intellij/plugins/armeria/`. User-visible strings go through `message(...)` and `ArmeriaBundle.properties`.
+Main Kotlin packages live under each module's `src/main/kotlin/com/linecorp/intellij/plugins/armeria/`. User-visible strings go through `message(...)` and `ArmeriaBundle.properties`. CI (`.github/workflows/main.yml`) runs per-module test tasks (`:plugin-wizard:test`, `:plugin-route-analysis:fastTest`, `:plugin-route-analysis:test`, `:plugin:test`) then `./gradlew build -x test` on Java 25.
+
+### Running the plugin (headless cloud caveat)
+
+`:plugin:runIde` launches **IntelliJ IDEA Ultimate** (`plugin/build.gradle.kts`) on the VNC display (`DISPLAY=:1`). In the offline cloud sandbox it hangs during startup awaiting `LicensingFacade` (AI-promo / Ultimate licensing) and never reaches the Welcome screen without a JetBrains license and network to JetBrains services. Disabling `org.jetbrains.completion.full.line` in the sandbox `config/disabled_plugins.txt` clears one promo stall but startup still blocks. For headless verification, exercise the plugin through the platform test suites (they run the real plugin code, e.g. `ArmeriaRouteCollector.collect` discovering routes from Java/Kotlin PSI) instead of the GUI.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ IntelliJ IDEA Plugin for [Armeria](https://armeria.dev/)
 This plugin is evolving toward an Armeria cockpit inside IntelliJ IDEA:
 
 - Route Explorer tool window for discovering annotated services and server registrations
+- Armeria Clients explorer for WebClient, gRPC, and Thrift client discovery
+- Armeria run configuration with module classpath and main class selection
 - Armeria-specific duplicate route inspection for annotated services
 - DocService URL detection in console output for faster local verification
 
@@ -14,7 +16,10 @@ This plugin is evolving toward an Armeria cockpit inside IntelliJ IDEA:
 
 | Path | Role |
 | --- | --- |
-| `plugin/` | **Canonical** plugin sources, file templates, starters, resources, tests, and `CHANGELOG.md` |
+| `plugin-shared/` | Shared bundle, icons, and starters |
+| `plugin-route-analysis/` | Route Explorer, inspections, and related analysis |
+| `plugin-wizard/` | New Project Wizard templates and verification |
+| `plugin/` | Aggregating plugin module, run config, Clients explorer, resources, and `CHANGELOG.md` |
 | `build-logic/` | Generic IntelliJ Platform convention (`com.linecorp.intellij.platform-plugin`) |
 | `gradle/libs.versions.toml` | Kotlin, IntelliJ Platform Gradle Plugin, and IDE version pins |
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 
 - Armeria run configuration discovery now resolves Kotlin top-level `fun main()` via the file facade (`MainKt`), matching New Project Wizard Kotlin templates.
+- Deduplicated GraphQL and Thrift IDL routes in Route Explorer when the same operation appears in multiple schema files.
 
 ### Security
 
@@ -33,7 +34,7 @@
 - Added DocService runtime route sync action in Route Explorer.
 - Added Kotlin source support to Route Explorer for annotated services and Server.builder registrations.
 - Added Velocity-based regression tests for New Project Wizard file templates.
-- Added `plugin/src/test/resources/wizard-verification-matrix.md` documenting representative wizard scenarios.
+- Added `plugin-wizard/src/test/resources/wizard-verification-matrix.md` documenting representative wizard scenarios.
 - Added an Armeria Route Explorer tool window for discovering annotated services and registered routes.
 - Added a duplicate annotated route inspection for Armeria HTTP services.
 - Added DocService URL detection in console output.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -12,7 +12,6 @@
 ### Fixed
 
 - Armeria run configuration discovery now resolves Kotlin top-level `fun main()` via the file facade (`MainKt`), matching New Project Wizard Kotlin templates.
-- Deduplicated GraphQL and Thrift IDL routes in Route Explorer when the same operation appears in multiple schema files.
 
 ### Security
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Corrects documentation that still described a single-module `plugin/` layout and a non-existent `:plugin:fastTest` task. Docs and agent skills now match the multi-module Gradle layout and where `fastTest` actually lives.

## Changes

- `AGENTS.md`: build/test table and prose use `:plugin:test`, `:plugin-route-analysis:test`, and `:plugin-route-analysis:fastTest`; project layout lists `plugin-shared`, `plugin-route-analysis`, `plugin-wizard`, and `plugin`
- `.cursor/skills/gradle-tapi-mcp/SKILL.md` and `.github/skills/gradle-tapi-mcp/SKILL.md`: replace `:plugin:fastTest` with `:plugin-route-analysis:fastTest`; keep `:plugin:test` for the plugin module
- `plugin/CHANGELOG.md`: fix 0.1.0 wizard matrix path to `plugin-wizard/src/test/resources/wizard-verification-matrix.md`
- `README.md`: multi-module project layout; Current focus mentions Clients explorer and Armeria run configuration

## Test plan

- [ ] Diff is docs/skills only (no Kotlin/Gradle behavior changes)
- [ ] Confirm `plugin-route-analysis` defines `fastTest` and `plugin-wizard` owns the verification matrix file
- [ ] Spot-check AGENTS / README / skill tables for consistent task paths
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f43ca-6943-78eb-9e5f-8bd2be6c3b3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f43ca-6943-78eb-9e5f-8bd2be6c3b3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

