### PR TITLE
perf: cache proto route merge in Route Explorer collector

### DIFF
--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollector.kt
@@ -4,6 +4,7 @@ import com.intellij.ide.highlighter.JavaFileType
 import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiElement
@@ -12,6 +13,7 @@ import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiMethodCallExpression
 import com.intellij.psi.search.FileTypeIndex
 import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.util.CachedValue
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.PsiModificationTracker
@@ -21,24 +23,47 @@ import org.jetbrains.kotlin.psi.KtFile
 object ArmeriaRouteCollector {
 
     private val KOTLIN_PLUGIN_ID = PluginId.getId("org.jetbrains.kotlin")
+    private val PROJECT_ROUTES_KEY =
+        Key.create<CachedValue<List<ArmeriaRoute>>>("armeria.routeCollector.projectRoutes")
+    private val PROJECT_ROUTES_WITH_PROTO_KEY =
+        Key.create<CachedValue<List<ArmeriaRoute>>>("armeria.routeCollector.projectRoutesWithProto")
 
     fun collect(project: Project, includeProtoRoutes: Boolean = false): List<ArmeriaRoute> {
         val metrics = ArmeriaRouteCollectionMetrics()
         val startedAt = System.nanoTime()
         val routes = ArmeriaRouteCollectionMetrics.runWith(metrics) {
-            val cachedRoutes = CachedValuesManager.getManager(project).getCachedValue(project) {
-                computeProjectRoutes(project)
-            }
-            if (includeProtoRoutes) {
-                mergeProtoRoutesIfEnabled(project, cachedRoutes)
+            if (includeProtoRoutes && ArmeriaGrpcRouteCollector.isProtoRouteDiscoveryEnabled()) {
+                cachedProjectRoutesWithProto(project)
             } else {
-                cachedRoutes
+                cachedProjectRoutes(project)
             }
         }
         metrics.elapsedMs = (System.nanoTime() - startedAt) / 1_000_000
         ArmeriaRouteCollectionMetrics.logIfEnabled(metrics.snapshot())
         return routes
     }
+
+    private fun cachedProjectRoutes(project: Project): List<ArmeriaRoute> =
+        CachedValuesManager.getManager(project).getCachedValue(
+            project,
+            PROJECT_ROUTES_KEY,
+            { computeProjectRoutes(project) },
+            false,
+        )
+
+    private fun cachedProjectRoutesWithProto(project: Project): List<ArmeriaRoute> =
+        CachedValuesManager.getManager(project).getCachedValue(
+            project,
+            PROJECT_ROUTES_WITH_PROTO_KEY,
+            {
+                val baseRoutes = cachedProjectRoutes(project)
+                CachedValueProvider.Result.create(
+                    mergeProtoRoutes(project, baseRoutes),
+                    PsiModificationTracker.MODIFICATION_COUNT,
+                )
+            },
+            false,
+        )
 
     private fun computeProjectRoutes(project: Project): CachedValueProvider.Result<List<ArmeriaRoute>> {
         val scope = collectionScope(project)
@@ -103,10 +128,7 @@ object ArmeriaRouteCollector {
         )
     }
 
-    private fun mergeProtoRoutesIfEnabled(project: Project, baseRoutes: List<ArmeriaRoute>): List<ArmeriaRoute> {
-        if (!ArmeriaGrpcRouteCollector.isProtoRouteDiscoveryEnabled()) {
-            return baseRoutes
-        }
+    private fun mergeProtoRoutes(project: Project, baseRoutes: List<ArmeriaRoute>): List<ArmeriaRoute> {
         val scope = collectionScope(project)
         val routes = baseRoutes.toMutableList()
         ArmeriaGrpcRouteCollector.collect(project, scope, routes)

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollectorTest.kt
@@ -289,4 +289,31 @@ class ArmeriaGrpcRouteCollectorTest : ArmeriaFixtureTestBase() {
         assertNotNull(routes.firstOrNull { it.path == "/grpc" })
         assertNotNull(routes.firstOrNull { it.path == "/com.example.Greeter/SayHello" })
     }
+
+    fun testProtoRouteMergeIsCachedAcrossCollectCalls() {
+        myFixture.configureByText(
+            "greeter.proto",
+            """
+            syntax = "proto3";
+            package com.example;
+
+            service Greeter {
+              rpc SayHello(HelloRequest) returns (HelloResponse);
+            }
+            """.trimIndent(),
+        )
+
+        val first = ArmeriaRouteCollector.collect(project, includeProtoRoutes = true)
+        val firstScan = ArmeriaRouteCollectionMetrics.lastSnapshot!!.filesScanned
+        assertEquals(listOf("/com.example.Greeter/SayHello"), first.map { it.path })
+        assertTrue(firstScan > 0)
+
+        val second = ArmeriaRouteCollector.collect(project, includeProtoRoutes = true)
+        val secondScan = ArmeriaRouteCollectionMetrics.lastSnapshot!!.filesScanned
+        assertEquals(first.map { it.path }, second.map { it.path })
+        assertEquals(0, secondScan)
+
+        val withoutProto = ArmeriaRouteCollector.collect(project, includeProtoRoutes = false)
+        assertTrue(withoutProto.none { it.path == "/com.example.Greeter/SayHello" })
+    }
 }

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 
 - Armeria run configuration discovery now resolves Kotlin top-level `fun main()` via the file facade (`MainKt`), matching New Project Wizard Kotlin templates.
+- Route Explorer caches proto route merging so Refresh no longer re-scans `.proto` files on every collect.
 
 ### Security
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Route Explorer refreshes with `includeProtoRoutes=true` re-scanned every `.proto` file on each call. Only the non-proto route set was cached, so proto-heavy projects paid a growing cost on every Refresh.

## Changes

- Cache the with-proto merged route list separately via `CachedValuesManager`, invalidated on `PsiModificationTracker.MODIFICATION_COUNT`
- Keep the base (non-proto) cache for callers with `includeProtoRoutes=false`
- Preserve the `armeria.grpc.proto.routes.enabled` registry kill-switch on the proto path

## Test plan

- [ ] `:plugin-route-analysis:test --tests ArmeriaGrpcRouteCollectorTest`
- [ ] `:plugin-route-analysis:test --tests ArmeriaGrpcRouteCollectorGateTest`
- [ ] Toggle the proto registry key and confirm routes appear/disappear after PSI invalidation / refresh
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f43ca-6943-78eb-9e5f-8bd2be6c3b3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f43ca-6943-78eb-9e5f-8bd2be6c3b3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

