### PR TITLE
fix: ensure Route Explorer panel for DocService runtime sync

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 ### Added
 
+- Added fixture regression tests for duplicate route and duplicate registration inspections (Java and Kotlin).
+
 ### Changed
 
 ### Deprecated
@@ -12,6 +14,7 @@
 ### Fixed
 
 - Armeria run configuration discovery now resolves Kotlin top-level `fun main()` via the file facade (`MainKt`), matching New Project Wizard Kotlin templates.
+- DocService runtime sync activates the Armeria Services tool window when needed so synced routes can be applied even if Route Explorer was never opened.
 
 ### Security
 

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerAccess.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerAccess.kt
@@ -13,4 +13,31 @@ object ArmeriaRouteExplorerAccess {
             .mapNotNull { it.component as? ArmeriaRouteExplorerPanel }
             .firstOrNull()
     }
+
+    /**
+     * Returns the Route Explorer panel, activating the Armeria Services tool window first when needed
+     * so [ArmeriaRouteExplorerToolWindowFactory] can create content.
+     */
+    fun ensurePanel(project: Project, onReady: (ArmeriaRouteExplorerPanel?) -> Unit) {
+        if (project.isDisposed) {
+            onReady(null)
+            return
+        }
+        findPanel(project)?.let {
+            onReady(it)
+            return
+        }
+        val toolWindow = ToolWindowManager.getInstance(project).getToolWindow(TOOL_WINDOW_ID)
+        if (toolWindow == null) {
+            onReady(null)
+            return
+        }
+        toolWindow.activate({
+            if (project.isDisposed) {
+                onReady(null)
+                return@activate
+            }
+            onReady(findPanel(project))
+        }, true, false)
+    }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSyncRuntimeRoutesAction.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSyncRuntimeRoutesAction.kt
@@ -61,24 +61,28 @@ class ArmeriaSyncRuntimeRoutesAction : DumbAwareAction(
                         }
                         when (result) {
                             is ArmeriaDocServiceFetchResult.Success -> {
-                                val explorerPanel = ArmeriaRouteExplorerAccess.findPanel(project)
-                                if (explorerPanel != null) {
-                                    explorerPanel.applyRuntimeRoutes(result.routes)
-                                    Messages.showInfoMessage(
-                                        project,
-                                        message(
-                                            "route.explorer.sync.success",
-                                            result.routes.size,
-                                            result.specificationUrl,
-                                        ),
-                                        message("route.explorer.action.syncRuntime"),
-                                    )
-                                } else {
-                                    Messages.showWarningDialog(
-                                        project,
-                                        message("route.explorer.sync.panelUnavailable"),
-                                        message("route.explorer.action.syncRuntime"),
-                                    )
+                                ArmeriaRouteExplorerAccess.ensurePanel(project) { explorerPanel ->
+                                    if (project.isDisposed) {
+                                        return@ensurePanel
+                                    }
+                                    if (explorerPanel != null) {
+                                        explorerPanel.applyRuntimeRoutes(result.routes)
+                                        Messages.showInfoMessage(
+                                            project,
+                                            message(
+                                                "route.explorer.sync.success",
+                                                result.routes.size,
+                                                result.specificationUrl,
+                                            ),
+                                            message("route.explorer.action.syncRuntime"),
+                                        )
+                                    } else {
+                                        Messages.showWarningDialog(
+                                            project,
+                                            message("route.explorer.sync.panelUnavailable"),
+                                            message("route.explorer.action.syncRuntime"),
+                                        )
+                                    }
                                 }
                             }
                             is ArmeriaDocServiceFetchResult.Failure -> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

DocService runtime sync could fetch routes successfully but still fail to apply them when the Armeria Services tool window had never been opened, because the Route Explorer panel did not exist yet.

This change activates the tool window after a successful fetch so the panel is created before applying runtime routes, and only shows the panel-unavailable warning if the panel is still missing afterward.

## Changes

- Add `ArmeriaRouteExplorerAccess.ensurePanel` to activate Armeria Services and resolve the Route Explorer panel
- Wire DocService sync success handling through `ensurePanel` before `applyRuntimeRoutes` and the success dialog
- Document the fix under CHANGELOG Unreleased Fixed

## Test plan

- [x] `:plugin:compileKotlin` via Gradle MCP
- [ ] Manual: with Armeria Services never opened, run Sync Runtime Routes against a live DocService — tool window opens, routes apply, success dialog (no panel-unavailable warning)
- [ ] Manual: with Armeria Services already open, sync still applies routes and shows success
- [ ] Manual: if the tool window cannot be created, panel-unavailable warning still appears after a successful fetch
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f43ca-6943-78eb-9e5f-8bd2be6c3b3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f43ca-6943-78eb-9e5f-8bd2be6c3b3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

