### PR TITLE
docs: add Copilot review preflight skills for plugin implementation

### DIFF
--- a/.cursor/skills/armeria-route-psi-analysis/SKILL.md
+++ b/.cursor/skills/armeria-route-psi-analysis/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: armeria-route-psi-analysis
+description: >-
+  PSI and route-analysis implementation patterns for plugin-route-analysis. Use when
+  editing ArmeriaRouteCollector, decorator/registration collectors, duplicate detection,
+  virtualHost scoping, annotated-service parsing, or related regression tests.
+---
+
+# Armeria route PSI analysis
+
+This skill captures recurring GitHub Copilot review findings on route/client PSI
+collectors. Apply it when changing code under `plugin-route-analysis/`.
+
+## When to use
+
+- `ArmeriaRouteCollector`, `ArmeriaKotlinRouteCollector`, extended-registration collectors
+- `ArmeriaRouteSupport`, decorator/annotated metadata helpers
+- Duplicate route/registration inspections and indexes
+- Java or Kotlin fixture tests for route discovery
+
+## Core principle: resolve values, do not stringify PSI
+
+Copilot frequently flags `expression.text` / `value.text` fallbacks that produce misleading
+routes such as `/MY_PATH_CONST` or `/PATH_PREFIX` instead of evaluated values.
+
+### Preferred order
+
+1. **Literals** — `PsiLiteralExpression`, Kotlin string literals (`ArmeriaKotlinExpressionSupport`)
+2. **Constants** — `evaluateConstant()` / field references / `KtNamedDeclaration` initializers
+3. **References** — resolve `PsiReference` to qualified names or string values
+4. **Last resort** — keep raw expression text for display only; do **not** pass through
+   `normalizePath()` or duplicate-index keys unless the value is known to be a path literal
+
+Reuse existing helpers before adding new extractors:
+
+- `ArmeriaRouteSupport.extractStrings()` / `evaluateConstant()`
+- `ArmeriaKotlinExpressionSupport` for Kotlin call chains
+- `ArmeriaDecoratorSupport` / `ArmeriaKotlinDecoratorSupport` for decorator class names
+
+When a path cannot be resolved, prefer omitting the route or marking metadata as unresolved
+over inventing a normalized path that triggers false-positive duplicate detection.
+
+## virtualHost scoping (Armeria semantics)
+
+`virtualHost("host")` applies to registrations **after** the call in the fluent chain,
+including inside the lambda body. It must **not** retroactively annotate earlier registrations.
+
+Implementation checklist:
+
+1. Walk the **forward** chained call sequence from each `virtualHost` site.
+2. Track lambda-scoped registrations inside the `virtualHost` block.
+3. Use `ArmeriaRouteVirtualHostAnnotator` / registration keys — do not rescan entire files.
+4. Duplicate detection must include `virtualHostName` in the key so `/api` on different
+   hosts are not grouped as duplicates.
+
+Add regression tests for: backward chain (must not annotate), forward chain, nested virtualHost.
+
+## Java / Kotlin parity
+
+When changing registration or decorator parsing in Java collectors, check whether the Kotlin
+path needs the same change:
+
+| Shared helper | Purpose |
+|---------------|---------|
+| `ArmeriaBuilderCallHeuristics` | Detect builder-style registration calls |
+| `ArmeriaRegistrationChainReducer` | Fluent `route()` / `routeDecorator()` chains |
+| `CoreServiceRegistrationMethod` | Core service method names |
+| `ArmeriaRouteVirtualHostAnnotator` | Apply hostname to registration keys |
+
+Add or update tests in **both**:
+
+- `ArmeriaExtendedRegistrationCollectorTest` (Java fixtures)
+- `ArmeriaKotlinExtendedRegistrationCollectorTest` (Kotlin fixtures)
+
+## Decorator and fluent chains
+
+Common Copilot findings:
+
+- Default `routeDecorator()` without `.path(...)` is `PathType.GLOB` with `/**`
+- `methods(HttpMethod.POST, HttpMethod.PUT)` renders as `"POST, PUT"` (strip `HttpMethod.` prefix)
+- `@Decorator({A.class, B.class})` array values need explicit handling — do not collapse to
+  a single brace string via `renderMemberValue()` fallback
+- Class literals in annotations: resolve to qualified names, not `{...}` text
+
+## Annotated services
+
+- Distinguish `@Get` / `@Post` / etc. from `service()` registrations — `service()` maps all
+  HTTP methods; label and `RouteMatch` must reflect that.
+- Path prefix annotations (`@PathPrefix`, `@Prefix`) compose with method-level paths; reuse
+  `ArmeriaAnnotatedMetadataSupport` rather than duplicating annotation walks.
+- For duplicate inspections, scope keys consistently (class, method, path, HTTP method,
+  virtual host).
+
+## Performance and caching
+
+Route collection runs on every explorer refresh. Copilot flags full-project Java file walks.
+
+Preferred approach (already used in `ArmeriaRouteCollector`):
+
+1. **Index-backed searches** — `AnnotatedElementsSearch`, `FileTypeIndex`, `ReferencesSearch`
+2. **Early exit** — skip files without Armeria imports/references before deep PSI walks
+3. **Project cache** — `CachedValuesManager` keyed on `PsiModificationTracker`
+4. **Production scope** — `collectionScope()` uses production sources; if excluding test sources,
+   document the behavior change in the PR summary
+
+Do not rescan fallback-processed files twice in one collection pass.
+
+## Proto / gRPC / Spring routes
+
+- gRPC/proto routes: use Proto Editor PSI when available; cache merged proto routes
+  (`mergeProtoRoutesIfEnabled`) to avoid repeated merges.
+- Spring Boot YAML/Java config collectors: guard optional Kotlin/Spring PSI behind availability
+  checks; keep Spring-specific code in `ArmeriaSpringBootRouteCollector`.
+- GraphQL / Thrift deduplication: align dedupe keys with HTTP route keys (path + method + host).
+
+## Regression tests
+
+When fixing collector behavior, add a focused fixture test that would have failed before the fix:
+
+```
+plugin-route-analysis/src/test/...     — PSI fixture tests (platform harness)
+plugin-route-analysis/src/fastTest/... — pure unit tests (no fixtures)
+```
+
+Name tests after the behavior (`virtualHost_doesNotAnnotateEarlierRegistrations`), not the PR number.
+
+## Related skills
+
+- `intellij-armeria-plugin` — UI/i18n, index readiness, module placement, test task paths
+- `gradle-tapi-mcp` — run `:plugin-route-analysis:test` / `fastTest` with correct `taskPath`
+- `copilot-review-preflight` — pre-PR checklist

--- a/.cursor/skills/copilot-review-preflight/SKILL.md
+++ b/.cursor/skills/copilot-review-preflight/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: copilot-review-preflight
+description: >-
+  Pre-implementation and pre-PR checklist derived from recurring GitHub Copilot review
+  comments on this repository. Use before opening a PR or when implementing features
+  likely to trigger Copilot review (plugin UI, route collectors, agent docs/scripts).
+---
+
+# Copilot review preflight
+
+This skill aggregates patterns from **318** GitHub Copilot pull-request review comments
+on `nise-nabe/armeria-intellij-plugin` (through July 2026). Use it as a final pass
+before requesting review.
+
+## When to use
+
+- Before opening or updating a PR (especially feature/fix PRs with plugin code)
+- When Copilot review has flagged similar issues on prior PRs in the same area
+- At the start of work in a new area — pick the specialized skill below first
+
+## Specialized skills (read the relevant one during implementation)
+
+| Area | Skill |
+|------|-------|
+| UI, run configs, tool windows, inspections, module placement | `intellij-armeria-plugin` |
+| Route/client PSI collectors, duplicates, virtualHost | `armeria-route-psi-analysis` |
+| Gradle build/test via MCP | `gradle-tapi-mcp` |
+| PR body format | `.cursor/rules/pr-description-format.mdc` |
+
+## Quick checklist by change type
+
+### Plugin feature code (`plugin/`, `plugin-shared/`, `plugin-wizard/`)
+
+- [ ] User-visible strings use `message(...)` + `ArmeriaBundle.properties` (no hard-coded English)
+- [ ] HTML tooltips escape dynamic PSI text
+- [ ] Tree selection / equality uses stable route fields, not localized labels
+- [ ] Background PSI uses `ReadAction.nonBlocking` + `expireWith` + `coalesceBy`
+- [ ] Index-heavy paths handle `IndexNotReadyException` or defer until smart mode
+- [ ] Kotlin-specific types are not imported in always-loaded classes without guards
+- [ ] Run-config `main` detection uses `PsiMethodUtil`, not any `static main`
+- [ ] Code and tests live in the correct module (see `intellij-armeria-plugin`)
+
+### Route analysis (`plugin-route-analysis/`)
+
+- [ ] Paths and annotation values resolved via constant evaluation, not raw `expression.text`
+- [ ] `virtualHost` applies forward-only; duplicate keys include hostname
+- [ ] Java and Kotlin collectors stay in parity; shared reducers updated together
+- [ ] Decorator chains, annotated services, and proto/grpc routes have regression tests
+- [ ] Collection uses indices/cache; no accidental full-project rescan
+- [ ] Test plan uses `:plugin-route-analysis:test` or `fastTest`, not `:plugin:test`
+
+### Agent docs and shell scripts (`.cursor/`, `.github/`, `AGENTS.md`)
+
+- [ ] Invoke new shell scripts via `bash path/to/script.sh`, not relying on executable bit
+- [ ] Installer scripts preflight required tools (`unzip`, `curl`) with clear errors
+- [ ] Gradle MCP docs match the pinned server version in `install-gradle-tapi-mcp.sh`
+- [ ] Avoid environment-specific assertions (`DISPLAY=:1`) in durable docs — phrase as sandbox-relative
+- [ ] MCP config uses `stdio` transport; repo root derived from script path, not fragile `pwd`
+- [ ] PR description is a feature summary (not a "review fixes" changelog) per `pr-description-format.mdc`
+
+## Top recurring Copilot themes (frequency)
+
+| Theme | Approx. hits | Primary skill |
+|-------|-------------|---------------|
+| Multi-module placement / wrong test task | 21+ | `intellij-armeria-plugin` |
+| Run configuration / main entry detection | 19 | `intellij-armeria-plugin` |
+| Async UI lifecycle (`expireWith`, dispose) | 16 | `intellij-armeria-plugin` |
+| Hard-coded / non-localized UI strings | 16 | `intellij-armeria-plugin` |
+| PSI literal fallback / misleading paths | 15+ | `armeria-route-psi-analysis` |
+| Annotated service / decorator parsing | 30+ | `armeria-route-psi-analysis` |
+| Optional Kotlin plugin classloading | 11+ | `intellij-armeria-plugin` |
+| Gradle MCP version/doc drift | 7+ | `gradle-tapi-mcp` |
+| Bash script executable-bit assumptions | 5+ | checklist above |
+| Index not ready during refresh/execute | 2+ | `intellij-armeria-plugin` |
+
+## Verification before PR
+
+1. Read the specialized skill for your change area.
+2. Run compile/tests via Gradle MCP with the correct module `taskPath` (see `gradle-tapi-mcp`).
+3. Scan the diff for `expression.text`, hard-coded `"` strings in UI code, and Kotlin imports
+   in shared collectors.
+4. Write the PR body as Summary / Changes / Test plan — fold any review-driven edits into
+   **Changes**, do not add "Copilot review fixes" sections.
+
+## Test plan template
+
+```markdown
+## Test plan
+- [ ] `:plugin-route-analysis:fastTest` — <class or area> (if route-analysis logic changed)
+- [ ] `:plugin-route-analysis:test` — <fixture test class> (if PSI fixtures added)
+- [ ] `:plugin:test` — <class> (if aggregating plugin UI changed)
+- [ ] `:plugin:compileKotlin` — clean compile
+```
+
+Replace task paths with the module that actually contains the test sources.

--- a/.cursor/skills/intellij-armeria-plugin/SKILL.md
+++ b/.cursor/skills/intellij-armeria-plugin/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: intellij-armeria-plugin
+description: >-
+  IntelliJ Platform plugin conventions for this repository. Use when implementing
+  or editing plugin UI, run configurations, tool windows, inspections, actions,
+  or any Kotlin code under plugin/, plugin-shared/, or plugin-wizard/.
+---
+
+# IntelliJ Armeria plugin conventions
+
+This skill captures recurring GitHub Copilot review findings on plugin implementation
+in this repository. Apply it **during implementation**, not only before opening a PR.
+
+## When to use
+
+- Adding or changing tool windows, panels, actions, run configurations, inspections
+- Touching user-visible text, Swing renderers, or FormBuilder fields
+- Calling PSI/index APIs from UI or run-configuration startup paths
+- Deciding which Gradle module should own new code or tests
+
+## Module placement
+
+| Module | Owns |
+|--------|------|
+| `plugin-route-analysis/` | Route/Client collectors, PSI analysis, route-related unit/fixture tests |
+| `plugin-shared/` | Shared bundle helpers, cross-cutting PSI utilities, test fixtures |
+| `plugin-wizard/` | New-project/module wizard, file templates, starter resources |
+| `plugin/` | `plugin.xml` wiring, UI panels/actions, run configs, inspection registration |
+
+Do not put collector logic in `plugin/` when it belongs in `plugin-route-analysis/`.
+Do not add route-analysis tests under `plugin/src/test` when the class under test lives
+in `plugin-route-analysis/`.
+
+## Internationalization (i18n)
+
+All user-visible strings must go through `message(...)` with keys in
+`plugin-shared/src/main/resources/messages/ArmeriaBundle.properties`.
+
+```kotlin
+// Good
+add(object : DumbAwareAction(message("route.explorer.action.refresh")) { ... })
+
+// Bad — hard-coded English in UI
+statusLabel.text = "Refreshing Armeria routes..."
+```
+
+Additional rules Copilot repeatedly flags:
+
+- **FormBuilder labels** — match existing plugin style; field labels use a trailing colon.
+- **Properties file hygiene** — no duplicate keys; keep `[Unreleased]` changelog templates intact.
+- **Stable identity** — when restoring tree selection or comparing routes, use stable fields
+  (`routeMatch`, `httpMethod`, registration key), not localized labels like `methodLabel`.
+- **HTML in renderers** — escape dynamic values (`descriptionText`, decorator names, unresolved
+  expressions) before embedding in HTML tooltips; unresolved PSI text may contain `<` or `&`.
+
+## Optional Kotlin plugin safety
+
+Kotlin support is optional. Classes loaded on every IDE startup must not hard-reference
+Kotlin plugin types (`KotlinFileType`, `KtFile`, `KtNamedFunction`, etc.) at the class level.
+
+```kotlin
+// Bad — can cause NoClassDefFoundError when Kotlin plugin is absent/disabled
+import org.jetbrains.kotlin.idea.KotlinFileType
+FileTypeIndex.getFiles(KotlinFileType.INSTANCE, scope)
+
+// Good — guard and delegate to a Kotlin-only helper loaded only when available
+if (isKotlinPluginAvailable()) {
+    ArmeriaKotlinRouteCollector.collect(...)
+}
+```
+
+Checklist:
+
+1. Gate Kotlin paths with `isKotlinPluginAvailable()` (plugin installed **and** enabled).
+2. Keep Kotlin-specific imports in `ArmeriaKotlin*` files, not in shared entry points like
+   `ArmeriaRouteCollector` unless the class is only loaded when Kotlin is present.
+3. Prefer extracting Kotlin iteration into `ArmeriaKotlinRouteCollector` / `ArmeriaKotlin*Support`.
+
+## Index readiness and dumb mode
+
+Index-backed APIs (`FileTypeIndex`, `AnnotatedElementsSearch`, `ReferencesSearch`,
+`resolveMethod`, full-project `collect`) throw `IndexNotReadyException` while indexing.
+
+| Context | Required handling |
+|---------|-------------------|
+| Run configuration startup (`execute`, `createState`) | Best-effort: catch `IndexNotReadyException`, return `null`/skip feature |
+| Tool window registered `DumbAware` | Defer index-heavy refresh until smart mode, or catch and show empty state |
+| Background refresh | Do not assume indices are ready on first open |
+
+Existing pattern: `ArmeriaRunProfileState.resolveDocServiceUrl()` catches
+`IndexNotReadyException` and skips the console hint.
+
+## Background work and UI lifecycle
+
+Route/client explorer refresh uses `ReadAction.nonBlocking`, not blocking `ReadAction.run`
+on the EDT.
+
+Required patterns:
+
+```kotlin
+ReadAction.nonBlocking<List<ArmeriaRoute>> { ArmeriaRouteCollector.collect(project) }
+    .coalesceBy(this)          // collapse duplicate refreshes
+    .expireWith(this)          // cancel when panel/tool window is disposed
+    .finishOnUiThread(ModalityState.defaultModalityState()) { routes -> updateTree(routes) }
+    .submit(AppExecutorUtil.getAppExecutorService())
+```
+
+Never call heavy `ArmeriaRouteCollector.collect()` synchronously inside `execute()` or
+action `actionPerformed` without a documented reason.
+
+## Run configuration entry points
+
+When detecting JVM `main` classes:
+
+- Use `PsiMethodUtil.hasMainInClass` / `hasMainMethod` / `findMainMethod`.
+- Do **not** treat any `static` method named `main` as valid — invalid signatures
+  (`static void main()`, `static int main(String[])`) are not runnable.
+- For Kotlin top-level `main`, resolve via facade class (`MainKt`) in `ArmeriaKotlinMainClassSupport`.
+- Gate Armeria run configs on actual server usage (`Server.builder()` / Armeria application
+  references), not any `com.linecorp.armeria` import in the file.
+
+## IntelliJ API hygiene
+
+- Prefer `project.basePath` over deprecated `Project.baseDir`; avoid `File(".")` fallbacks.
+- Smart pointers: `SmartPointerManager.getInstance(project).createSmartPsiElementPointer(element)`.
+- Enum naming in this codebase: prefer ALL_CAPS entries (e.g. `RouteProtocol.HTTP`), not PascalCase.
+- `const val` names use `UPPER_SNAKE_CASE` when they are true constants.
+
+## Test task paths (multi-module)
+
+Match the Gradle task to the module that contains the test class:
+
+| Test location | Gradle task |
+|---------------|-------------|
+| `plugin-route-analysis/src/test` | `:plugin-route-analysis:test` |
+| `plugin-route-analysis/src/fastTest` | `:plugin-route-analysis:fastTest` |
+| `plugin/src/test` | `:plugin:test` |
+| `plugin-wizard/src/test` | `:plugin-wizard:test` |
+
+When documenting a test plan in a PR, use the module-qualified task. With Gradle MCP,
+set `taskPath` accordingly (e.g. `":plugin-route-analysis:test"`).
+
+## Related skills
+
+- `armeria-route-psi-analysis` — PSI collectors, route semantics, constant evaluation
+- `gradle-tapi-mcp` — build/test execution and `taskPath` usage
+- `copilot-review-preflight` — pre-PR checklist aggregating common review themes

--- a/.github/skills/armeria-route-psi-analysis/SKILL.md
+++ b/.github/skills/armeria-route-psi-analysis/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: armeria-route-psi-analysis
+description: >-
+  PSI and route-analysis implementation patterns for plugin-route-analysis. Use when
+  editing ArmeriaRouteCollector, decorator/registration collectors, duplicate detection,
+  virtualHost scoping, annotated-service parsing, or related regression tests.
+---
+
+# Armeria route PSI analysis
+
+This skill captures recurring GitHub Copilot review findings on route/client PSI
+collectors. Apply it when changing code under `plugin-route-analysis/`.
+
+## When to use
+
+- `ArmeriaRouteCollector`, `ArmeriaKotlinRouteCollector`, extended-registration collectors
+- `ArmeriaRouteSupport`, decorator/annotated metadata helpers
+- Duplicate route/registration inspections and indexes
+- Java or Kotlin fixture tests for route discovery
+
+## Core principle: resolve values, do not stringify PSI
+
+Copilot frequently flags `expression.text` / `value.text` fallbacks that produce misleading
+routes such as `/MY_PATH_CONST` or `/PATH_PREFIX` instead of evaluated values.
+
+### Preferred order
+
+1. **Literals** — `PsiLiteralExpression`, Kotlin string literals (`ArmeriaKotlinExpressionSupport`)
+2. **Constants** — `evaluateConstant()` / field references / `KtNamedDeclaration` initializers
+3. **References** — resolve `PsiReference` to qualified names or string values
+4. **Last resort** — keep raw expression text for display only; do **not** pass through
+   `normalizePath()` or duplicate-index keys unless the value is known to be a path literal
+
+Reuse existing helpers before adding new extractors:
+
+- `ArmeriaRouteSupport.extractStrings()` / `evaluateConstant()`
+- `ArmeriaKotlinExpressionSupport` for Kotlin call chains
+- `ArmeriaDecoratorSupport` / `ArmeriaKotlinDecoratorSupport` for decorator class names
+
+When a path cannot be resolved, prefer omitting the route or marking metadata as unresolved
+over inventing a normalized path that triggers false-positive duplicate detection.
+
+## virtualHost scoping (Armeria semantics)
+
+`virtualHost("host")` applies to registrations **after** the call in the fluent chain,
+including inside the lambda body. It must **not** retroactively annotate earlier registrations.
+
+Implementation checklist:
+
+1. Walk the **forward** chained call sequence from each `virtualHost` site.
+2. Track lambda-scoped registrations inside the `virtualHost` block.
+3. Use `ArmeriaRouteVirtualHostAnnotator` / registration keys — do not rescan entire files.
+4. Duplicate detection must include `virtualHostName` in the key so `/api` on different
+   hosts are not grouped as duplicates.
+
+Add regression tests for: backward chain (must not annotate), forward chain, nested virtualHost.
+
+## Java / Kotlin parity
+
+When changing registration or decorator parsing in Java collectors, check whether the Kotlin
+path needs the same change:
+
+| Shared helper | Purpose |
+|---------------|---------|
+| `ArmeriaBuilderCallHeuristics` | Detect builder-style registration calls |
+| `ArmeriaRegistrationChainReducer` | Fluent `route()` / `routeDecorator()` chains |
+| `CoreServiceRegistrationMethod` | Core service method names |
+| `ArmeriaRouteVirtualHostAnnotator` | Apply hostname to registration keys |
+
+Add or update tests in **both**:
+
+- `ArmeriaExtendedRegistrationCollectorTest` (Java fixtures)
+- `ArmeriaKotlinExtendedRegistrationCollectorTest` (Kotlin fixtures)
+
+## Decorator and fluent chains
+
+Common Copilot findings:
+
+- Default `routeDecorator()` without `.path(...)` is `PathType.GLOB` with `/**`
+- `methods(HttpMethod.POST, HttpMethod.PUT)` renders as `"POST, PUT"` (strip `HttpMethod.` prefix)
+- `@Decorator({A.class, B.class})` array values need explicit handling — do not collapse to
+  a single brace string via `renderMemberValue()` fallback
+- Class literals in annotations: resolve to qualified names, not `{...}` text
+
+## Annotated services
+
+- Distinguish `@Get` / `@Post` / etc. from `service()` registrations — `service()` maps all
+  HTTP methods; label and `RouteMatch` must reflect that.
+- Path prefix annotations (`@PathPrefix`, `@Prefix`) compose with method-level paths; reuse
+  `ArmeriaAnnotatedMetadataSupport` rather than duplicating annotation walks.
+- For duplicate inspections, scope keys consistently (class, method, path, HTTP method,
+  virtual host).
+
+## Performance and caching
+
+Route collection runs on every explorer refresh. Copilot flags full-project Java file walks.
+
+Preferred approach (already used in `ArmeriaRouteCollector`):
+
+1. **Index-backed searches** — `AnnotatedElementsSearch`, `FileTypeIndex`, `ReferencesSearch`
+2. **Early exit** — skip files without Armeria imports/references before deep PSI walks
+3. **Project cache** — `CachedValuesManager` keyed on `PsiModificationTracker`
+4. **Production scope** — `collectionScope()` uses production sources; if excluding test sources,
+   document the behavior change in the PR summary
+
+Do not rescan fallback-processed files twice in one collection pass.
+
+## Proto / gRPC / Spring routes
+
+- gRPC/proto routes: use Proto Editor PSI when available; cache merged proto routes
+  (`mergeProtoRoutesIfEnabled`) to avoid repeated merges.
+- Spring Boot YAML/Java config collectors: guard optional Kotlin/Spring PSI behind availability
+  checks; keep Spring-specific code in `ArmeriaSpringBootRouteCollector`.
+- GraphQL / Thrift deduplication: align dedupe keys with HTTP route keys (path + method + host).
+
+## Regression tests
+
+When fixing collector behavior, add a focused fixture test that would have failed before the fix:
+
+```
+plugin-route-analysis/src/test/...     — PSI fixture tests (platform harness)
+plugin-route-analysis/src/fastTest/... — pure unit tests (no fixtures)
+```
+
+Name tests after the behavior (`virtualHost_doesNotAnnotateEarlierRegistrations`), not the PR number.
+
+## Related skills
+
+- `intellij-armeria-plugin` — UI/i18n, index readiness, module placement, test task paths
+- `gradle-tapi-mcp` — run `:plugin-route-analysis:test` / `fastTest` with correct `taskPath`
+- `copilot-review-preflight` — pre-PR checklist

--- a/.github/skills/copilot-review-preflight/SKILL.md
+++ b/.github/skills/copilot-review-preflight/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: copilot-review-preflight
+description: >-
+  Pre-implementation and pre-PR checklist derived from recurring GitHub Copilot review
+  comments on this repository. Use before opening a PR or when implementing features
+  likely to trigger Copilot review (plugin UI, route collectors, agent docs/scripts).
+---
+
+# Copilot review preflight
+
+This skill aggregates patterns from **318** GitHub Copilot pull-request review comments
+on `nise-nabe/armeria-intellij-plugin` (through July 2026). Use it as a final pass
+before requesting review.
+
+## When to use
+
+- Before opening or updating a PR (especially feature/fix PRs with plugin code)
+- When Copilot review has flagged similar issues on prior PRs in the same area
+- At the start of work in a new area — pick the specialized skill below first
+
+## Specialized skills (read the relevant one during implementation)
+
+| Area | Skill |
+|------|-------|
+| UI, run configs, tool windows, inspections, module placement | `intellij-armeria-plugin` |
+| Route/client PSI collectors, duplicates, virtualHost | `armeria-route-psi-analysis` |
+| Gradle build/test via MCP | `gradle-tapi-mcp` |
+| PR body format | `.cursor/rules/pr-description-format.mdc` |
+
+## Quick checklist by change type
+
+### Plugin feature code (`plugin/`, `plugin-shared/`, `plugin-wizard/`)
+
+- [ ] User-visible strings use `message(...)` + `ArmeriaBundle.properties` (no hard-coded English)
+- [ ] HTML tooltips escape dynamic PSI text
+- [ ] Tree selection / equality uses stable route fields, not localized labels
+- [ ] Background PSI uses `ReadAction.nonBlocking` + `expireWith` + `coalesceBy`
+- [ ] Index-heavy paths handle `IndexNotReadyException` or defer until smart mode
+- [ ] Kotlin-specific types are not imported in always-loaded classes without guards
+- [ ] Run-config `main` detection uses `PsiMethodUtil`, not any `static main`
+- [ ] Code and tests live in the correct module (see `intellij-armeria-plugin`)
+
+### Route analysis (`plugin-route-analysis/`)
+
+- [ ] Paths and annotation values resolved via constant evaluation, not raw `expression.text`
+- [ ] `virtualHost` applies forward-only; duplicate keys include hostname
+- [ ] Java and Kotlin collectors stay in parity; shared reducers updated together
+- [ ] Decorator chains, annotated services, and proto/grpc routes have regression tests
+- [ ] Collection uses indices/cache; no accidental full-project rescan
+- [ ] Test plan uses `:plugin-route-analysis:test` or `fastTest`, not `:plugin:test`
+
+### Agent docs and shell scripts (`.cursor/`, `.github/`, `AGENTS.md`)
+
+- [ ] Invoke new shell scripts via `bash path/to/script.sh`, not relying on executable bit
+- [ ] Installer scripts preflight required tools (`unzip`, `curl`) with clear errors
+- [ ] Gradle MCP docs match the pinned server version in `install-gradle-tapi-mcp.sh`
+- [ ] Avoid environment-specific assertions (`DISPLAY=:1`) in durable docs — phrase as sandbox-relative
+- [ ] MCP config uses `stdio` transport; repo root derived from script path, not fragile `pwd`
+- [ ] PR description is a feature summary (not a "review fixes" changelog) per `pr-description-format.mdc`
+
+## Top recurring Copilot themes (frequency)
+
+| Theme | Approx. hits | Primary skill |
+|-------|-------------|---------------|
+| Multi-module placement / wrong test task | 21+ | `intellij-armeria-plugin` |
+| Run configuration / main entry detection | 19 | `intellij-armeria-plugin` |
+| Async UI lifecycle (`expireWith`, dispose) | 16 | `intellij-armeria-plugin` |
+| Hard-coded / non-localized UI strings | 16 | `intellij-armeria-plugin` |
+| PSI literal fallback / misleading paths | 15+ | `armeria-route-psi-analysis` |
+| Annotated service / decorator parsing | 30+ | `armeria-route-psi-analysis` |
+| Optional Kotlin plugin classloading | 11+ | `intellij-armeria-plugin` |
+| Gradle MCP version/doc drift | 7+ | `gradle-tapi-mcp` |
+| Bash script executable-bit assumptions | 5+ | checklist above |
+| Index not ready during refresh/execute | 2+ | `intellij-armeria-plugin` |
+
+## Verification before PR
+
+1. Read the specialized skill for your change area.
+2. Run compile/tests via Gradle MCP with the correct module `taskPath` (see `gradle-tapi-mcp`).
+3. Scan the diff for `expression.text`, hard-coded `"` strings in UI code, and Kotlin imports
+   in shared collectors.
+4. Write the PR body as Summary / Changes / Test plan — fold any review-driven edits into
+   **Changes**, do not add "Copilot review fixes" sections.
+
+## Test plan template
+
+```markdown
+## Test plan
+- [ ] `:plugin-route-analysis:fastTest` — <class or area> (if route-analysis logic changed)
+- [ ] `:plugin-route-analysis:test` — <fixture test class> (if PSI fixtures added)
+- [ ] `:plugin:test` — <class> (if aggregating plugin UI changed)
+- [ ] `:plugin:compileKotlin` — clean compile
+```
+
+Replace task paths with the module that actually contains the test sources.

--- a/.github/skills/intellij-armeria-plugin/SKILL.md
+++ b/.github/skills/intellij-armeria-plugin/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: intellij-armeria-plugin
+description: >-
+  IntelliJ Platform plugin conventions for this repository. Use when implementing
+  or editing plugin UI, run configurations, tool windows, inspections, actions,
+  or any Kotlin code under plugin/, plugin-shared/, or plugin-wizard/.
+---
+
+# IntelliJ Armeria plugin conventions
+
+This skill captures recurring GitHub Copilot review findings on plugin implementation
+in this repository. Apply it **during implementation**, not only before opening a PR.
+
+## When to use
+
+- Adding or changing tool windows, panels, actions, run configurations, inspections
+- Touching user-visible text, Swing renderers, or FormBuilder fields
+- Calling PSI/index APIs from UI or run-configuration startup paths
+- Deciding which Gradle module should own new code or tests
+
+## Module placement
+
+| Module | Owns |
+|--------|------|
+| `plugin-route-analysis/` | Route/Client collectors, PSI analysis, route-related unit/fixture tests |
+| `plugin-shared/` | Shared bundle helpers, cross-cutting PSI utilities, test fixtures |
+| `plugin-wizard/` | New-project/module wizard, file templates, starter resources |
+| `plugin/` | `plugin.xml` wiring, UI panels/actions, run configs, inspection registration |
+
+Do not put collector logic in `plugin/` when it belongs in `plugin-route-analysis/`.
+Do not add route-analysis tests under `plugin/src/test` when the class under test lives
+in `plugin-route-analysis/`.
+
+## Internationalization (i18n)
+
+All user-visible strings must go through `message(...)` with keys in
+`plugin-shared/src/main/resources/messages/ArmeriaBundle.properties`.
+
+```kotlin
+// Good
+add(object : DumbAwareAction(message("route.explorer.action.refresh")) { ... })
+
+// Bad — hard-coded English in UI
+statusLabel.text = "Refreshing Armeria routes..."
+```
+
+Additional rules Copilot repeatedly flags:
+
+- **FormBuilder labels** — match existing plugin style; field labels use a trailing colon.
+- **Properties file hygiene** — no duplicate keys; keep `[Unreleased]` changelog templates intact.
+- **Stable identity** — when restoring tree selection or comparing routes, use stable fields
+  (`routeMatch`, `httpMethod`, registration key), not localized labels like `methodLabel`.
+- **HTML in renderers** — escape dynamic values (`descriptionText`, decorator names, unresolved
+  expressions) before embedding in HTML tooltips; unresolved PSI text may contain `<` or `&`.
+
+## Optional Kotlin plugin safety
+
+Kotlin support is optional. Classes loaded on every IDE startup must not hard-reference
+Kotlin plugin types (`KotlinFileType`, `KtFile`, `KtNamedFunction`, etc.) at the class level.
+
+```kotlin
+// Bad — can cause NoClassDefFoundError when Kotlin plugin is absent/disabled
+import org.jetbrains.kotlin.idea.KotlinFileType
+FileTypeIndex.getFiles(KotlinFileType.INSTANCE, scope)
+
+// Good — guard and delegate to a Kotlin-only helper loaded only when available
+if (isKotlinPluginAvailable()) {
+    ArmeriaKotlinRouteCollector.collect(...)
+}
+```
+
+Checklist:
+
+1. Gate Kotlin paths with `isKotlinPluginAvailable()` (plugin installed **and** enabled).
+2. Keep Kotlin-specific imports in `ArmeriaKotlin*` files, not in shared entry points like
+   `ArmeriaRouteCollector` unless the class is only loaded when Kotlin is present.
+3. Prefer extracting Kotlin iteration into `ArmeriaKotlinRouteCollector` / `ArmeriaKotlin*Support`.
+
+## Index readiness and dumb mode
+
+Index-backed APIs (`FileTypeIndex`, `AnnotatedElementsSearch`, `ReferencesSearch`,
+`resolveMethod`, full-project `collect`) throw `IndexNotReadyException` while indexing.
+
+| Context | Required handling |
+|---------|-------------------|
+| Run configuration startup (`execute`, `createState`) | Best-effort: catch `IndexNotReadyException`, return `null`/skip feature |
+| Tool window registered `DumbAware` | Defer index-heavy refresh until smart mode, or catch and show empty state |
+| Background refresh | Do not assume indices are ready on first open |
+
+Existing pattern: `ArmeriaRunProfileState.resolveDocServiceUrl()` catches
+`IndexNotReadyException` and skips the console hint.
+
+## Background work and UI lifecycle
+
+Route/client explorer refresh uses `ReadAction.nonBlocking`, not blocking `ReadAction.run`
+on the EDT.
+
+Required patterns:
+
+```kotlin
+ReadAction.nonBlocking<List<ArmeriaRoute>> { ArmeriaRouteCollector.collect(project) }
+    .coalesceBy(this)          // collapse duplicate refreshes
+    .expireWith(this)          // cancel when panel/tool window is disposed
+    .finishOnUiThread(ModalityState.defaultModalityState()) { routes -> updateTree(routes) }
+    .submit(AppExecutorUtil.getAppExecutorService())
+```
+
+Never call heavy `ArmeriaRouteCollector.collect()` synchronously inside `execute()` or
+action `actionPerformed` without a documented reason.
+
+## Run configuration entry points
+
+When detecting JVM `main` classes:
+
+- Use `PsiMethodUtil.hasMainInClass` / `hasMainMethod` / `findMainMethod`.
+- Do **not** treat any `static` method named `main` as valid — invalid signatures
+  (`static void main()`, `static int main(String[])`) are not runnable.
+- For Kotlin top-level `main`, resolve via facade class (`MainKt`) in `ArmeriaKotlinMainClassSupport`.
+- Gate Armeria run configs on actual server usage (`Server.builder()` / Armeria application
+  references), not any `com.linecorp.armeria` import in the file.
+
+## IntelliJ API hygiene
+
+- Prefer `project.basePath` over deprecated `Project.baseDir`; avoid `File(".")` fallbacks.
+- Smart pointers: `SmartPointerManager.getInstance(project).createSmartPsiElementPointer(element)`.
+- Enum naming in this codebase: prefer ALL_CAPS entries (e.g. `RouteProtocol.HTTP`), not PascalCase.
+- `const val` names use `UPPER_SNAKE_CASE` when they are true constants.
+
+## Test task paths (multi-module)
+
+Match the Gradle task to the module that contains the test class:
+
+| Test location | Gradle task |
+|---------------|-------------|
+| `plugin-route-analysis/src/test` | `:plugin-route-analysis:test` |
+| `plugin-route-analysis/src/fastTest` | `:plugin-route-analysis:fastTest` |
+| `plugin/src/test` | `:plugin:test` |
+| `plugin-wizard/src/test` | `:plugin-wizard:test` |
+
+When documenting a test plan in a PR, use the module-qualified task. With Gradle MCP,
+set `taskPath` accordingly (e.g. `":plugin-route-analysis:test"`).
+
+## Related skills
+
+- `armeria-route-psi-analysis` — PSI collectors, route semantics, constant evaluation
+- `gradle-tapi-mcp` — build/test execution and `taskPath` usage
+- `copilot-review-preflight` — pre-PR checklist aggregating common review themes


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Past GitHub Copilot pull-request reviews on this repository surface the same implementation pitfalls repeatedly (hard-coded UI strings, PSI `expression.text` fallbacks, optional Kotlin plugin classloading, wrong Gradle test module paths, and virtualHost scoping mistakes). This PR adds three agent skills that encode those patterns so they can be applied during implementation, not only after review.

The skills are derived from an analysis of **318** Copilot review comments across merged and open PRs.

## Changes

- **`intellij-armeria-plugin`** — Plugin platform conventions: i18n via `ArmeriaBundle`, optional Kotlin plugin safety, index/dumb-mode handling, `ReadAction.nonBlocking` lifecycle, run-config main detection, multi-module placement, and correct Gradle test task paths
- **`armeria-route-psi-analysis`** — Route PSI collector patterns: constant evaluation over `expression.text`, forward-only `virtualHost` scoping, Java/Kotlin parity, decorator/annotated-service parsing, caching/index usage
- **`copilot-review-preflight`** — Aggregated pre-PR checklist with frequency table and routing to the specialized skills above (plus existing `gradle-tapi-mcp`)

Each skill is mirrored under `.cursor/skills/` (Cursor Cloud agents) and `.github/skills/` (GitHub Copilot agents).

## Test plan

- [x] Skills are valid Markdown with `name` / `description` frontmatter
- [x] Content cross-references existing skills (`gradle-tapi-mcp`) and rules (`pr-description-format.mdc`)
- [x] No code or build changes — documentation only

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f555c-87ae-7c48-8e14-93277f011c4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f555c-87ae-7c48-8e14-93277f011c4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

