### PR TITLE
docs: add token-efficient PR review response skill

### DIFF
--- a/.cursor/skills/copilot-review-preflight/SKILL.md
+++ b/.cursor/skills/copilot-review-preflight/SKILL.md
@@ -17,11 +17,13 @@ before requesting review.
 - Before opening or updating a PR (especially feature/fix PRs with plugin code)
 - When Copilot review has flagged similar issues on prior PRs in the same area
 - At the start of work in a new area — pick the specialized skill below first
+- **After review comments arrive** — switch to `pr-review-response` for triage, batch fixes, and resolving threads efficiently
 
 ## Specialized skills (read the relevant one during implementation)
 
 | Area | Skill |
 |------|-------|
+| **Addressing PR review comments** | `pr-review-response` |
 | UI, run configs, tool windows, inspections, module placement | `intellij-armeria-plugin` |
 | Route/client PSI collectors, duplicates, virtualHost | `armeria-route-psi-analysis` |
 | Gradle build/test via MCP | `gradle-tapi-mcp` |

--- a/.cursor/skills/pr-review-response/SKILL.md
+++ b/.cursor/skills/pr-review-response/SKILL.md
@@ -24,8 +24,9 @@ do not read the full skill unless Gradle MCP fails.
 
 ## Phase 1 — Fetch comments (minimal payload)
 
-**Do not** call `gh api repos/.../pulls/{n}/comments` without a filter — the REST
-endpoint returns full `diff_hunk` per comment (~50 KB for a typical Copilot review).
+**Do not** call `gh api repos/.../pulls/{n}/comments` — the REST endpoint always
+includes `diff_hunk` per comment (~50 KB for a typical Copilot review) and there is
+no query parameter to omit it.
 
 ### Preferred: GraphQL (resolved state + metadata only)
 
@@ -84,15 +85,16 @@ gh pr view N --json headRefName,baseRefName,title
 ```
 
 Review comments still require the GraphQL query above. There is no lightweight REST
-alternative: avoid `gh pr view N --comments` on large reviews (overview noise) and avoid
-`gh api repos/.../pulls/{n}/comments` (includes `diff_hunk` per comment). Retry or paginate
+alternative: `gh pr view N --comments` shows only issue-style conversation comments, not
+inline code review threads (and `gh pr view --json reviews` omits line comments too). Avoid
+`gh api repos/.../pulls/{n}/comments` (always includes `diff_hunk`). Retry or paginate
 GraphQL instead.
 
 ### Checkout once
 
 ```bash
 git fetch origin <headRefName>
-git checkout <headRefName>
+git checkout -B <headRefName> origin/<headRefName>
 ```
 
 Do not explore the repo on `main` if the PR branch exists.

--- a/.cursor/skills/pr-review-response/SKILL.md
+++ b/.cursor/skills/pr-review-response/SKILL.md
@@ -160,15 +160,16 @@ git commit -m "fix: address PR <N> review comments"
 Follow **`gradle-tapi-mcp`** constraints:
 
 1. `gradle_connection_status` — stop if not connected.
-2. **One** `gradle_run_tasks` with `[":<module>:compileKotlin", ":<module>:compileTestKotlin"]`, `background: true` on cold start.
+2. **One** `gradle_run_tasks` batching `compileKotlin` plus the test source-set compile task for the suite you will run (`compileTestKotlin` for `:test`; `compileFastTestKotlin` or `fastTestClasses` for `:fastTest` — `src/fastTest` is not covered by `compileTestKotlin`), `background: true` on cold start.
 3. Poll `gradle_get_build_status` until terminal — **do not** set `includeOutput: true` while `status: running` (reduces duplicate stdout in agent context). Enable output only on failure.
 4. **One** `gradle_run_tests` batching all affected test classes/methods in a single call.
 5. On failure, rerun **only** the failing method(s) — not the full class suite.
 
 | Changed code in | Compile | Tests |
 |-----------------|---------|-------|
-| `plugin/` | `:plugin:compileKotlin` | `:plugin:test` |
-| `plugin-route-analysis/` | `:plugin-route-analysis:compileKotlin` | `:plugin-route-analysis:fastTest` or `:test` |
+| `plugin/` | `:plugin:compileKotlin`, `:plugin:compileTestKotlin` | `:plugin:test` |
+| `plugin-route-analysis/` (`src/test`) | `:plugin-route-analysis:compileKotlin`, `:plugin-route-analysis:compileTestKotlin` | `:plugin-route-analysis:test` |
+| `plugin-route-analysis/` (`src/fastTest`) | `:plugin-route-analysis:compileKotlin`, `:plugin-route-analysis:compileFastTestKotlin` | `:plugin-route-analysis:fastTest` |
 
 Do **not** run `build` for review-fix verification unless the PR touched build logic or CI parity is explicitly required.
 

--- a/.cursor/skills/pr-review-response/SKILL.md
+++ b/.cursor/skills/pr-review-response/SKILL.md
@@ -29,6 +29,12 @@ endpoint returns full `diff_hunk` per comment (~50 KB for a typical Copilot revi
 
 ### Preferred: GraphQL (resolved state + metadata only)
 
+The query below caps at **100 review threads** and **5 comments per thread** (`first` limits).
+That is enough for typical Copilot/Thermos reviews; for larger PRs, paginate with
+`pageInfo { hasNextPage endCursor }` on `reviewThreads` (and on `comments` inside a thread
+when a thread has more than five replies) instead of raising `first` blindly — token cost
+grows with every extra node.
+
 ```bash
 gh api graphql -f query='
 {
@@ -38,10 +44,12 @@ gh api graphql -f query='
       headRefName
       baseRefName
       reviewThreads(first: 100) {
+        pageInfo { hasNextPage endCursor }
         nodes {
           id
           isResolved
           comments(first: 5) {
+            pageInfo { hasNextPage endCursor }
             nodes {
               databaseId
               body
@@ -66,13 +74,19 @@ Extract:
 | `body` + `path` + `line` | Triage and locate code |
 | `headRefName` | Checkout branch |
 
-### Fallback: unresolved threads only
+### Fallback: PR metadata only (not review threads)
+
+When you need branch names before running GraphQL (or to recover from a GraphQL failure),
+fetch PR metadata separately — **`gh pr view` does not return review threads or comment bodies**:
 
 ```bash
 gh pr view N --json headRefName,baseRefName,title
 ```
 
-Use GraphQL above; avoid `gh pr view N --comments` for large reviews (duplicates overview noise).
+Review comments still require the GraphQL query above. There is no lightweight REST
+alternative: avoid `gh pr view N --comments` on large reviews (overview noise) and avoid
+`gh api repos/.../pulls/{n}/comments` (includes `diff_hunk` per comment). Retry or paginate
+GraphQL instead.
 
 ### Checkout once
 
@@ -185,7 +199,7 @@ Report in the user’s language:
 
 | Anti-pattern | Cost | Alternative |
 |--------------|------|-------------|
-| REST `/pulls/comments` with diff_hunks | ~12k tok | GraphQL without hunks |
+| REST `/pulls/comments` with `diff_hunk` | ~12k tok | GraphQL without hunks |
 | 45+ tool rounds (fix → test → fix → test) | ~30k tok cumulative | Batch fixes, one verify |
 | Full file Write after Read | ~6k tok per file | StrReplace hunks |
 | `gradle_get_build_status` + `includeOutput: true` every 30s while running | Growing stdout each poll | Poll without output until terminal |

--- a/.cursor/skills/pr-review-response/SKILL.md
+++ b/.cursor/skills/pr-review-response/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: pr-review-response
+description: >-
+  Efficient workflow for triaging, fixing, and resolving GitHub PR review comments
+  (Copilot, Thermos, human reviewers). Optimized for token use and agent round-trips.
+  Use when asked to address PR review comments, resolve review threads, or fix
+  findings from a specific pull request number.
+---
+
+# PR review response (token-efficient)
+
+Workflow for **triage → batch fix → verify once → resolve threads**, derived from
+agent sessions on this repository (e.g. PR #208, ~45 tool rounds without this skill).
+
+Read **`cloud-github`** for PR tools and **`copilot-review-preflight`** for recurring
+fix patterns. Read **`gradle-tapi-mcp`** only for the verification subsection below —
+do not read the full skill unless Gradle MCP fails.
+
+## When to use
+
+- User asks to address / fix / resolve comments on PR *N*
+- After Copilot or Thermos review on an open PR
+- Before marking review threads resolved
+
+## Phase 1 — Fetch comments (minimal payload)
+
+**Do not** call `gh api repos/.../pulls/{n}/comments` without a filter — the REST
+endpoint returns full `diff_hunk` per comment (~50 KB for a typical Copilot review).
+
+### Preferred: GraphQL (resolved state + metadata only)
+
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "OWNER", name: "REPO") {
+    pullRequest(number: N) {
+      title
+      headRefName
+      baseRefName
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 5) {
+            nodes {
+              databaseId
+              body
+              path
+              line
+              author { login }
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+Extract:
+
+| Field | Use |
+|-------|-----|
+| `databaseId` | `ManagePullRequest` `resolve_comment` `comment_id` |
+| `isResolved` | Skip already resolved |
+| `body` + `path` + `line` | Triage and locate code |
+| `headRefName` | Checkout branch |
+
+### Fallback: unresolved threads only
+
+```bash
+gh pr view N --json headRefName,baseRefName,title
+```
+
+Use GraphQL above; avoid `gh pr view N --comments` for large reviews (duplicates overview noise).
+
+### Checkout once
+
+```bash
+git fetch origin <headRefName>
+git checkout <headRefName>
+```
+
+Do not explore the repo on `main` if the PR branch exists.
+
+## Phase 2 — Triage (before reading code)
+
+For each **unresolved** thread, record:
+
+| Thread | Valid? | Priority | Action |
+|--------|--------|----------|--------|
+| … | yes/no | P0–P3 | fix / skip + reply |
+
+**Priority guide**
+
+| Priority | Examples |
+|----------|----------|
+| **P0** | Crashes (`NoClassDefFoundError`, `IndexNotReadyException`), wrong results in production paths |
+| **P1** | Real bugs, security, broken navigation/resolution for common cases |
+| **P2** | Performance, test stability, redundant work, misleading API usage |
+| **P3** | Style, dead code, unused variables |
+
+Skip invalid comments with a brief PR reply; do not implement speculative fixes.
+
+**Batch by file** — e.g. all `ArmeriaRouteNavigationSupport.kt` comments in one edit pass.
+
+## Phase 3 — Read code (targeted)
+
+| Do | Don't |
+|----|-------|
+| `Grep` for symbol / line from comment | Read entire large files |
+| `Read` with `offset`/`limit` around `line` | Re-read files already in context |
+| Read **one** specialized skill for the area | Read `gradle-tapi-mcp` in full |
+| Follow `copilot-review-preflight` checklist | Re-fetch PR comments |
+
+For optional Kotlin plugin issues, follow the **`ArmeriaClientCollector` / `ArmeriaKotlinClientCollector`** split pattern (guard with `PluginManagerCore.isLoaded`, no `Kt*` imports in always-loaded classes).
+
+## Phase 4 — Implement (single pass)
+
+1. Apply all accepted fixes per file before any Gradle run.
+2. Keep diffs minimal — one concern per hunk where possible.
+3. Add/adjust tests only when the comment is about missing coverage or you fixed a bug.
+4. For test fixtures: **reuse `setUp()` stubs** — do not duplicate Java FQCN annotations as Kotlin `annotation class` in the same fixture.
+
+Commit once before verification:
+
+```bash
+git add <paths>
+git commit -m "fix: address PR <N> review comments"
+```
+
+## Phase 5 — Verify (one compile + one test run)
+
+Follow **`gradle-tapi-mcp`** constraints:
+
+1. `gradle_connection_status` — stop if not connected.
+2. **One** `gradle_run_tasks` with `[":<module>:compileKotlin", ":<module>:compileTestKotlin"]`, `background: true` on cold start.
+3. Poll `gradle_get_build_status` until terminal — **do not** set `includeOutput: true` while `status: running` (reduces duplicate stdout in agent context). Enable output only on failure.
+4. **One** `gradle_run_tests` batching all affected test classes/methods in a single call.
+5. On failure, rerun **only** the failing method(s) — not the full class suite.
+
+| Changed code in | Compile | Tests |
+|-----------------|---------|-------|
+| `plugin/` | `:plugin:compileKotlin` | `:plugin:test` |
+| `plugin-route-analysis/` | `:plugin-route-analysis:compileKotlin` | `:plugin-route-analysis:fastTest` or `:test` |
+
+Do **not** run `build` for review-fix verification unless the PR touched build logic or CI parity is explicitly required.
+
+## Phase 6 — Push and resolve
+
+```bash
+git push -u origin <headRefName>
+```
+
+Resolve threads with **ManagePullRequest** `resolve_comment` — pass each `databaseId` from GraphQL. Resolve only after the fix is pushed.
+
+```
+action: resolve_comment
+branch_name: <headRefName>
+comment_id: <databaseId>
+```
+
+Update PR body via `update_pr` only when behavior changed materially — fold fixes into **Changes**, not a "review fixes" section (see `.cursor/rules/pr-description-format.mdc`).
+
+## Phase 7 — User summary
+
+Report in the user’s language:
+
+1. Per-comment validity and priority (table)
+2. What was fixed vs skipped
+3. Test command and result
+4. Link to PR
+
+## Token budget checklist
+
+- [ ] GraphQL used instead of REST review comments API
+- [ ] ≤ 1 branch checkout
+- [ ] Files read with offset/limit or Grep, not full-file unless refactoring
+- [ ] Gradle: ≤ 1 compile + ≤ 2 test MCP calls (full batch + optional single-method retry)
+- [ ] No `sleep` polling loops longer than needed — poll every 15–30s, no `includeOutput` until failed
+- [ ] `resolve_comment` batched in one agent turn (parallel tool calls)
+- [ ] Did not re-read `gradle-tapi-mcp` or `AGENTS.md` in full
+
+## Anti-patterns (observed in high-token sessions)
+
+| Anti-pattern | Cost | Alternative |
+|--------------|------|-------------|
+| REST `/pulls/comments` with diff_hunks | ~12k tok | GraphQL without hunks |
+| 45+ tool rounds (fix → test → fix → test) | ~30k tok cumulative | Batch fixes, one verify |
+| Full file Write after Read | ~6k tok per file | StrReplace hunks |
+| `gradle_get_build_status` + `includeOutput: true` every 30s while running | Growing stdout each poll | Poll without output until terminal |
+| Reading 16 KB gradle skill for a compile+test | ~4k tok | Use table above |
+| Six sequential `resolve_comment` turns | 6 round-trips | Parallel in one message |
+
+## Related skills
+
+| Need | Skill |
+|------|-------|
+| PR create/update body | `cloud-github` + `pr-description-format.mdc` |
+| Copilot recurring patterns | `copilot-review-preflight` |
+| Plugin / PSI conventions | `intellij-armeria-plugin` |
+| Route collectors | `armeria-route-psi-analysis` |
+| Gradle MCP details / failures | `gradle-tapi-mcp` |

--- a/.cursor/skills/pr-review-response/SKILL.md
+++ b/.cursor/skills/pr-review-response/SKILL.md
@@ -24,6 +24,13 @@ do not read the full skill unless Gradle MCP fails.
 
 ## Phase 1 — Fetch comments (minimal payload)
 
+Before any `gh` call in Cursor Cloud (see `.cursor/rules/cloud-github.mdc`):
+
+1. Resolve: `command -v gh` or `/exec-daemon/gh`
+2. Verify: `gh auth status`
+3. If either step fails, stop — do not install `gh` in agent sessions. Use
+   **ManagePullRequest** for PR create/update/resolve; retry GraphQL only after auth works.
+
 **Do not** call `gh api repos/.../pulls/{n}/comments` — the REST endpoint always
 includes `diff_hunk` per comment (~50 KB for a typical Copilot review) and there is
 no query parameter to omit it.
@@ -56,6 +63,9 @@ gh api graphql -f query='
               body
               path
               line
+              originalLine
+              startLine
+              originalStartLine
               author { login }
             }
           }
@@ -72,7 +82,7 @@ Extract:
 |-------|-----|
 | `databaseId` | `ManagePullRequest` `resolve_comment` `comment_id` |
 | `isResolved` | Skip already resolved |
-| `body` + `path` + `line` | Triage and locate code |
+| `body` + `path` + line fields | Triage and locate code — prefer `line`; when `line` is null (outdated thread), use `originalLine`; for multi-line comments use `startLine` / `originalStartLine` |
 | `headRefName` | Checkout branch |
 
 ### Fallback: PR metadata only (not review threads)
@@ -125,7 +135,7 @@ Skip invalid comments with a brief PR reply; do not implement speculative fixes.
 | Do | Don't |
 |----|-------|
 | `Grep` for symbol / line from comment | Read entire large files |
-| `Read` with `offset`/`limit` around `line` | Re-read files already in context |
+| `Read` with `offset`/`limit` around `line` (or `originalLine` when outdated) | Re-read files already in context |
 | Read **one** specialized skill for the area | Read `gradle-tapi-mcp` in full |
 | Follow `copilot-review-preflight` checklist | Re-fetch PR comments |
 
@@ -189,6 +199,7 @@ Report in the user’s language:
 
 ## Token budget checklist
 
+- [ ] `gh` preflight (`command -v gh`, `gh auth status`) before GraphQL
 - [ ] GraphQL used instead of REST review comments API
 - [ ] ≤ 1 branch checkout
 - [ ] Files read with offset/limit or Grep, not full-file unless refactoring


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a dedicated agent skill for addressing PR review comments (Copilot, Thermos, human) with lower token use and fewer tool round-trips. Derived from the PR #208 review-response session (~45 tool calls, ~80k tokens).

## Changes

- New `.cursor/skills/pr-review-response/SKILL.md` — phased workflow: `gh` preflight → GraphQL fetch → triage → batch fix → single compile/test verify → parallel `resolve_comment`
- GraphQL query documents `first` pagination limits (100 threads, 5 comments per thread) and `pageInfo` follow-up queries for larger reviews
- GraphQL fetches `line`, `originalLine`, `startLine`, and `originalStartLine` so outdated or multi-line threads locate code without extra round-trips
- Clarifies that `gh pr view --json` fetches PR metadata only, not review threads; REST `/pulls/comments` always includes `diff_hunk` (no filter to omit it)
- Phase 5 verification table distinguishes `compileTestKotlin` vs `compileFastTestKotlin` for `:test` vs `:fastTest` suites
- Documents anti-patterns (REST review comments with `diff_hunk`, per-fix test runs, polling with `includeOutput` while running)
- Cross-links from `copilot-review-preflight` when review comments arrive post-implementation

## Test plan

- [x] Skill follows existing frontmatter and table conventions in `.cursor/skills/`
- [x] Links to `cloud-github`, `copilot-review-preflight`, and `gradle-tapi-mcp` are valid paths
- [x] All Copilot review threads on PR #249 addressed and resolved

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55bb-0ec7-7250-8056-310a387778e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55bb-0ec7-7250-8056-310a387778e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

