### PR TITLE
docs: sync .github skills and clarify NON_HTTP Generate HTTP wording

### DIFF
--- a/.cursor/skills/armeria-route-psi-analysis/SKILL.md
+++ b/.cursor/skills/armeria-route-psi-analysis/SKILL.md
@@ -158,10 +158,12 @@ tokens) — fixing one call site while leaving siblings is a recurring miss.
 
 When emitting routes that are not PSI call-site registrations:
 
-1. **`RouteMatch` must match HTTP capability** — `RouteMatch.NON_HTTP` disables “Generate HTTP
-   Request” (supported only for gRPC) and drops method labels. Use `NON_HTTP` only for true
-   non-HTTP protocols (gRPC, Thrift, DocService). HTTP config routes (health/metrics/actuator)
-   use `RouteMatch.CONFIG` (or another HTTP-capable match still excluded from duplicate index).
+1. **`RouteMatch` must match HTTP capability** — “Generate HTTP Request” supports many HTTP
+   `RouteMatch` values (`ANNOTATED_HTTP`, `SERVICE`, `CONFIG`, `RUNTIME`, …). For
+   `RouteMatch.NON_HTTP` it is enabled **only for gRPC**; other `NON_HTTP` routes (Thrift,
+   DocService, port bindings) are unsupported and method labels are dropped. Use `NON_HTTP`
+   only for true non-HTTP protocols. HTTP config routes (health/metrics/actuator) use
+   `RouteMatch.CONFIG` (or another HTTP-capable match still excluded from duplicate index).
 2. **Distinct display paths** — Route Explorer renders pill + `path`. Port bindings must not use
    `path = "/"` (collides with real `/` routes); use a synthetic form such as `":<port>"`.
 3. **Multi-value fields in labels** — if config has multiple protocols, store/join all of them

--- a/.cursor/skills/armeria-route-psi-analysis/SKILL.md
+++ b/.cursor/skills/armeria-route-psi-analysis/SKILL.md
@@ -178,9 +178,9 @@ When emitting routes that are not PSI call-site registrations:
 
 - gRPC/proto routes: use Proto Editor PSI when available; cache merged proto routes
   (`mergeProtoRoutesIfEnabled`) to avoid repeated merges.
-- Spring Boot config collectors (`ArmeriaSpringConfigRouteCollector`, Java `@Bean` collectors):
-  follow the hand-rolled parser and synthetic-route rules above; guard optional Spring/Kotlin PSI
-  behind availability checks.
+- Spring Boot config collectors: `ArmeriaSpringConfigRouteCollector` (YAML/properties) and
+  `ArmeriaSpringBootRouteCollector` (Java `@Bean` PSI walks) — follow the hand-rolled parser and
+  synthetic-route rules above; guard optional Spring/Kotlin PSI behind availability checks.
 - GraphQL / Thrift deduplication: align dedupe keys with HTTP route keys (path + method + host).
 
 ## Regression tests

--- a/.cursor/skills/copilot-review-preflight/SKILL.md
+++ b/.cursor/skills/copilot-review-preflight/SKILL.md
@@ -58,7 +58,7 @@ config-parser findings). Use it as a final pass before requesting review.
 - [ ] Unquoted YAML scalars/lists strip trailing `# …`; comment-only values are empty
 - [ ] Nested YAML keys matched only at parent indentation (not first-anywhere)
 - [ ] `.properties`: last-wins (including indexed keys); `=` and `:` delimiters; line-anchored regexes that skip `#`/`!` comments
-- [ ] HTTP config routes use an HTTP-capable `RouteMatch` (not `NON_HTTP`); DocService/gRPC stay `NON_HTTP`
+- [ ] HTTP config routes use an HTTP-capable `RouteMatch` (not `NON_HTTP`); use `NON_HTTP` only for true non-HTTP protocols (DocService, Thrift, port bindings); note “Generate HTTP Request” for `NON_HTTP` is enabled **only for gRPC**
 - [ ] Synthetic routes use distinct display paths (e.g. `":8080"`, not `"/"` for port bindings)
 - [ ] Multi-value config (protocols, includes) reflected in emitted labels, not truncated to first
 

--- a/.cursor/skills/copilot-review-preflight/SKILL.md
+++ b/.cursor/skills/copilot-review-preflight/SKILL.md
@@ -69,6 +69,7 @@ config-parser findings). Use it as a final pass before requesting review.
 - [ ] Gradle MCP docs match the pinned server version in `install-gradle-tapi-mcp.sh`
 - [ ] Avoid environment-specific assertions (`DISPLAY=:1`) in durable docs — phrase as sandbox-relative
 - [ ] MCP config uses `stdio` transport; repo root derived from script path, not fragile `pwd`
+- [ ] When editing a skill that also lives under `.github/skills/`, update **both** copies (GitHub Copilot agents load `.github/skills/…`)
 - [ ] PR description is a feature summary (not a "review fixes" changelog) per `pr-description-format.mdc`
 
 ## Top recurring Copilot themes (frequency)

--- a/.github/skills/armeria-route-psi-analysis/SKILL.md
+++ b/.github/skills/armeria-route-psi-analysis/SKILL.md
@@ -3,7 +3,8 @@ name: armeria-route-psi-analysis
 description: >-
   PSI and route-analysis implementation patterns for plugin-route-analysis. Use when
   editing ArmeriaRouteCollector, decorator/registration collectors, duplicate detection,
-  virtualHost scoping, annotated-service parsing, or related regression tests.
+  virtualHost scoping, annotated-service parsing, Spring YAML/properties config collectors,
+  or related regression tests.
 ---
 
 # Armeria route PSI analysis
@@ -15,6 +16,7 @@ collectors. Apply it when changing code under `plugin-route-analysis/`.
 
 - `ArmeriaRouteCollector`, `ArmeriaKotlinRouteCollector`, extended-registration collectors
 - `ArmeriaRouteSupport`, decorator/annotated metadata helpers
+- Spring Boot config collectors (`ArmeriaSpringConfigRouteCollector` and related)
 - Duplicate route/registration inspections and indexes
 - Java or Kotlin fixture tests for route discovery
 
@@ -105,12 +107,80 @@ Preferred approach (already used in `ArmeriaRouteCollector`):
 
 Do not rescan fallback-processed files twice in one collection pass.
 
+### FilenameIndex: name-driven lookup, not extension scans
+
+When collecting a small, known filename set (e.g. `application*.{yml,yaml,properties}`):
+
+```kotlin
+// Bad — walks every YAML/properties file in large Spring repos on each recompute
+FilenameIndex.getAllFilesByExt(project, "yml", scope)
+    .filter { isApplicationConfigFile(it.name) }
+
+// Good — filter filenames first, then resolve only matching VirtualFiles
+FilenameIndex.getAllFilenames(project)
+    .asSequence()
+    .filter { isApplicationConfigFile(it) }
+    .flatMap { name -> FilenameIndex.getVirtualFilesByName(name, scope) }
+    .sortedWith(compareBy({ it.path }, { it.name }))
+```
+
+Sort candidates before any “first wins” dedupe — `FilenameIndex` iteration order is not stable,
+so unsorted first-wins produces non-deterministic Route Explorer output across refreshes.
+
+## Hand-rolled YAML / `.properties` parsers
+
+Prefer a real parser when available. When keeping a lightweight text parser (as in
+`ArmeriaSpringConfigRouteCollector`), Copilot repeatedly flags the same gaps (PR #211):
+
+### YAML
+
+| Rule | Why |
+|------|-----|
+| Strip trailing `# …` on **unquoted** scalars, list items, and inline mapping values | Otherwise `protocols: http # primary` becomes tokens `http`, `#`, `primary` |
+| Treat comment-only values (`include: # comment`) as empty | Leading `#` is not matched by `\s+#.*$` alone |
+| Do **not** strip inside quoted strings | `"# not a comment"` must stay intact |
+| Match nested keys only at the **parent block’s indentation level** | First-anywhere `ports:` can pick up `armeria:\n  foo:\n    ports:` |
+
+Apply stripping in **every** scalar path (inline mapping, nested list, `readYamlScalar`, include
+tokens) — fixing one call site while leaving siblings is a recurring miss.
+
+### Spring / Java `.properties`
+
+| Rule | Why |
+|------|-----|
+| Last occurrence of a key wins | Spring/Java Properties semantics; `Regex.find` returns the first match |
+| Indexed keys (`ports[0].protocols[0]`, `include[0]`) overwrite that index, not union | Appending then `distinct()` keeps stale values |
+| Unindexed repeats (`include=docs` then `include=health`) are last-wins, not a set union | |
+| Accept both `=` and `:` delimiters | Spring allows either |
+| Anchor patterns to line start (`(?m)^…`) and skip `#` / `!` comment lines | Unanchored regex matches `# armeria.ports[0].port=8080` |
+
+## Synthetic / config-sourced route emission
+
+When emitting routes that are not PSI call-site registrations:
+
+1. **`RouteMatch` must match HTTP capability** — “Generate HTTP Request” supports many HTTP
+   `RouteMatch` values (`ANNOTATED_HTTP`, `SERVICE`, `CONFIG`, `RUNTIME`, …). For
+   `RouteMatch.NON_HTTP` it is enabled **only for gRPC**; other `NON_HTTP` routes (Thrift,
+   DocService, port bindings) are unsupported and method labels are dropped. Use `NON_HTTP`
+   only for true non-HTTP protocols. HTTP config routes (health/metrics/actuator) use
+   `RouteMatch.CONFIG` (or another HTTP-capable match still excluded from duplicate index).
+2. **Distinct display paths** — Route Explorer renders pill + `path`. Port bindings must not use
+   `path = "/"` (collides with real `/` routes); use a synthetic form such as `":<port>"`.
+3. **Multi-value fields in labels** — if config has multiple protocols, store/join all of them
+   in `protocol` / summary text, not only `protocols.first()`.
+4. **Dedupe keys include distinguishing fields** — e.g. internal-service path alone is insufficient
+   when `internal-services.port` differs across `application.yml` vs `.properties`; include port
+   (and profile) in the key, or encode explicit precedence.
+5. **Class names match scope** — if a collector parses YAML **and** properties, do not keep a
+   `*Yaml*` type name; prefer a format-neutral name (`ArmeriaSpringConfigRouteCollector`).
+
 ## Proto / gRPC / Spring routes
 
 - gRPC/proto routes: use Proto Editor PSI when available; cache merged proto routes
   (`mergeProtoRoutesIfEnabled`) to avoid repeated merges.
-- Spring Boot YAML/Java config collectors: guard optional Kotlin/Spring PSI behind availability
-  checks; keep Spring-specific code in `ArmeriaSpringBootRouteCollector`.
+- Spring Boot config collectors (`ArmeriaSpringConfigRouteCollector`, Java `@Bean` collectors):
+  follow the hand-rolled parser and synthetic-route rules above; guard optional Spring/Kotlin PSI
+  behind availability checks.
 - GraphQL / Thrift deduplication: align dedupe keys with HTTP route keys (path + method + host).
 
 ## Regression tests

--- a/.github/skills/armeria-route-psi-analysis/SKILL.md
+++ b/.github/skills/armeria-route-psi-analysis/SKILL.md
@@ -178,9 +178,9 @@ When emitting routes that are not PSI call-site registrations:
 
 - gRPC/proto routes: use Proto Editor PSI when available; cache merged proto routes
   (`mergeProtoRoutesIfEnabled`) to avoid repeated merges.
-- Spring Boot config collectors (`ArmeriaSpringConfigRouteCollector`, Java `@Bean` collectors):
-  follow the hand-rolled parser and synthetic-route rules above; guard optional Spring/Kotlin PSI
-  behind availability checks.
+- Spring Boot config collectors: `ArmeriaSpringConfigRouteCollector` (YAML/properties) and
+  `ArmeriaSpringBootRouteCollector` (Java `@Bean` PSI walks) — follow the hand-rolled parser and
+  synthetic-route rules above; guard optional Spring/Kotlin PSI behind availability checks.
 - GraphQL / Thrift deduplication: align dedupe keys with HTTP route keys (path + method + host).
 
 ## Regression tests

--- a/.github/skills/copilot-review-preflight/SKILL.md
+++ b/.github/skills/copilot-review-preflight/SKILL.md
@@ -58,7 +58,7 @@ config-parser findings). Use it as a final pass before requesting review.
 - [ ] Unquoted YAML scalars/lists strip trailing `# …`; comment-only values are empty
 - [ ] Nested YAML keys matched only at parent indentation (not first-anywhere)
 - [ ] `.properties`: last-wins (including indexed keys); `=` and `:` delimiters; line-anchored regexes that skip `#`/`!` comments
-- [ ] HTTP config routes use an HTTP-capable `RouteMatch` (not `NON_HTTP`); DocService/gRPC stay `NON_HTTP`
+- [ ] HTTP config routes use an HTTP-capable `RouteMatch` (not `NON_HTTP`); use `NON_HTTP` only for true non-HTTP protocols (DocService, Thrift, port bindings); note “Generate HTTP Request” for `NON_HTTP` is enabled **only for gRPC**
 - [ ] Synthetic routes use distinct display paths (e.g. `":8080"`, not `"/"` for port bindings)
 - [ ] Multi-value config (protocols, includes) reflected in emitted labels, not truncated to first
 

--- a/.github/skills/copilot-review-preflight/SKILL.md
+++ b/.github/skills/copilot-review-preflight/SKILL.md
@@ -8,22 +8,24 @@ description: >-
 
 # Copilot review preflight
 
-This skill aggregates patterns from **318** GitHub Copilot pull-request review comments
-on `nise-nabe/armeria-intellij-plugin` (through July 2026). Use it as a final pass
-before requesting review.
+This skill aggregates patterns from **337+** GitHub Copilot pull-request review comments
+on `nise-nabe/armeria-intellij-plugin` (through July 2026, including PR #211’s 19 Spring
+config-parser findings). Use it as a final pass before requesting review.
 
 ## When to use
 
 - Before opening or updating a PR (especially feature/fix PRs with plugin code)
 - When Copilot review has flagged similar issues on prior PRs in the same area
 - At the start of work in a new area — pick the specialized skill below first
+- **After review comments arrive** — switch to `pr-review-response` for triage, batch fixes, and resolving threads efficiently
 
 ## Specialized skills (read the relevant one during implementation)
 
 | Area | Skill |
 |------|-------|
+| **Addressing PR review comments** | `pr-review-response` |
 | UI, run configs, tool windows, inspections, module placement | `intellij-armeria-plugin` |
-| Route/client PSI collectors, duplicates, virtualHost | `armeria-route-psi-analysis` |
+| Route/client PSI collectors, Spring YAML/properties, virtualHost | `armeria-route-psi-analysis` |
 | Gradle build/test via MCP | `gradle-tapi-mcp` |
 | PR body format | `.cursor/rules/pr-description-format.mdc` |
 
@@ -47,7 +49,18 @@ before requesting review.
 - [ ] Java and Kotlin collectors stay in parity; shared reducers updated together
 - [ ] Decorator chains, annotated services, and proto/grpc routes have regression tests
 - [ ] Collection uses indices/cache; no accidental full-project rescan
+- [ ] Filename-driven `FilenameIndex` lookups (not `getAllFilesByExt` + filter) for known names
+- [ ] “First wins” collectors sort inputs; dedupe keys include all distinguishing fields
 - [ ] Test plan uses `:plugin-route-analysis:test` or `fastTest`, not `:plugin:test`
+
+### Hand-rolled Spring YAML / `.properties` parsers
+
+- [ ] Unquoted YAML scalars/lists strip trailing `# …`; comment-only values are empty
+- [ ] Nested YAML keys matched only at parent indentation (not first-anywhere)
+- [ ] `.properties`: last-wins (including indexed keys); `=` and `:` delimiters; line-anchored regexes that skip `#`/`!` comments
+- [ ] HTTP config routes use an HTTP-capable `RouteMatch` (not `NON_HTTP`); DocService/gRPC stay `NON_HTTP`
+- [ ] Synthetic routes use distinct display paths (e.g. `":8080"`, not `"/"` for port bindings)
+- [ ] Multi-value config (protocols, includes) reflected in emitted labels, not truncated to first
 
 ### Agent docs and shell scripts (`.cursor/`, `.github/`, `AGENTS.md`)
 
@@ -56,6 +69,7 @@ before requesting review.
 - [ ] Gradle MCP docs match the pinned server version in `install-gradle-tapi-mcp.sh`
 - [ ] Avoid environment-specific assertions (`DISPLAY=:1`) in durable docs — phrase as sandbox-relative
 - [ ] MCP config uses `stdio` transport; repo root derived from script path, not fragile `pwd`
+- [ ] When editing a skill that also lives under `.github/skills/`, update **both** copies (GitHub Copilot agents load `.github/skills/…`)
 - [ ] PR description is a feature summary (not a "review fixes" changelog) per `pr-description-format.mdc`
 
 ## Top recurring Copilot themes (frequency)
@@ -68,6 +82,9 @@ before requesting review.
 | Hard-coded / non-localized UI strings | 16 | `intellij-armeria-plugin` |
 | PSI literal fallback / misleading paths | 15+ | `armeria-route-psi-analysis` |
 | Annotated service / decorator parsing | 30+ | `armeria-route-psi-analysis` |
+| Hand-rolled YAML/properties parsing (comments, last-wins, delimiters) | 11+ (PR #211) | `armeria-route-psi-analysis` |
+| Synthetic route emission (`RouteMatch`, display path, dedupe keys) | 6+ (PR #211) | `armeria-route-psi-analysis` |
+| FilenameIndex scan vs name-driven lookup / non-deterministic order | 3+ (PR #211) | `armeria-route-psi-analysis` |
 | Optional Kotlin plugin classloading | 11+ | `intellij-armeria-plugin` |
 | Gradle MCP version/doc drift | 7+ | `gradle-tapi-mcp` |
 | Bash script executable-bit assumptions | 5+ | checklist above |
@@ -77,8 +94,9 @@ before requesting review.
 
 1. Read the specialized skill for your change area.
 2. Run compile/tests via Gradle MCP with the correct module `taskPath` (see `gradle-tapi-mcp`).
-3. Scan the diff for `expression.text`, hard-coded `"` strings in UI code, and Kotlin imports
-   in shared collectors.
+3. Scan the diff for `expression.text`, hard-coded `"` strings in UI code, Kotlin imports
+   in shared collectors, and (for config parsers) missing comment stripping / first-match
+   `.properties` reads / `getAllFilesByExt` scans.
 4. Write the PR body as Summary / Changes / Test plan — fold any review-driven edits into
    **Changes**, do not add "Copilot review fixes" sections.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to Copilot review on #258. That PR updated `.cursor/skills/…`, but GitHub Copilot agents load `.github/skills/…`, so the mirrored copies were stale. This branch also clarifies `RouteMatch.NON_HTTP` wording for “Generate HTTP Request” and adds a dual-copy sync checklist item.

Because this branch stacks on #258, merge #258 first (or merge this PR alone if #258 is closed in favor of it). Prefer merging #258 then this PR once GitHub retargets, or merge this PR if you want both the skill content and the `.github` sync in one shot.

## Changes

- Sync `.github/skills/armeria-route-psi-analysis` and `.github/skills/copilot-review-preflight` with the updated `.cursor` copies
- Reword `RouteMatch.NON_HTTP` guidance: Generate HTTP Request supports many HTTP matches; for `NON_HTTP` it is enabled only for gRPC
- Align the preflight checklist bullet with that semantics (DocService/Thrift/port bindings stay `NON_HTTP`; gRPC is the only `NON_HTTP` case that enables Generate HTTP Request)
- Name both Spring collectors explicitly: `ArmeriaSpringConfigRouteCollector` (YAML/properties) and `ArmeriaSpringBootRouteCollector` (Java `@Bean` PSI)
- Add a preflight checklist item to update both `.cursor/skills` and `.github/skills` when a skill exists in both places
- Includes the #258 skill content (FilenameIndex, YAML/properties parser rules, synthetic route emission, preflight checklist/theme rows)

## Depends on

- #258 (stacked; this branch contains #258 commits plus the follow-up)

## Test plan

- [x] `diff` confirms `.cursor` and `.github` copies of both skills match after sync
- [x] Verified `ArmeriaHttpRequestGenerator.supports` treats many HTTP `RouteMatch` values as supported and `NON_HTTP` only when gRPC
- [x] Docs/skills only — no plugin code changes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7241-eb56-7ecf-85a9-bff7c5eef1c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7241-eb56-7ecf-85a9-bff7c5eef1c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

