### PR TITLE
docs: capture PR #212 Copilot patterns in agent skills

### DIFF
--- a/.cursor/skills/armeria-route-psi-analysis/SKILL.md
+++ b/.cursor/skills/armeria-route-psi-analysis/SKILL.md
@@ -140,9 +140,14 @@ Prefer a real parser when available. When keeping a lightweight text parser (as 
 | Treat comment-only values (`include: # comment`) as empty | Leading `#` is not matched by `\s+#.*$` alone |
 | Do **not** strip inside quoted strings | `"# not a comment"` must stay intact |
 | Match nested keys only at the **parent block’s indentation level** | First-anywhere `ports:` can pick up `armeria:\n  foo:\n    ports:` |
+| List scalars with `:` are **not** always inline mappings (PR #212) | `- http://example.com` must stay a scalar; require `:` + whitespace (or EOL) before treating as `key: value` |
+| Guard empty indent stack before `stack.last()` | Top-level YAML lists (or bad indentation) otherwise throw / skip the whole list silently |
 
 Apply stripping in **every** scalar path (inline mapping, nested list, `readYamlScalar`, include
 tokens) — fixing one call site while leaving siblings is a recurring miss.
+
+Add a regression test for colon-bearing list scalars (`- http://…`) whenever the flattener
+changes — this edge case has already slipped past review once.
 
 ### Spring / Java `.properties`
 

--- a/.cursor/skills/copilot-review-preflight/SKILL.md
+++ b/.cursor/skills/copilot-review-preflight/SKILL.md
@@ -8,9 +8,10 @@ description: >-
 
 # Copilot review preflight
 
-This skill aggregates patterns from **337+** GitHub Copilot pull-request review comments
+This skill aggregates patterns from **350+** GitHub Copilot pull-request review comments
 on `nise-nabe/armeria-intellij-plugin` (through July 2026, including PR #211’s 19 Spring
-config-parser findings). Use it as a final pass before requesting review.
+config-parser findings and PR #212’s 17 Spring Boot Config explorer findings). Use it as a
+final pass before requesting review.
 
 ## When to use
 
@@ -33,14 +34,25 @@ config-parser findings). Use it as a final pass before requesting review.
 
 ### Plugin feature code (`plugin/`, `plugin-shared/`, `plugin-wizard/`)
 
-- [ ] User-visible strings use `message(...)` + `ArmeriaBundle.properties` (no hard-coded English)
+- [ ] User-visible strings use `message(...)` + `ArmeriaBundle.properties` (no hard-coded English, including completion docs / tooltip maps)
+- [ ] No unused bundle keys; status copy lists every file type / profile variant actually scanned
 - [ ] HTML tooltips escape dynamic PSI text
 - [ ] Tree selection / equality uses stable route fields, not localized labels
 - [ ] Background PSI uses `ReadAction.nonBlocking` + `expireWith` + `coalesceBy`
 - [ ] Index-heavy paths handle `IndexNotReadyException` or defer until smart mode
 - [ ] Kotlin-specific types are not imported in always-loaded classes without guards
+- [ ] Optional `*-integration.xml` holds only extensions that need that plugin; tool windows / explorers that work without it stay in main `plugin.xml`
+- [ ] Table/tree renderers reset tooltip/font every cell; use `convertRowIndexToModel`; clear model on refresh failure
+- [ ] Config/`VirtualFile` text uses charset-aware VFS APIs (`LoadTextUtil`), not hard-coded UTF-8
+- [ ] Hot-path filename/key checks use hoisted constants, not per-call `setOf(...)`
 - [ ] Run-config `main` detection uses `PsiMethodUtil`, not any `static main`
 - [ ] Code and tests live in the correct module (see `intellij-armeria-plugin`)
+
+### YAML / properties completion (when adding contributors)
+
+- [ ] Prefix-match the leaf lookup string, not the full dotted path
+- [ ] Key-path walk includes `YAMLKeyValue` parents (nested block / flow mappings)
+- [ ] No dangling `" — "` (or similar) when documentation is empty
 
 ### Route analysis (`plugin-route-analysis/`)
 
@@ -57,6 +69,8 @@ config-parser findings). Use it as a final pass before requesting review.
 
 - [ ] Unquoted YAML scalars/lists strip trailing `# …`; comment-only values are empty
 - [ ] Nested YAML keys matched only at parent indentation (not first-anywhere)
+- [ ] YAML list items with `:` (e.g. `- http://…`) stay scalars unless `:` is followed by whitespace/EOL
+- [ ] Flatten/stack walks guard empty indent stack (top-level lists must not throw / silently skip)
 - [ ] `.properties`: last-wins (including indexed keys); `=` and `:` delimiters; line-anchored regexes that skip `#`/`!` comments
 - [ ] HTTP config routes use an HTTP-capable `RouteMatch` (not `NON_HTTP`); use `NON_HTTP` only for true non-HTTP protocols (DocService, Thrift, port bindings); note “Generate HTTP Request” for `NON_HTTP` is enabled **only for gRPC**
 - [ ] Synthetic routes use distinct display paths (e.g. `":8080"`, not `"/"` for port bindings)
@@ -79,12 +93,15 @@ config-parser findings). Use it as a final pass before requesting review.
 | Multi-module placement / wrong test task | 21+ | `intellij-armeria-plugin` |
 | Run configuration / main entry detection | 19 | `intellij-armeria-plugin` |
 | Async UI lifecycle (`expireWith`, dispose) | 16 | `intellij-armeria-plugin` |
-| Hard-coded / non-localized UI strings | 16 | `intellij-armeria-plugin` |
+| Hard-coded / non-localized UI strings | 16+ (PR #212 docs maps) | `intellij-armeria-plugin` |
 | PSI literal fallback / misleading paths | 15+ | `armeria-route-psi-analysis` |
 | Annotated service / decorator parsing | 30+ | `armeria-route-psi-analysis` |
-| Hand-rolled YAML/properties parsing (comments, last-wins, delimiters) | 11+ (PR #211) | `armeria-route-psi-analysis` |
+| Hand-rolled YAML/properties parsing (comments, last-wins, delimiters, `:` in list scalars) | 14+ (PR #211/#212) | `armeria-route-psi-analysis` |
 | Synthetic route emission (`RouteMatch`, display path, dedupe keys) | 6+ (PR #211) | `armeria-route-psi-analysis` |
 | FilenameIndex scan vs name-driven lookup / non-deterministic order | 3+ (PR #211) | `armeria-route-psi-analysis` |
+| Optional dependency config owning core UI (`*-integration.xml`) | 2+ (PR #212) | `intellij-armeria-plugin` |
+| Swing renderer reuse / view→model index / stale model on error | 3+ (PR #212) | `intellij-armeria-plugin` |
+| YAML completion path / leaf prefix / empty doc tails | 3+ (PR #212) | `intellij-armeria-plugin` |
 | Optional Kotlin plugin classloading | 11+ | `intellij-armeria-plugin` |
 | Gradle MCP version/doc drift | 7+ | `gradle-tapi-mcp` |
 | Bash script executable-bit assumptions | 5+ | checklist above |
@@ -94,9 +111,11 @@ config-parser findings). Use it as a final pass before requesting review.
 
 1. Read the specialized skill for your change area.
 2. Run compile/tests via Gradle MCP with the correct module `taskPath` (see `gradle-tapi-mcp`).
-3. Scan the diff for `expression.text`, hard-coded `"` strings in UI code, Kotlin imports
-   in shared collectors, and (for config parsers) missing comment stripping / first-match
-   `.properties` reads / `getAllFilesByExt` scans.
+3. Scan the diff for `expression.text`, hard-coded `"` strings in UI code (including
+   documentation maps), Kotlin imports in shared collectors, tool windows registered only
+   under optional `*-integration.xml`, renderer state that is set but never cleared, and
+   (for config parsers) missing comment stripping / `:`-in-list-scalar handling / first-match
+   `.properties` reads / `getAllFilesByExt` scans / hard-coded UTF-8 `contentsToByteArray`.
 4. Write the PR body as Summary / Changes / Test plan — fold any review-driven edits into
    **Changes**, do not add "Copilot review fixes" sections.
 

--- a/.cursor/skills/intellij-armeria-plugin/SKILL.md
+++ b/.cursor/skills/intellij-armeria-plugin/SKILL.md
@@ -47,11 +47,61 @@ statusLabel.text = "Refreshing Armeria routes..."
 Additional rules Copilot repeatedly flags:
 
 - **FormBuilder labels** — match existing plugin style; field labels use a trailing colon.
-- **Properties file hygiene** — no duplicate keys; keep `[Unreleased]` changelog templates intact.
+- **Properties file hygiene** — no duplicate keys; no unused keys added “for later”; keep
+  `[Unreleased]` changelog templates intact. Completion docs / tooltip descriptions are
+  user-visible — route them through the bundle too (not hard-coded English maps).
+- **Status copy matches capability** — if the collector also scans `application.yaml` and
+  profile variants (`application-dev.properties`), the empty/status string must say so.
 - **Stable identity** — when restoring tree selection or comparing routes, use stable fields
   (`routeMatch`, `httpMethod`, registration key), not localized labels like `methodLabel`.
 - **HTML in renderers** — escape dynamic values (`descriptionText`, decorator names, unresolved
   expressions) before embedding in HTML tooltips; unresolved PSI text may contain `<` or `&`.
+
+## Optional dependency config files (`*-integration.xml`)
+
+Optional config files loaded via `config-file` / `depends` (YAML, Kotlin, Spring, …) must
+contain **only** extensions that require that plugin. Copilot flags core UI registered only
+behind an optional dependency (PR #212):
+
+| Put in main `plugin.xml` | Put in optional `*-integration.xml` |
+|--------------------------|-------------------------------------|
+| Tool windows, actions, explorers that work without the optional plugin | Completion contributors, PSI annotators, language-specific handlers |
+
+Example: Spring Boot Config explorer works for `.properties` without the YAML plugin — register
+the tool window in `plugin.xml`, leave only `CompletionContributor` for YAML in
+`yaml-integration.xml`. Disabling YAML must not hide the explorer.
+
+## Swing table / tree renderers
+
+Cell renderers are reused. Always reset shared state for every cell, and map view → model
+indices when a sorter may be enabled (PR #212):
+
+```kotlin
+override fun getTableCellRendererComponent(...): Component {
+    val c = super.getTableCellRendererComponent(...)
+    val modelRow = table.convertRowIndexToModel(row)
+    toolTipText = null          // reset before optional set
+    font = table.font           // reset bold/italic before optional set
+    // then set tooltip / bold only for the cells that need them, using modelRow
+    return c
+}
+```
+
+On refresh **failure**, clear the table/tree model as well as updating the status label —
+leaving stale rows under an error message is misleading.
+
+## VirtualFile text loading
+
+Prefer charset-aware VFS APIs over hard-coded UTF-8 byte decoding:
+
+```kotlin
+// Bad — ignores project/file encoding
+String(vf.contentsToByteArray(), Charsets.UTF_8)
+
+// Good
+LoadTextUtil.loadText(vf).toString()
+// or: vf.charset / EncodingManager when building a Reader
+```
 
 ## Optional Kotlin plugin safety
 
@@ -125,6 +175,21 @@ When detecting JVM `main` classes:
 - Smart pointers: `SmartPointerManager.getInstance(project).createSmartPsiElementPointer(element)`.
 - Enum naming in this codebase: prefer ALL_CAPS entries (e.g. `RouteProtocol.HTTP`), not PascalCase.
 - `const val` names use `UPPER_SNAKE_CASE` when they are true constants.
+- Hot-path predicates (filename checks on every completion/collector call) must not allocate
+  `setOf(...)` / `listOf(...)` per invocation — hoist to a `private val` / companion constant.
+
+## YAML / properties completion contributors
+
+When completing nested config keys under a parent mapping:
+
+1. **Prefix-match the leaf lookup string**, not the full dotted suggestion path — typing `po`
+   under `internal-services:` must match `port`, even if the suggestion id is
+   `armeria.internal-services.port`.
+2. **Walk `YAMLKeyValue` parents** when computing the current key path — stopping at
+   `YAMLMapping` / `YAMLSequenceItem` alone truncates nested block mappings
+   (`server: { port: ... }` → path becomes just `port`).
+3. **Omit empty documentation tails** — do not append `" — "` (or similar) when there is no
+   description; dangling separators show up in the lookup list.
 
 ## Test task paths (multi-module)
 

--- a/.github/skills/armeria-route-psi-analysis/SKILL.md
+++ b/.github/skills/armeria-route-psi-analysis/SKILL.md
@@ -140,9 +140,14 @@ Prefer a real parser when available. When keeping a lightweight text parser (as 
 | Treat comment-only values (`include: # comment`) as empty | Leading `#` is not matched by `\s+#.*$` alone |
 | Do **not** strip inside quoted strings | `"# not a comment"` must stay intact |
 | Match nested keys only at the **parent block’s indentation level** | First-anywhere `ports:` can pick up `armeria:\n  foo:\n    ports:` |
+| List scalars with `:` are **not** always inline mappings (PR #212) | `- http://example.com` must stay a scalar; require `:` + whitespace (or EOL) before treating as `key: value` |
+| Guard empty indent stack before `stack.last()` | Top-level YAML lists (or bad indentation) otherwise throw / skip the whole list silently |
 
 Apply stripping in **every** scalar path (inline mapping, nested list, `readYamlScalar`, include
 tokens) — fixing one call site while leaving siblings is a recurring miss.
+
+Add a regression test for colon-bearing list scalars (`- http://…`) whenever the flattener
+changes — this edge case has already slipped past review once.
 
 ### Spring / Java `.properties`
 

--- a/.github/skills/copilot-review-preflight/SKILL.md
+++ b/.github/skills/copilot-review-preflight/SKILL.md
@@ -8,9 +8,10 @@ description: >-
 
 # Copilot review preflight
 
-This skill aggregates patterns from **337+** GitHub Copilot pull-request review comments
+This skill aggregates patterns from **350+** GitHub Copilot pull-request review comments
 on `nise-nabe/armeria-intellij-plugin` (through July 2026, including PR #211’s 19 Spring
-config-parser findings). Use it as a final pass before requesting review.
+config-parser findings and PR #212’s 17 Spring Boot Config explorer findings). Use it as a
+final pass before requesting review.
 
 ## When to use
 
@@ -33,14 +34,25 @@ config-parser findings). Use it as a final pass before requesting review.
 
 ### Plugin feature code (`plugin/`, `plugin-shared/`, `plugin-wizard/`)
 
-- [ ] User-visible strings use `message(...)` + `ArmeriaBundle.properties` (no hard-coded English)
+- [ ] User-visible strings use `message(...)` + `ArmeriaBundle.properties` (no hard-coded English, including completion docs / tooltip maps)
+- [ ] No unused bundle keys; status copy lists every file type / profile variant actually scanned
 - [ ] HTML tooltips escape dynamic PSI text
 - [ ] Tree selection / equality uses stable route fields, not localized labels
 - [ ] Background PSI uses `ReadAction.nonBlocking` + `expireWith` + `coalesceBy`
 - [ ] Index-heavy paths handle `IndexNotReadyException` or defer until smart mode
 - [ ] Kotlin-specific types are not imported in always-loaded classes without guards
+- [ ] Optional `*-integration.xml` holds only extensions that need that plugin; tool windows / explorers that work without it stay in main `plugin.xml`
+- [ ] Table/tree renderers reset tooltip/font every cell; use `convertRowIndexToModel`; clear model on refresh failure
+- [ ] Config/`VirtualFile` text uses charset-aware VFS APIs (`LoadTextUtil`), not hard-coded UTF-8
+- [ ] Hot-path filename/key checks use hoisted constants, not per-call `setOf(...)`
 - [ ] Run-config `main` detection uses `PsiMethodUtil`, not any `static main`
 - [ ] Code and tests live in the correct module (see `intellij-armeria-plugin`)
+
+### YAML / properties completion (when adding contributors)
+
+- [ ] Prefix-match the leaf lookup string, not the full dotted path
+- [ ] Key-path walk includes `YAMLKeyValue` parents (nested block / flow mappings)
+- [ ] No dangling `" — "` (or similar) when documentation is empty
 
 ### Route analysis (`plugin-route-analysis/`)
 
@@ -57,6 +69,8 @@ config-parser findings). Use it as a final pass before requesting review.
 
 - [ ] Unquoted YAML scalars/lists strip trailing `# …`; comment-only values are empty
 - [ ] Nested YAML keys matched only at parent indentation (not first-anywhere)
+- [ ] YAML list items with `:` (e.g. `- http://…`) stay scalars unless `:` is followed by whitespace/EOL
+- [ ] Flatten/stack walks guard empty indent stack (top-level lists must not throw / silently skip)
 - [ ] `.properties`: last-wins (including indexed keys); `=` and `:` delimiters; line-anchored regexes that skip `#`/`!` comments
 - [ ] HTTP config routes use an HTTP-capable `RouteMatch` (not `NON_HTTP`); use `NON_HTTP` only for true non-HTTP protocols (DocService, Thrift, port bindings); note “Generate HTTP Request” for `NON_HTTP` is enabled **only for gRPC**
 - [ ] Synthetic routes use distinct display paths (e.g. `":8080"`, not `"/"` for port bindings)
@@ -79,12 +93,15 @@ config-parser findings). Use it as a final pass before requesting review.
 | Multi-module placement / wrong test task | 21+ | `intellij-armeria-plugin` |
 | Run configuration / main entry detection | 19 | `intellij-armeria-plugin` |
 | Async UI lifecycle (`expireWith`, dispose) | 16 | `intellij-armeria-plugin` |
-| Hard-coded / non-localized UI strings | 16 | `intellij-armeria-plugin` |
+| Hard-coded / non-localized UI strings | 16+ (PR #212 docs maps) | `intellij-armeria-plugin` |
 | PSI literal fallback / misleading paths | 15+ | `armeria-route-psi-analysis` |
 | Annotated service / decorator parsing | 30+ | `armeria-route-psi-analysis` |
-| Hand-rolled YAML/properties parsing (comments, last-wins, delimiters) | 11+ (PR #211) | `armeria-route-psi-analysis` |
+| Hand-rolled YAML/properties parsing (comments, last-wins, delimiters, `:` in list scalars) | 14+ (PR #211/#212) | `armeria-route-psi-analysis` |
 | Synthetic route emission (`RouteMatch`, display path, dedupe keys) | 6+ (PR #211) | `armeria-route-psi-analysis` |
 | FilenameIndex scan vs name-driven lookup / non-deterministic order | 3+ (PR #211) | `armeria-route-psi-analysis` |
+| Optional dependency config owning core UI (`*-integration.xml`) | 2+ (PR #212) | `intellij-armeria-plugin` |
+| Swing renderer reuse / view→model index / stale model on error | 3+ (PR #212) | `intellij-armeria-plugin` |
+| YAML completion path / leaf prefix / empty doc tails | 3+ (PR #212) | `intellij-armeria-plugin` |
 | Optional Kotlin plugin classloading | 11+ | `intellij-armeria-plugin` |
 | Gradle MCP version/doc drift | 7+ | `gradle-tapi-mcp` |
 | Bash script executable-bit assumptions | 5+ | checklist above |
@@ -94,9 +111,11 @@ config-parser findings). Use it as a final pass before requesting review.
 
 1. Read the specialized skill for your change area.
 2. Run compile/tests via Gradle MCP with the correct module `taskPath` (see `gradle-tapi-mcp`).
-3. Scan the diff for `expression.text`, hard-coded `"` strings in UI code, Kotlin imports
-   in shared collectors, and (for config parsers) missing comment stripping / first-match
-   `.properties` reads / `getAllFilesByExt` scans.
+3. Scan the diff for `expression.text`, hard-coded `"` strings in UI code (including
+   documentation maps), Kotlin imports in shared collectors, tool windows registered only
+   under optional `*-integration.xml`, renderer state that is set but never cleared, and
+   (for config parsers) missing comment stripping / `:`-in-list-scalar handling / first-match
+   `.properties` reads / `getAllFilesByExt` scans / hard-coded UTF-8 `contentsToByteArray`.
 4. Write the PR body as Summary / Changes / Test plan — fold any review-driven edits into
    **Changes**, do not add "Copilot review fixes" sections.
 

--- a/.github/skills/intellij-armeria-plugin/SKILL.md
+++ b/.github/skills/intellij-armeria-plugin/SKILL.md
@@ -47,11 +47,61 @@ statusLabel.text = "Refreshing Armeria routes..."
 Additional rules Copilot repeatedly flags:
 
 - **FormBuilder labels** — match existing plugin style; field labels use a trailing colon.
-- **Properties file hygiene** — no duplicate keys; keep `[Unreleased]` changelog templates intact.
+- **Properties file hygiene** — no duplicate keys; no unused keys added “for later”; keep
+  `[Unreleased]` changelog templates intact. Completion docs / tooltip descriptions are
+  user-visible — route them through the bundle too (not hard-coded English maps).
+- **Status copy matches capability** — if the collector also scans `application.yaml` and
+  profile variants (`application-dev.properties`), the empty/status string must say so.
 - **Stable identity** — when restoring tree selection or comparing routes, use stable fields
   (`routeMatch`, `httpMethod`, registration key), not localized labels like `methodLabel`.
 - **HTML in renderers** — escape dynamic values (`descriptionText`, decorator names, unresolved
   expressions) before embedding in HTML tooltips; unresolved PSI text may contain `<` or `&`.
+
+## Optional dependency config files (`*-integration.xml`)
+
+Optional config files loaded via `config-file` / `depends` (YAML, Kotlin, Spring, …) must
+contain **only** extensions that require that plugin. Copilot flags core UI registered only
+behind an optional dependency (PR #212):
+
+| Put in main `plugin.xml` | Put in optional `*-integration.xml` |
+|--------------------------|-------------------------------------|
+| Tool windows, actions, explorers that work without the optional plugin | Completion contributors, PSI annotators, language-specific handlers |
+
+Example: Spring Boot Config explorer works for `.properties` without the YAML plugin — register
+the tool window in `plugin.xml`, leave only `CompletionContributor` for YAML in
+`yaml-integration.xml`. Disabling YAML must not hide the explorer.
+
+## Swing table / tree renderers
+
+Cell renderers are reused. Always reset shared state for every cell, and map view → model
+indices when a sorter may be enabled (PR #212):
+
+```kotlin
+override fun getTableCellRendererComponent(...): Component {
+    val c = super.getTableCellRendererComponent(...)
+    val modelRow = table.convertRowIndexToModel(row)
+    toolTipText = null          // reset before optional set
+    font = table.font           // reset bold/italic before optional set
+    // then set tooltip / bold only for the cells that need them, using modelRow
+    return c
+}
+```
+
+On refresh **failure**, clear the table/tree model as well as updating the status label —
+leaving stale rows under an error message is misleading.
+
+## VirtualFile text loading
+
+Prefer charset-aware VFS APIs over hard-coded UTF-8 byte decoding:
+
+```kotlin
+// Bad — ignores project/file encoding
+String(vf.contentsToByteArray(), Charsets.UTF_8)
+
+// Good
+LoadTextUtil.loadText(vf).toString()
+// or: vf.charset / EncodingManager when building a Reader
+```
 
 ## Optional Kotlin plugin safety
 
@@ -125,6 +175,21 @@ When detecting JVM `main` classes:
 - Smart pointers: `SmartPointerManager.getInstance(project).createSmartPsiElementPointer(element)`.
 - Enum naming in this codebase: prefer ALL_CAPS entries (e.g. `RouteProtocol.HTTP`), not PascalCase.
 - `const val` names use `UPPER_SNAKE_CASE` when they are true constants.
+- Hot-path predicates (filename checks on every completion/collector call) must not allocate
+  `setOf(...)` / `listOf(...)` per invocation — hoist to a `private val` / companion constant.
+
+## YAML / properties completion contributors
+
+When completing nested config keys under a parent mapping:
+
+1. **Prefix-match the leaf lookup string**, not the full dotted suggestion path — typing `po`
+   under `internal-services:` must match `port`, even if the suggestion id is
+   `armeria.internal-services.port`.
+2. **Walk `YAMLKeyValue` parents** when computing the current key path — stopping at
+   `YAMLMapping` / `YAMLSequenceItem` alone truncates nested block mappings
+   (`server: { port: ... }` → path becomes just `port`).
+3. **Omit empty documentation tails** — do not append `" — "` (or similar) when there is no
+   description; dangling separators show up in the lookup list.
 
 ## Test task paths (multi-module)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR #212 (Spring Boot Armeria configuration explorer) drew 17 Copilot review threads across several rounds. This PR folds the **recurring, reusable** themes into the agent skills so the same classes of issues are caught before the next feature PR.

## Changes

- **`intellij-armeria-plugin`**: optional `*-integration.xml` must not own core tool windows; Swing renderer reset + view→model index; clear model on refresh failure; charset-aware `VirtualFile` reads; hot-path constant hoisting; YAML/properties completion path rules (leaf prefix, `YAMLKeyValue` walk, no empty doc tails); tighter i18n/bundle hygiene (unused keys, status copy matches scan scope)
- **`armeria-route-psi-analysis`**: YAML list scalars with `:` (e.g. `- http://…`) stay scalars; empty indent-stack guard; regression-test note for colon-bearing list items
- **`copilot-review-preflight`**: checklist + theme frequency table updated for PR #212; pre-PR scan guidance expanded
- Mirrored the same updates under `.github/skills/` for Copilot agents

## Test plan

- [ ] Skim skill diffs for accuracy against the 17 PR #212 threads
- [ ] Confirm `.cursor/skills/` and `.github/skills/` copies stay in sync for the three files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7266-e106-7668-af77-dbd0634d0424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7266-e106-7668-af77-dbd0634d0424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

