### PR TITLE
Prefetch IntelliJ Platform in Cursor Cloud install

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -41,4 +41,21 @@ setup_gh_cli() {
   fi
 }
 
+# Prefetch IntelliJ Ultimate via IPGP so Cursor can checkpoint ~/.gradle (and related
+# caches) after install. Subsequent cloud agents then skip the multi-hundred-MB download.
+# Soft-fail: feature branches mid-change must not block agent setup.
+warm_intellij_platform() {
+  echo "Warming IntelliJ Platform (Ultimate) for Cursor Cloud snapshot..."
+  if ! (
+    cd "${repo_root}"
+    ./gradlew \
+      :plugin:compileTestKotlin \
+      :plugin-route-analysis:compileTestKotlin \
+      :plugin-wizard:compileTestKotlin
+  ); then
+    echo "Warning: IntelliJ Platform warm failed; the first test run in this session may download the IDE." >&2
+  fi
+}
+
 setup_gh_cli
+warm_intellij_platform

--- a/.cursor/skills/gradle-tapi-mcp/SKILL.md
+++ b/.cursor/skills/gradle-tapi-mcp/SKILL.md
@@ -126,7 +126,9 @@ rm -rf .intellijPlatform/sandbox/plugin/IU-*/system-test
    - MCP: a **single** `gradle_run_tests` (batch multiple classes/methods when needed), `background: true`, then poll `gradle_get_build_status`
    - Shell: `./gradlew :plugin:test --tests 'fully.qualified.ClassName'`
 
-After the sandbox is warm, single-class MCP runs often finish in a few seconds. The first cold run can take several minutes.
+After the sandbox is warm, single-class MCP runs often finish in a few seconds. The first cold run can take several minutes when the IDE distribution is not yet cached.
+
+`.cursor/install.sh` prefetches Ultimate via `compileTestKotlin` so Cursor Cloud environment checkpoints can retain the IPGP/Gradle IDE cache across agents. Prefer relying on that snapshot for download cost; remaining cold time is mostly daemon + test sandbox warm-up.
 
 ## Running builds and tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ IntelliJ Platform plugin for Armeria. Gradle multi-project build (`build-logic`,
 - **Gradle daemon JVM**: Adoptium 25 (pinned in `gradle/gradle-daemon-jvm.properties`; Foojay resolver downloads it). The running daemon may report a different Java until it restarts and applies the pin — see `gradle_get_build_environment`.
 - **Compile toolchain**: Java 21 JetBrains (configured in `build-logic/src/main/kotlin/com.linecorp.intellij.platform-plugin.gradle.kts` and inherited by `plugin/`).
 - Gradle wrapper (`./gradlew`) remains available as a **fallback** when MCP is unavailable.
+- **IntelliJ Platform prefetch**: `.cursor/install.sh` runs `compileTestKotlin` on plugin modules so IPGP downloads Ultimate into the Gradle cache. Cursor checkpoints that disk state after a long `install`, so later cloud agents usually skip the cold IDE download. Bumping `idea-platform` in `gradle/libs.versions.toml` triggers a fresh download on the next install.
 
 ### MCP: Gradle Tooling API (default for Gradle tasks)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cursor Cloud agents do not ship with IntelliJ IDEA, so the IntelliJ Platform Gradle Plugin downloads Ultimate on the first test/compile. That cold download dominates first-run cost across agents.

This change warms Ultimate during `.cursor/install.sh` so Cursor’s post-install environment checkpoint can retain the Gradle/IPGP IDE cache for later agents.

## Changes

- `.cursor/install.sh` runs `:plugin:compileTestKotlin`, `:plugin-route-analysis:compileTestKotlin`, and `:plugin-wizard:compileTestKotlin` after MCP/`gh` setup
- Warm failure is a warning only (mid-branch compile breaks must not block agent setup)
- Document the prefetch + snapshot behavior in `AGENTS.md` and the Cursor `gradle-tapi-mcp` skill

## Test plan

- [ ] `bash -n .cursor/install.sh`
- [ ] Run `.cursor/install.sh` on a machine without Ultimate cached and confirm IPGP downloads during warm
- [ ] After Cursor checkpoints the environment, start a new cloud agent and confirm the first test run skips the IDE download (daemon/sandbox warm-up may still take time)
- [ ] Confirm a deliberate compile failure in the warm step prints the warning and does not abort the rest of install

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7290-be94-7083-a62d-4055ea6e9d3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7290-be94-7083-a62d-4055ea6e9d3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

