### PR TITLE
chore: release 0.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # suppress inspection "UnusedProperty" for whole file
 kotlin.code.style=official
 
-pluginVersion=0.1.0
+pluginVersion=0.2.0
 
 org.gradle.jvmargs=-Xmx2g
 org.gradle.parallel=true

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,11 +1,8 @@
 # Changelog
 
 ## [Unreleased]
-### Added
 
-- Extended Armeria Clients explorer with Retrofit/WebClient transport detection, client decorator collection, EndpointGroup usage, and a structured detail panel.
-- Live templates for annotated route methods, `Server.builder()`, and `WebClient` decorator chains (Java/Kotlin).
-- Intention action to generate `@Get` route method stubs in annotated Java service classes.
+### Added
 
 ### Changed
 
@@ -15,9 +12,19 @@
 
 ### Fixed
 
-- Armeria run configuration discovery now resolves Kotlin top-level `fun main()` via the file facade (`MainKt`), matching New Project Wizard Kotlin templates.
-
 ### Security
+
+## [0.2.0] - 2026-07-18
+
+### Added
+
+- Extended Armeria Clients explorer with Retrofit/WebClient transport detection, client decorator collection, EndpointGroup usage, and a structured detail panel.
+- Live templates for annotated route methods, `Server.builder()`, and `WebClient` decorator chains (Java/Kotlin).
+- Intention action to generate `@Get` route method stubs in annotated Java service classes.
+
+### Fixed
+
+- Armeria run configuration discovery now resolves Kotlin top-level `fun main()` via the file facade (`MainKt`), matching New Project Wizard Kotlin templates.
 
 ## [0.1.0] - 2026-07-04
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Release **v0.2.0** of the Armeria IntelliJ plugin. Bumps `pluginVersion` to `0.2.0` and moves `[Unreleased]` changelog entries into the `0.2.0` section.

## Changes

- Set `pluginVersion=0.2.0` in `gradle.properties`
- Patch `plugin/CHANGELOG.md` for `0.2.0` (2026-07-18)
- Restore `[0.1.0]` changelog header brackets after `patchChangelog`

### Highlights in 0.2.0

**Added**
- Extended Armeria Clients explorer with Retrofit/WebClient transport detection, client decorator collection, EndpointGroup usage, and a structured detail panel
- Live templates for annotated route methods, `Server.builder()`, and `WebClient` decorator chains (Java/Kotlin)
- Intention action to generate `@Get` route method stubs in annotated Java service classes

**Fixed**
- Armeria run configuration discovery now resolves Kotlin top-level `fun main()` via the file facade (`MainKt`)

## Test plan

- [x] `:plugin:patchChangelog -Prelease.version=0.2.0`
- [x] `build` and `:plugin:buildPlugin` succeed locally
- [x] `plugin/build/distributions/plugin-0.2.0.zip` produced
- [ ] CI green on merge
- [ ] Tag `v0.2.0` and publish GitHub Release after merge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1583e44f-538e-4014-9e58-67bafd08b90b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1583e44f-538e-4014-9e58-67bafd08b90b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

