### PR TITLE
chore: bump to 0.2.1-SNAPSHOT after 0.2.0 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # suppress inspection "UnusedProperty" for whole file
 kotlin.code.style=official
 
-pluginVersion=0.2.0
+pluginVersion=0.2.1-SNAPSHOT
 
 org.gradle.jvmargs=-Xmx2g
 org.gradle.parallel=true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resume development after the **v0.2.0** release by bumping `pluginVersion` to `0.2.1-SNAPSHOT`.

## Changes

- Set `pluginVersion=0.2.1-SNAPSHOT` in `gradle.properties`

## Test plan

- [x] Version-only change; no code changes
- [ ] CI green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1583e44f-538e-4014-9e58-67bafd08b90b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1583e44f-538e-4014-9e58-67bafd08b90b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

