### PR TITLE
fix: dedupe GraphQL and Thrift routes in Route Explorer

### DIFF
--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGraphqlRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGraphqlRouteCollector.kt
@@ -18,16 +18,23 @@ internal object ArmeriaGraphqlRouteCollector {
         if (!ArmeriaIdlRouteSupport.isGraphqlOnClasspath(project, scope)) {
             return
         }
+        val seenGraphqlRoutes = mutableSetOf<String>()
         for (extension in GRAPHQL_EXTENSIONS) {
             for (virtualFile in FilenameIndex.getAllFilesByExt(project, extension, scope)) {
                 val psiFile = PsiManager.getInstance(project).findFile(virtualFile) ?: continue
                 for (operation in parseOperations(psiFile.text)) {
+                    val target = "${operation.operationType}.${operation.fieldName}"
+                    val dedupeKey =
+                        "${ArmeriaRouteMetadata.moduleName(psiFile)}:${ArmeriaIdlRouteSupport.DEFAULT_GRAPHQL_MOUNT_PATH}:$target"
+                    if (!seenGraphqlRoutes.add(dedupeKey)) {
+                        continue
+                    }
                     routes += ArmeriaRoute.create(
                         element = psiFile,
                         protocol = RouteProtocol.GRAPHQL.presentableName(),
                         httpMethod = "",
                         path = ArmeriaIdlRouteSupport.DEFAULT_GRAPHQL_MOUNT_PATH,
-                        target = "${operation.operationType}.${operation.fieldName}",
+                        target = target,
                         routeMatch = RouteMatch.NON_HTTP,
                     )
                 }

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGraphqlRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGraphqlRouteCollector.kt
@@ -19,25 +19,28 @@ internal object ArmeriaGraphqlRouteCollector {
             return
         }
         val seenGraphqlRoutes = mutableSetOf<String>()
-        for (extension in GRAPHQL_EXTENSIONS) {
-            for (virtualFile in FilenameIndex.getAllFilesByExt(project, extension, scope)) {
-                val psiFile = PsiManager.getInstance(project).findFile(virtualFile) ?: continue
-                for (operation in parseOperations(psiFile.text)) {
-                    val target = "${operation.operationType}.${operation.fieldName}"
-                    val dedupeKey =
-                        "${ArmeriaRouteMetadata.moduleName(psiFile)}:${ArmeriaIdlRouteSupport.DEFAULT_GRAPHQL_MOUNT_PATH}:$target"
-                    if (!seenGraphqlRoutes.add(dedupeKey)) {
-                        continue
-                    }
-                    routes += ArmeriaRoute.create(
-                        element = psiFile,
-                        protocol = RouteProtocol.GRAPHQL.presentableName(),
-                        httpMethod = "",
-                        path = ArmeriaIdlRouteSupport.DEFAULT_GRAPHQL_MOUNT_PATH,
-                        target = target,
-                        routeMatch = RouteMatch.NON_HTTP,
-                    )
+        // FilenameIndex iteration order is unstable; sort so first-wins dedupe is deterministic.
+        val virtualFiles = GRAPHQL_EXTENSIONS
+            .flatMap { extension -> FilenameIndex.getAllFilesByExt(project, extension, scope) }
+            .sortedWith(compareBy({ it.path }, { it.name }))
+        val psiManager = PsiManager.getInstance(project)
+        for (virtualFile in virtualFiles) {
+            val psiFile = psiManager.findFile(virtualFile) ?: continue
+            for (operation in parseOperations(psiFile.text)) {
+                val target = "${operation.operationType}.${operation.fieldName}"
+                val dedupeKey =
+                    "${ArmeriaRouteMetadata.moduleName(psiFile)}:${ArmeriaIdlRouteSupport.DEFAULT_GRAPHQL_MOUNT_PATH}:$target"
+                if (!seenGraphqlRoutes.add(dedupeKey)) {
+                    continue
                 }
+                routes += ArmeriaRoute.create(
+                    element = psiFile,
+                    protocol = RouteProtocol.GRAPHQL.presentableName(),
+                    httpMethod = "",
+                    path = ArmeriaIdlRouteSupport.DEFAULT_GRAPHQL_MOUNT_PATH,
+                    target = target,
+                    routeMatch = RouteMatch.NON_HTTP,
+                )
             }
         }
     }

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGraphqlRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGraphqlRouteCollector.kt
@@ -26,10 +26,11 @@ internal object ArmeriaGraphqlRouteCollector {
         val psiManager = PsiManager.getInstance(project)
         for (virtualFile in virtualFiles) {
             val psiFile = psiManager.findFile(virtualFile) ?: continue
+            val moduleName = ArmeriaRouteMetadata.moduleName(psiFile)
             for (operation in parseOperations(psiFile.text)) {
                 val target = "${operation.operationType}.${operation.fieldName}"
                 val dedupeKey =
-                    "${ArmeriaRouteMetadata.moduleName(psiFile)}:${ArmeriaIdlRouteSupport.DEFAULT_GRAPHQL_MOUNT_PATH}:$target"
+                    "$moduleName:${ArmeriaIdlRouteSupport.DEFAULT_GRAPHQL_MOUNT_PATH}:$target"
                 if (!seenGraphqlRoutes.add(dedupeKey)) {
                     continue
                 }

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaThriftRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaThriftRouteCollector.kt
@@ -26,10 +26,11 @@ internal object ArmeriaThriftRouteCollector {
         val psiManager = PsiManager.getInstance(project)
         for (virtualFile in virtualFiles) {
             val psiFile = psiManager.findFile(virtualFile) ?: continue
+            val moduleName = ArmeriaRouteMetadata.moduleName(psiFile)
             for (operation in parseOperations(psiFile.text)) {
                 val path = "/${operation.serviceName}"
                 val target = "${operation.serviceName}.${operation.methodName}"
-                val dedupeKey = "${ArmeriaRouteMetadata.moduleName(psiFile)}:$path:$target"
+                val dedupeKey = "$moduleName:$path:$target"
                 if (!seenThriftRoutes.add(dedupeKey)) {
                     continue
                 }

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaThriftRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaThriftRouteCollector.kt
@@ -20,8 +20,12 @@ internal object ArmeriaThriftRouteCollector {
             return
         }
         val seenThriftRoutes = mutableSetOf<String>()
-        for (virtualFile in FilenameIndex.getAllFilesByExt(project, "thrift", scope)) {
-            val psiFile = PsiManager.getInstance(project).findFile(virtualFile) ?: continue
+        // FilenameIndex iteration order is unstable; sort so first-wins dedupe is deterministic.
+        val virtualFiles = FilenameIndex.getAllFilesByExt(project, "thrift", scope)
+            .sortedWith(compareBy({ it.path }, { it.name }))
+        val psiManager = PsiManager.getInstance(project)
+        for (virtualFile in virtualFiles) {
+            val psiFile = psiManager.findFile(virtualFile) ?: continue
             for (operation in parseOperations(psiFile.text)) {
                 val path = "/${operation.serviceName}"
                 val target = "${operation.serviceName}.${operation.methodName}"

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaThriftRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaThriftRouteCollector.kt
@@ -19,15 +19,22 @@ internal object ArmeriaThriftRouteCollector {
         if (!ArmeriaIdlRouteSupport.isThriftOnClasspath(project, scope)) {
             return
         }
+        val seenThriftRoutes = mutableSetOf<String>()
         for (virtualFile in FilenameIndex.getAllFilesByExt(project, "thrift", scope)) {
             val psiFile = PsiManager.getInstance(project).findFile(virtualFile) ?: continue
             for (operation in parseOperations(psiFile.text)) {
+                val path = "/${operation.serviceName}"
+                val target = "${operation.serviceName}.${operation.methodName}"
+                val dedupeKey = "${ArmeriaRouteMetadata.moduleName(psiFile)}:$path:$target"
+                if (!seenThriftRoutes.add(dedupeKey)) {
+                    continue
+                }
                 routes += ArmeriaRoute.create(
                     element = psiFile,
                     protocol = RouteProtocol.THRIFT.presentableName(),
                     httpMethod = "",
-                    path = "/${operation.serviceName}",
-                    target = "${operation.serviceName}.${operation.methodName}",
+                    path = path,
+                    target = target,
                     routeMatch = RouteMatch.NON_HTTP,
                 )
             }

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaIdlRouteCollectorMultiModuleTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaIdlRouteCollectorMultiModuleTest.kt
@@ -1,0 +1,121 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.testFramework.HeavyPlatformTestCase
+import com.intellij.testFramework.PsiTestUtil
+import java.io.File
+
+class ArmeriaIdlRouteCollectorMultiModuleTest : HeavyPlatformTestCase() {
+    override fun setUp() {
+        super.setUp()
+        allowTestSandboxRoots()
+        createTestProjectStructure()
+        registerArmeriaIdlStubs()
+    }
+
+    private fun allowTestSandboxRoots() {
+        val sandboxRoot = File(PathManager.getConfigPath()).parentFile
+        val pluginsTestDir = sandboxRoot?.resolve("plugins-test")
+        if (pluginsTestDir != null && pluginsTestDir.isDirectory) {
+            VfsRootAccess.allowRootAccess(testRootDisposable, pluginsTestDir.absolutePath)
+            return
+        }
+
+        VfsRootAccess.allowRootAccess(testRootDisposable, PathManager.getPluginsPath())
+        sandboxRoot?.absolutePath?.let { root ->
+            VfsRootAccess.allowRootAccess(testRootDisposable, root)
+        }
+    }
+
+    fun testCollectGraphqlRoutesKeepDuplicateOperationsAcrossModules() {
+        val schema =
+            """
+            type Query {
+                user: User
+            }
+            """.trimIndent()
+        createTextFileInModule(module, "schema.graphql", schema)
+        val additionalModule = createAdditionalModule("additionalModule")
+        createTextFileInModule(additionalModule, "other.graphql", schema)
+
+        val routes = ArmeriaRouteCollector.collect(project)
+            .filter { it.protocol == RouteProtocol.GRAPHQL.presentableName() }
+
+        assertEquals(2, routes.size)
+        assertEquals(setOf("Query.user"), routes.map { it.target }.toSet())
+        assertEquals(setOf(module.name, additionalModule.name), routes.map { it.moduleName }.toSet())
+    }
+
+    fun testCollectThriftRoutesKeepDuplicateOperationsAcrossModules() {
+        val thrift =
+            """
+            service HelloService {
+                string sayHello(1: string name),
+            }
+            """.trimIndent()
+        createTextFileInModule(module, "hello.thrift", thrift)
+        val additionalModule = createAdditionalModule("additionalModule")
+        createTextFileInModule(additionalModule, "other.thrift", thrift)
+
+        val routes = ArmeriaRouteCollector.collect(project)
+            .filter { it.protocol == RouteProtocol.THRIFT.presentableName() }
+
+        assertEquals(2, routes.size)
+        assertEquals(setOf("HelloService.sayHello"), routes.map { it.target }.toSet())
+        assertEquals(setOf(module.name, additionalModule.name), routes.map { it.moduleName }.toSet())
+    }
+
+    private fun registerArmeriaIdlStubs() {
+        createTextFileInModule(
+            module,
+            "com/linecorp/armeria/server/graphql/GraphqlService.java",
+            """
+            package com.linecorp.armeria.server.graphql;
+
+            public final class GraphqlService {
+            }
+            """.trimIndent(),
+        )
+        createTextFileInModule(
+            module,
+            "com/linecorp/armeria/server/thrift/THttpService.java",
+            """
+            package com.linecorp.armeria.server.thrift;
+
+            public final class THttpService {
+            }
+            """.trimIndent(),
+        )
+    }
+
+    private fun createTextFileInModule(targetModule: Module, relativePath: String, content: String): VirtualFile {
+        val sourceRoot = moduleSourceRoot(targetModule)
+        val parts = relativePath.split("/")
+        var directory = sourceRoot
+        for (part in parts.dropLast(1)) {
+            directory = directory.findChild(part) ?: createChildDirectory(directory, part)
+        }
+        val file = createChildData(directory, parts.last())
+        setFileText(file, content)
+        PsiDocumentManager.getInstance(project).commitAllDocuments()
+        return file
+    }
+
+    private fun createAdditionalModule(name: String): Module {
+        val tempDir = createTempDir(name)
+        val additionalModule = createModuleAt(name, project, moduleType, tempDir.toPath())
+        PsiTestUtil.addSourceContentToRoots(additionalModule, getVirtualFile(tempDir))
+        return additionalModule
+    }
+
+    private fun moduleSourceRoot(targetModule: Module): VirtualFile {
+        val moduleRootManager = ModuleRootManager.getInstance(targetModule)
+        return moduleRootManager.sourceRoots.firstOrNull()
+            ?: moduleRootManager.contentRoots.first()
+    }
+}

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaIdlRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaIdlRouteCollectorTest.kt
@@ -1,5 +1,12 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.module.JavaModuleType
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModuleUtilCore
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.testFramework.PsiTestUtil
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
 
 class ArmeriaIdlRouteCollectorTest : ArmeriaFixtureTestBase() {
@@ -236,6 +243,46 @@ class ArmeriaIdlRouteCollectorTest : ArmeriaFixtureTestBase() {
         assertEquals("copy.thrift", route.pointer.element!!.containingFile.name)
     }
 
+    fun testCollectGraphqlRoutesKeepDuplicateOperationsAcrossModules() {
+        registerArmeriaIdlStubs()
+        val schema =
+            """
+            type Query {
+                user: User
+            }
+            """.trimIndent()
+        myFixture.configureByText("schema.graphql", schema)
+        val additionalModule = addAdditionalModuleWithTextFile("other.graphql", schema)
+
+        val routes = ArmeriaRouteCollector.collect(project)
+            .filter { it.protocol == RouteProtocol.GRAPHQL.presentableName() }
+
+        assertEquals(2, routes.size)
+        assertEquals(setOf("Query.user"), routes.map { it.target }.toSet())
+        val defaultModuleName = ModuleUtilCore.findModuleForPsiElement(myFixture.file)!!.name
+        assertEquals(setOf(defaultModuleName, additionalModule.name), routes.map { it.moduleName }.toSet())
+    }
+
+    fun testCollectThriftRoutesKeepDuplicateOperationsAcrossModules() {
+        registerArmeriaIdlStubs()
+        val thrift =
+            """
+            service HelloService {
+                string sayHello(1: string name),
+            }
+            """.trimIndent()
+        myFixture.configureByText("hello.thrift", thrift)
+        val additionalModule = addAdditionalModuleWithTextFile("other.thrift", thrift)
+
+        val routes = ArmeriaRouteCollector.collect(project)
+            .filter { it.protocol == RouteProtocol.THRIFT.presentableName() }
+
+        assertEquals(2, routes.size)
+        assertEquals(setOf("HelloService.sayHello"), routes.map { it.target }.toSet())
+        val defaultModuleName = ModuleUtilCore.findModuleForPsiElement(myFixture.file)!!.name
+        assertEquals(setOf(defaultModuleName, additionalModule.name), routes.map { it.moduleName }.toSet())
+    }
+
     fun testSkipIdlRoutesWhenProtocolNotOnClasspath() {
         myFixture.configureByText(
             "schema.graphql",
@@ -258,5 +305,16 @@ class ArmeriaIdlRouteCollectorTest : ArmeriaFixtureTestBase() {
             .filter { it.routeMatch == RouteMatch.NON_HTTP }
 
         assertTrue(routesWithoutIdlStubs.isEmpty())
+    }
+
+    private fun addAdditionalModuleWithTextFile(fileName: String, content: String): Module {
+        val moduleRoot = myFixture.tempDirFixture.createDir("additional-module")
+        val module = PsiTestUtil.addModule(project, JavaModuleType.getInstance(), "additionalModule", moduleRoot)
+        WriteAction.runAndWait {
+            val virtualFile = moduleRoot.createChildData(this, fileName)
+            VfsUtil.saveText(virtualFile, content)
+        }
+        PsiDocumentManager.getInstance(project).commitAllDocuments()
+        return module
     }
 }

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaIdlRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaIdlRouteCollectorTest.kt
@@ -212,7 +212,7 @@ class ArmeriaIdlRouteCollectorTest : ArmeriaFixtureTestBase() {
         val route = routes.single()
         assertEquals("Query.user", route.target)
         // Lexicographic path wins when FilenameIndex order is unstable.
-        assertEquals("copy.graphqls", route.element.containingFile.name)
+        assertEquals("copy.graphqls", route.pointer.element!!.containingFile.name)
     }
 
     fun testCollectThriftRoutesDedupesDuplicateOperationsAcrossFiles() {
@@ -233,7 +233,7 @@ class ArmeriaIdlRouteCollectorTest : ArmeriaFixtureTestBase() {
         val route = routes.single()
         assertEquals("HelloService.sayHello", route.target)
         // Lexicographic path wins when FilenameIndex order is unstable.
-        assertEquals("copy.thrift", route.element.containingFile.name)
+        assertEquals("copy.thrift", route.pointer.element!!.containingFile.name)
     }
 
     fun testSkipIdlRoutesWhenProtocolNotOnClasspath() {

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaIdlRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaIdlRouteCollectorTest.kt
@@ -1,12 +1,5 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
-import com.intellij.openapi.application.WriteAction
-import com.intellij.openapi.module.JavaModuleType
-import com.intellij.openapi.module.Module
-import com.intellij.openapi.module.ModuleUtilCore
-import com.intellij.openapi.vfs.VfsUtil
-import com.intellij.psi.PsiDocumentManager
-import com.intellij.testFramework.PsiTestUtil
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
 
 class ArmeriaIdlRouteCollectorTest : ArmeriaFixtureTestBase() {
@@ -243,46 +236,6 @@ class ArmeriaIdlRouteCollectorTest : ArmeriaFixtureTestBase() {
         assertEquals("copy.thrift", route.pointer.element!!.containingFile.name)
     }
 
-    fun testCollectGraphqlRoutesKeepDuplicateOperationsAcrossModules() {
-        registerArmeriaIdlStubs()
-        val schema =
-            """
-            type Query {
-                user: User
-            }
-            """.trimIndent()
-        myFixture.configureByText("schema.graphql", schema)
-        val additionalModule = addAdditionalModuleWithTextFile("other.graphql", schema)
-
-        val routes = ArmeriaRouteCollector.collect(project)
-            .filter { it.protocol == RouteProtocol.GRAPHQL.presentableName() }
-
-        assertEquals(2, routes.size)
-        assertEquals(setOf("Query.user"), routes.map { it.target }.toSet())
-        val defaultModuleName = ModuleUtilCore.findModuleForPsiElement(myFixture.file)!!.name
-        assertEquals(setOf(defaultModuleName, additionalModule.name), routes.map { it.moduleName }.toSet())
-    }
-
-    fun testCollectThriftRoutesKeepDuplicateOperationsAcrossModules() {
-        registerArmeriaIdlStubs()
-        val thrift =
-            """
-            service HelloService {
-                string sayHello(1: string name),
-            }
-            """.trimIndent()
-        myFixture.configureByText("hello.thrift", thrift)
-        val additionalModule = addAdditionalModuleWithTextFile("other.thrift", thrift)
-
-        val routes = ArmeriaRouteCollector.collect(project)
-            .filter { it.protocol == RouteProtocol.THRIFT.presentableName() }
-
-        assertEquals(2, routes.size)
-        assertEquals(setOf("HelloService.sayHello"), routes.map { it.target }.toSet())
-        val defaultModuleName = ModuleUtilCore.findModuleForPsiElement(myFixture.file)!!.name
-        assertEquals(setOf(defaultModuleName, additionalModule.name), routes.map { it.moduleName }.toSet())
-    }
-
     fun testSkipIdlRoutesWhenProtocolNotOnClasspath() {
         myFixture.configureByText(
             "schema.graphql",
@@ -305,16 +258,5 @@ class ArmeriaIdlRouteCollectorTest : ArmeriaFixtureTestBase() {
             .filter { it.routeMatch == RouteMatch.NON_HTTP }
 
         assertTrue(routesWithoutIdlStubs.isEmpty())
-    }
-
-    private fun addAdditionalModuleWithTextFile(fileName: String, content: String): Module {
-        val moduleRoot = myFixture.tempDirFixture.createDir("additional-module")
-        val module = PsiTestUtil.addModule(project, JavaModuleType.getInstance(), "additionalModule", moduleRoot)
-        WriteAction.runAndWait {
-            val virtualFile = moduleRoot.createChildData(this, fileName)
-            VfsUtil.saveText(virtualFile, content)
-        }
-        PsiDocumentManager.getInstance(project).commitAllDocuments()
-        return module
     }
 }

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaIdlRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaIdlRouteCollectorTest.kt
@@ -194,6 +194,42 @@ class ArmeriaIdlRouteCollectorTest : ArmeriaFixtureTestBase() {
         assertTrue(route.httpMethod.isBlank())
     }
 
+    fun testCollectGraphqlRoutesDedupesDuplicateOperationsAcrossFiles() {
+        registerArmeriaIdlStubs()
+        val schema =
+            """
+            type Query {
+                user: User
+            }
+            """.trimIndent()
+        myFixture.configureByText("schema.graphql", schema)
+        myFixture.configureByText("copy.graphqls", schema)
+
+        val routes = ArmeriaRouteCollector.collect(project)
+            .filter { it.protocol == RouteProtocol.GRAPHQL.presentableName() }
+
+        assertEquals(1, routes.size)
+        assertEquals("Query.user", routes.single().target)
+    }
+
+    fun testCollectThriftRoutesDedupesDuplicateOperationsAcrossFiles() {
+        registerArmeriaIdlStubs()
+        val thrift =
+            """
+            service HelloService {
+                string sayHello(1: string name),
+            }
+            """.trimIndent()
+        myFixture.configureByText("hello.thrift", thrift)
+        myFixture.configureByText("copy.thrift", thrift)
+
+        val routes = ArmeriaRouteCollector.collect(project)
+            .filter { it.protocol == RouteProtocol.THRIFT.presentableName() }
+
+        assertEquals(1, routes.size)
+        assertEquals("HelloService.sayHello", routes.single().target)
+    }
+
     fun testSkipIdlRoutesWhenProtocolNotOnClasspath() {
         myFixture.configureByText(
             "schema.graphql",

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaIdlRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaIdlRouteCollectorTest.kt
@@ -209,7 +209,10 @@ class ArmeriaIdlRouteCollectorTest : ArmeriaFixtureTestBase() {
             .filter { it.protocol == RouteProtocol.GRAPHQL.presentableName() }
 
         assertEquals(1, routes.size)
-        assertEquals("Query.user", routes.single().target)
+        val route = routes.single()
+        assertEquals("Query.user", route.target)
+        // Lexicographic path wins when FilenameIndex order is unstable.
+        assertEquals("copy.graphqls", route.element.containingFile.name)
     }
 
     fun testCollectThriftRoutesDedupesDuplicateOperationsAcrossFiles() {
@@ -227,7 +230,10 @@ class ArmeriaIdlRouteCollectorTest : ArmeriaFixtureTestBase() {
             .filter { it.protocol == RouteProtocol.THRIFT.presentableName() }
 
         assertEquals(1, routes.size)
-        assertEquals("HelloService.sayHello", routes.single().target)
+        val route = routes.single()
+        assertEquals("HelloService.sayHello", route.target)
+        // Lexicographic path wins when FilenameIndex order is unstable.
+        assertEquals("copy.thrift", route.element.containingFile.name)
     }
 
     fun testSkipIdlRoutesWhenProtocolNotOnClasspath() {

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Route Explorer deduplicates GraphQL and Thrift IDL routes per module when the same operation appears in multiple schema or `.thrift` files.
+
 ### Security
 
 ## [0.2.0] - 2026-07-18


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Route Explorer was listing duplicate GraphQL and Thrift operations when the same schema appeared in multiple files within a module. This change deduplicates IDL routes using a module-scoped key so each operation appears once per module, with deterministic file selection when duplicates exist.

## Changes

- GraphQL and Thrift collectors dedupe routes with keys that include `moduleName`, mount path, and operation target
- Virtual files are sorted before dedupe so the surviving route does not jump between files across refreshes
- Light fixture tests cover same-module dedupe across multiple files
- Heavy fixture tests (`ArmeriaIdlRouteCollectorMultiModuleTest`) assert the same operation in two modules yields two routes (one per module) for GraphQL and Thrift

## Test plan

- [x] `:plugin-route-analysis:test` — `ArmeriaIdlRouteCollectorTest` dedupe tests
- [x] `:plugin-route-analysis:test` — `ArmeriaIdlRouteCollectorMultiModuleTest` per-module scoping tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f731e-53ff-77af-89b5-7d9510ae2ea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f731e-53ff-77af-89b5-7d9510ae2ea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

