### PR TITLE
Consolidate Cursor Cloud setup into mise

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -10,6 +10,7 @@ ensure_mise() {
   fi
 
   echo "Installing mise..."
+  # mise.run bundles SHA-256 checksums for the pinned release it installs.
   curl -fsSL https://mise.run | sh
   export PATH="${HOME}/.local/bin:${PATH}"
 }
@@ -29,7 +30,10 @@ EOF
 ensure_mise
 export PATH="${HOME}/.local/bin:${PATH}"
 eval "$(mise activate bash)"
-ensure_mise_activate_in_shell
 
-mise install
+# MCP JAR has no Java dependency; install before mise-managed Java so a transient
+# Java download failure does not block Gradle MCP setup.
+bash "${repo_root}/.github/scripts/install-gradle-tapi-mcp.sh"
+
 mise run cloud:install
+ensure_mise_activate_in_shell

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -9,6 +9,11 @@ ensure_mise() {
     return 0
   fi
 
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "Error: curl is required to install mise but was not found on PATH." >&2
+    exit 1
+  fi
+
   echo "Installing mise..."
   # mise.run bundles SHA-256 checksums for the pinned release it installs.
   curl -fsSL https://mise.run | sh
@@ -21,10 +26,17 @@ ensure_mise_activate_in_shell() {
     return 0
   fi
 
-  cat >>"${HOME}/.bashrc" <<'EOF'
+  if ! cat >>"${HOME}/.bashrc" 2>/dev/null <<'EOF'
 # cursor-cloud: mise activate
+case ":$PATH:" in
+  *:"${HOME}/.local/bin":*) ;;
+  *) export PATH="${HOME}/.local/bin:${PATH}" ;;
+esac
 eval "$(mise activate bash)"
 EOF
+  then
+    echo "Warning: could not append mise hook to ${HOME}/.bashrc (read-only HOME?)." >&2
+  fi
 }
 
 ensure_mise

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -2,60 +2,34 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-bash "${repo_root}/.github/scripts/install-gradle-tapi-mcp.sh"
+cd "${repo_root}"
 
-setup_gh_cli() {
-  local gh_source="/exec-daemon/gh"
-  if [[ ! -x "${gh_source}" ]]; then
-    echo "Warning: ${gh_source} not found; gh CLI will be unavailable in this session." >&2
+ensure_mise() {
+  if command -v mise >/dev/null 2>&1; then
     return 0
   fi
 
-  if ! mkdir -p "${HOME}/.local/bin" 2>/dev/null; then
-    echo "Warning: could not create ${HOME}/.local/bin; gh symlink skipped." >&2
-  elif ! ln -sfn "${gh_source}" "${HOME}/.local/bin/gh" 2>/dev/null; then
-    echo "Warning: could not symlink gh to ${HOME}/.local/bin/gh." >&2
-  fi
-
-  if [[ -w /usr/local/bin ]]; then
-    if ! ln -sfn "${gh_source}" /usr/local/bin/gh 2>/dev/null; then
-      echo "Warning: could not symlink gh to /usr/local/bin/gh." >&2
-    fi
-  fi
-
-  if ! "${gh_source}" auth status >/dev/null 2>&1; then
-    local token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
-    if [[ -n "${token}" ]]; then
-      if ! "${gh_source}" auth login --hostname github.com --git-protocol https --with-token <<<"${token}"; then
-        echo "Warning: gh auth login failed; gh CLI may be unavailable for API calls." >&2
-        echo "Use ManagePullRequest for PRs, or set GH_TOKEN in Cursor Cloud Secrets." >&2
-      fi
-    else
-      echo "Warning: gh is not authenticated and GH_TOKEN/GITHUB_TOKEN is unset." >&2
-      echo "Set GH_TOKEN in Cursor Cloud Secrets, or use the ManagePullRequest tool for PRs." >&2
-    fi
-  fi
-
-  if ! command -v gh >/dev/null 2>&1; then
-    echo "Warning: gh is installed but not on PATH; use /exec-daemon/gh or ~/.local/bin/gh." >&2
-  fi
+  echo "Installing mise..."
+  curl -fsSL https://mise.run | sh
+  export PATH="${HOME}/.local/bin:${PATH}"
 }
 
-# Prefetch IntelliJ Ultimate via IPGP so Cursor can checkpoint ~/.gradle (and related
-# caches) after install. Subsequent cloud agents then skip the multi-hundred-MB download.
-# Soft-fail: feature branches mid-change must not block agent setup.
-warm_intellij_platform() {
-  echo "Warming IntelliJ Platform (Ultimate) for Cursor Cloud snapshot..."
-  if ! (
-    cd "${repo_root}"
-    ./gradlew \
-      :plugin:compileTestKotlin \
-      :plugin-route-analysis:compileTestKotlin \
-      :plugin-wizard:compileTestKotlin
-  ); then
-    echo "Warning: IntelliJ Platform warm failed; the first test run in this session may download the IDE." >&2
+ensure_mise_activate_in_shell() {
+  local marker='# cursor-cloud: mise activate'
+  if [[ -f "${HOME}/.bashrc" ]] && grep -qF "${marker}" "${HOME}/.bashrc" 2>/dev/null; then
+    return 0
   fi
+
+  cat >>"${HOME}/.bashrc" <<'EOF'
+# cursor-cloud: mise activate
+eval "$(mise activate bash)"
+EOF
 }
 
-setup_gh_cli
-warm_intellij_platform
+ensure_mise
+export PATH="${HOME}/.local/bin:${PATH}"
+eval "$(mise activate bash)"
+ensure_mise_activate_in_shell
+
+mise install
+mise run cloud:install

--- a/.cursor/scripts/setup-gh-cli.sh
+++ b/.cursor/scripts/setup-gh-cli.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+gh_source="/exec-daemon/gh"
+if [[ ! -x "${gh_source}" ]]; then
+  echo "Warning: ${gh_source} not found; gh CLI will be unavailable in this session." >&2
+  exit 0
+fi
+
+if ! mkdir -p "${HOME}/.local/bin" 2>/dev/null; then
+  echo "Warning: could not create ${HOME}/.local/bin; gh symlink skipped." >&2
+elif ! ln -sfn "${gh_source}" "${HOME}/.local/bin/gh" 2>/dev/null; then
+  echo "Warning: could not symlink gh to ${HOME}/.local/bin/gh." >&2
+fi
+
+if [[ -w /usr/local/bin ]]; then
+  if ! ln -sfn "${gh_source}" /usr/local/bin/gh 2>/dev/null; then
+    echo "Warning: could not symlink gh to /usr/local/bin/gh." >&2
+  fi
+fi
+
+if ! "${gh_source}" auth status >/dev/null 2>&1; then
+  token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+  if [[ -n "${token}" ]]; then
+    if ! "${gh_source}" auth login --hostname github.com --git-protocol https --with-token <<<"${token}"; then
+      echo "Warning: gh auth login failed; gh CLI may be unavailable for API calls." >&2
+      echo "Use ManagePullRequest for PRs, or set GH_TOKEN in Cursor Cloud Secrets." >&2
+    fi
+  else
+    echo "Warning: gh is not authenticated and GH_TOKEN/GITHUB_TOKEN is unset." >&2
+    echo "Set GH_TOKEN in Cursor Cloud Secrets, or use the ManagePullRequest tool for PRs." >&2
+  fi
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "Warning: gh is installed but not on PATH; use /exec-daemon/gh or ~/.local/bin/gh." >&2
+fi

--- a/.cursor/scripts/warm-intellij-platform.sh
+++ b/.cursor/scripts/warm-intellij-platform.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Prefetch IntelliJ Ultimate via IPGP so Cursor can checkpoint ~/.gradle (and related
+# caches) after install. Subsequent cloud agents then skip the multi-hundred-MB download.
+# Soft-fail: feature branches mid-change must not block agent setup.
+echo "Warming IntelliJ Platform (Ultimate) for Cursor Cloud snapshot..."
+if ! (
+  cd "${repo_root}"
+  ./gradlew \
+    :plugin:compileTestKotlin \
+    :plugin-route-analysis:compileTestKotlin \
+    :plugin-wizard:compileTestKotlin
+); then
+  echo "Warning: IntelliJ Platform warm failed; the first test run in this session may download the IDE." >&2
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,10 +6,11 @@ IntelliJ Platform plugin for Armeria. Gradle multi-project build (`build-logic`,
 
 ### Prerequisites
 
+- **Cursor Cloud setup**: `mise.toml` pins Java 25 and defines the `cloud:install` task (gh CLI setup and IntelliJ Platform warm). `.cursor/install.sh` bootstraps mise when needed, installs the Gradle MCP JAR first (no Java dependency), then runs `mise run cloud:install`. Locally, reproduce the same steps with `mise run cloud:install` after `mise install`.
 - **Gradle daemon JVM**: Adoptium 25 (pinned in `gradle/gradle-daemon-jvm.properties`; Foojay resolver downloads it). The running daemon may report a different Java until it restarts and applies the pin — see `gradle_get_build_environment`.
 - **Compile toolchain**: Java 21 JetBrains (configured in `build-logic/src/main/kotlin/com.linecorp.intellij.platform-plugin.gradle.kts` and inherited by `plugin/`).
 - Gradle wrapper (`./gradlew`) remains available as a **fallback** when MCP is unavailable.
-- **IntelliJ Platform prefetch**: `.cursor/install.sh` runs `compileTestKotlin` on plugin modules so IPGP downloads Ultimate into the Gradle cache. Cursor checkpoints that disk state after a long `install`, so later cloud agents usually skip the cold IDE download. Bumping `idea-platform` in `gradle/libs.versions.toml` triggers a fresh download on the next install.
+- **IntelliJ Platform prefetch**: `cloud:install` runs `compileTestKotlin` on plugin modules so IPGP downloads Ultimate into the Gradle cache. Cursor checkpoints that disk state after a long `install`, so later cloud agents usually skip the cold IDE download. Bumping `idea-platform` in `gradle/libs.versions.toml` triggers a fresh download on the next install.
 
 ### MCP: Gradle Tooling API (default for Gradle tasks)
 

--- a/mise.toml
+++ b/mise.toml
@@ -5,9 +5,8 @@ min_version = "2024.11.1"
 java = "25"
 
 [tasks."cloud:install"]
-description = "Cursor Cloud environment setup (MCP JAR, gh CLI, IntelliJ Platform warm)"
+description = "Cursor Cloud environment setup (gh CLI, IntelliJ Platform warm; MCP JAR is installed by .cursor/install.sh first)"
 run = [
-  "bash .github/scripts/install-gradle-tapi-mcp.sh",
   "bash .cursor/scripts/setup-gh-cli.sh",
   "bash .cursor/scripts/warm-intellij-platform.sh",
 ]

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,13 @@
+min_version = "2024.11.1"
+
+[tools]
+# Aligns with gradle/gradle-daemon-jvm.properties (daemon JVM) and CI (setup-java 25).
+java = "25"
+
+[tasks."cloud:install"]
+description = "Cursor Cloud environment setup (MCP JAR, gh CLI, IntelliJ Platform warm)"
+run = [
+  "bash .github/scripts/install-gradle-tapi-mcp.sh",
+  "bash .cursor/scripts/setup-gh-cli.sh",
+  "bash .cursor/scripts/warm-intellij-platform.sh",
+]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Consolidates Cursor Cloud setup into `mise.toml` and keeps `.cursor/install.sh` as a thin entrypoint. The Gradle MCP JAR is installed first in `install.sh` (no Java dependency); gh CLI setup and IntelliJ Platform warm are delegated to `mise run cloud:install`. Locally, the same steps can be reproduced with `mise run cloud:install`.

## Changes

- Add `mise.toml` — pin Java 25 and define the `cloud:install` task (gh CLI setup, IntelliJ Platform warm)
- Add `.cursor/scripts/setup-gh-cli.sh` — Cloud-specific `/exec-daemon/gh` symlink and authentication
- Add `.cursor/scripts/warm-intellij-platform.sh` — IPGP Ultimate prefetch (soft-fail as before)
- Update `.cursor/install.sh` — bootstrap mise, append activate hook to `~/.bashrc` only after success, install MCP JAR first then delegate to `mise run cloud:install`
- Harden `install.sh` — preflight `curl` before mise bootstrap; ensure `~/.local/bin` is on PATH in the persisted bashrc hook; best-effort bashrc append when HOME is read-only
- Update `AGENTS.md` — document `mise.toml` and setup order under Prerequisites

## Test plan

- [x] `bash -n` syntax check on all scripts
- [x] `mise install` confirms Java 25 installation
- [x] `bash .cursor/install.sh` succeeds for MCP JAR fetch, gh setup, and `compileTestKotlin` warm

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7389-6757-7499-874a-1258688a1129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7389-6757-7499-874a-1258688a1129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

