### PR TITLE
fix: keep DocService runtime routes across Route Explorer refresh

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Route Explorer deduplicates GraphQL and Thrift IDL routes per module when the same operation appears in multiple schema or `.thrift` files.
 - DocService runtime route sync activates the Armeria Services tool window when needed so routes apply even if it was closed before the fetch completed.
+- Route Explorer Refresh no longer clears DocService-synced runtime routes; synced routes stay until the next sync replaces them.
 
 ### Security
 

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerPanel.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerPanel.kt
@@ -38,7 +38,6 @@ class ArmeriaRouteExplorerPanel(
     private var staticRoutes: List<ArmeriaRoute> = emptyList()
     private var runtimeRoutes: List<ArmeriaRoute> = emptyList()
     private var refreshGeneration = 0
-    private var runtimeApplyGeneration = 0
     private var selectedRoute: ArmeriaRoute? = null
     private var currentModuleOnly = false
     private var initialRefreshScheduled = false
@@ -165,9 +164,7 @@ class ArmeriaRouteExplorerPanel(
                     return@finishOnUiThread
                 }
                 staticRoutes = collectedRoutes
-                if (runtimeApplyGeneration < generation) {
-                    runtimeRoutes = emptyList()
-                }
+                // Keep DocService-synced runtime routes across static refreshes until the next sync.
                 rebuildTree()
                 updateStatusLabel()
                 updateDetailFootnote()
@@ -177,7 +174,6 @@ class ArmeriaRouteExplorerPanel(
     fun staticRoutes(): List<ArmeriaRoute> = staticRoutes
 
     fun applyRuntimeRoutes(routes: List<ArmeriaRoute>) {
-        runtimeApplyGeneration = refreshGeneration
         runtimeRoutes = routes
         rebuildTree()
         updateStatusLabel()

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerPanel.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerPanel.kt
@@ -35,8 +35,7 @@ import javax.swing.tree.DefaultTreeModel
 class ArmeriaRouteExplorerPanel(
     private val project: Project,
 ) : SimpleToolWindowPanel(true, true), Disposable, UiDataProvider {
-    private var staticRoutes: List<ArmeriaRoute> = emptyList()
-    private var runtimeRoutes: List<ArmeriaRoute> = emptyList()
+    private val routeState = ArmeriaRouteExplorerRouteState()
     private var refreshGeneration = 0
     private var selectedRoute: ArmeriaRoute? = null
     private var currentModuleOnly = false
@@ -163,24 +162,23 @@ class ArmeriaRouteExplorerPanel(
                 if (generation != refreshGeneration) {
                     return@finishOnUiThread
                 }
-                staticRoutes = collectedRoutes
-                // Keep DocService-synced runtime routes across static refreshes until the next sync.
+                routeState.applyStatic(collectedRoutes)
                 rebuildTree()
                 updateStatusLabel()
                 updateDetailFootnote()
             }.submit(AppExecutorUtil.getAppExecutorService())
     }
 
-    fun staticRoutes(): List<ArmeriaRoute> = staticRoutes
+    fun staticRoutes(): List<ArmeriaRoute> = routeState.staticRoutes
 
     fun applyRuntimeRoutes(routes: List<ArmeriaRoute>) {
-        runtimeRoutes = routes
+        routeState.applyRuntime(routes)
         rebuildTree()
         updateStatusLabel()
         updateDetailFootnote()
     }
 
-    private fun allRoutes(): List<ArmeriaRoute> = staticRoutes + runtimeRoutes
+    private fun allRoutes(): List<ArmeriaRoute> = routeState.allRoutes()
 
     private fun rebuildTree() {
         val previousSelection = ArmeriaRouteTreeBuilder.selectedRoute(routeTree.lastSelectedPathComponent)
@@ -219,10 +217,11 @@ class ArmeriaRouteExplorerPanel(
     }
 
     private fun updateDetailFootnote() {
-        detailFootnote.text = if (runtimeRoutes.isEmpty()) {
+        val runtimeCount = routeState.runtimeRoutes.size
+        detailFootnote.text = if (runtimeCount == 0) {
             message("route.explorer.footnote.static")
         } else {
-            message("route.explorer.footnote.runtime", runtimeRoutes.size)
+            message("route.explorer.footnote.runtime", runtimeCount)
         }
     }
 

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerRouteState.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerRouteState.kt
@@ -1,0 +1,24 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+/**
+ * Static and DocService runtime routes shown in Route Explorer.
+ *
+ * [runtimeRoutes] survive [applyStatic] (Refresh) until [applyRuntime] replaces them.
+ */
+internal class ArmeriaRouteExplorerRouteState {
+    var staticRoutes: List<ArmeriaRoute> = emptyList()
+        private set
+
+    var runtimeRoutes: List<ArmeriaRoute> = emptyList()
+        private set
+
+    fun applyStatic(routes: List<ArmeriaRoute>) {
+        staticRoutes = routes
+    }
+
+    fun applyRuntime(routes: List<ArmeriaRoute>) {
+        runtimeRoutes = routes
+    }
+
+    fun allRoutes(): List<ArmeriaRoute> = staticRoutes + runtimeRoutes
+}

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerRouteStateTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerRouteStateTest.kt
@@ -1,0 +1,70 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.SmartPsiElementPointer
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ArmeriaRouteExplorerRouteStateTest {
+    @Test
+    fun applyStatic_keepsPreviouslySyncedRuntimeRoutes() {
+        val state = ArmeriaRouteExplorerRouteState()
+        val runtime = testRoute(moduleName = "Runtime (DocService)", path = "/runtime")
+        val staticBefore = testRoute(moduleName = "app", path = "/old")
+        val staticAfter = testRoute(moduleName = "app", path = "/new")
+
+        state.applyStatic(listOf(staticBefore))
+        state.applyRuntime(listOf(runtime))
+        state.applyStatic(listOf(staticAfter))
+
+        assertEquals(listOf(staticAfter), state.staticRoutes)
+        assertEquals(listOf(runtime), state.runtimeRoutes)
+        assertEquals(listOf(staticAfter, runtime), state.allRoutes())
+    }
+
+    @Test
+    fun applyRuntime_replacesPreviousRuntimeRoutes() {
+        val state = ArmeriaRouteExplorerRouteState()
+        val first = testRoute(moduleName = "Runtime (DocService)", path = "/a")
+        val second = testRoute(moduleName = "Runtime (DocService)", path = "/b")
+
+        state.applyRuntime(listOf(first))
+        state.applyRuntime(listOf(second))
+
+        assertEquals(listOf(second), state.runtimeRoutes)
+    }
+
+    private fun testRoute(moduleName: String, path: String): ArmeriaRoute {
+        return ArmeriaRoute(
+            protocol = "HTTP",
+            httpMethod = "GET",
+            path = path,
+            target = "Handler",
+            routeMatch = RouteMatch.RUNTIME,
+            moduleName = moduleName,
+            targetUnresolved = false,
+            isDocService = false,
+            decorators = emptyList(),
+            exceptionHandlers = emptyList(),
+            pointer = TestPsiPointer,
+        )
+    }
+
+    private object TestPsiPointer : SmartPsiElementPointer<PsiElement> {
+        override fun getElement(): PsiElement? = null
+
+        override fun getContainingFile(): PsiFile? = null
+
+        override fun getRange(): TextRange? = null
+
+        override fun getProject(): Project = throw UnsupportedOperationException()
+
+        override fun getVirtualFile(): VirtualFile = throw UnsupportedOperationException()
+
+        override fun getPsiRange(): TextRange? = null
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

DocService-synced runtime routes disappeared from Route Explorer whenever the user clicked Refresh. Static analysis still updated correctly, but users had to sync again to restore runtime routes.

This change keeps those runtime routes across static refreshes until the next DocService sync replaces them.

Closes #271

## Changes

- Stop clearing runtime routes when a static refresh finishes after the last sync
- Remove the `runtimeApplyGeneration` gate that tied runtime lifetime to refresh generation
- Own static/runtime lists in `ArmeriaRouteExplorerRouteState` with an explicit retain-across-refresh contract
- Unit tests for refresh retention and sync replacement
- CHANGELOG Unreleased Fixed note

## Test plan

- [ ] Open Route Explorer, sync from DocService, click Refresh — runtime routes remain
- [ ] Sync again with different results — runtime routes are replaced
- [ ] Confirm static route refresh still updates the tree
- [x] `:plugin:compileKotlin` / `:plugin:compileTestKotlin` via Gradle MCP (SUCCESS)
- [x] `ArmeriaRouteExplorerRouteStateTest` via Gradle MCP (SUCCESS)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7441-d0d0-7ac3-98fd-5a0ca534d19c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7441-d0d0-7ac3-98fd-5a0ca534d19c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

