### PR TITLE
Replace Spring application.yml scraper with IntelliJ YAML PSI

### DIFF
--- a/.cursor/skills/armeria-route-psi-analysis/SKILL.md
+++ b/.cursor/skills/armeria-route-psi-analysis/SKILL.md
@@ -147,6 +147,8 @@ Copilot repeatedly flags the same gaps (PR #211) for that path:
 | Keep YAML PSI imports in `ArmeriaYamlSpringConfigReader` (not the always-loaded collector entry) | Same optional-plugin isolation pattern as Kotlin helpers |
 | Read only **top-level** `armeria` mappings (walk all YAML documents) | Nested `wrapper.armeria` / `armeria.foo.ports` must not emit routes |
 | Prefer `YAMLScalar.textValue` / sequence items over raw node text | Quotes and comments are already stripped by the PSI |
+| If the file is not a `YAMLFile` (e.g. Plain Text), parse via `YAMLElementGenerator.createDummyYamlWithText` and leave navigation on the original `PsiFile` | Restores discovery without pointing at a disposable PSI tree |
+| Shared defaults / include expansion live in `SpringArmeriaConfigSemantics` | Keeps the optional YAML reader from depending on collector orchestration |
 
 ### Spring / Java `.properties`
 

--- a/.cursor/skills/armeria-route-psi-analysis/SKILL.md
+++ b/.cursor/skills/armeria-route-psi-analysis/SKILL.md
@@ -127,27 +127,26 @@ FilenameIndex.getAllFilenames(project)
 Sort candidates before any “first wins” dedupe — `FilenameIndex` iteration order is not stable,
 so unsorted first-wins produces non-deterministic Route Explorer output across refreshes.
 
-## Hand-rolled YAML / `.properties` parsers
+## Spring Boot config YAML / `.properties`
 
-Prefer a real parser when available. When keeping a lightweight text parser (as in
-`ArmeriaSpringConfigRouteCollector`), Copilot repeatedly flags the same gaps (PR #211):
+YAML (`application.yml` / `.yaml`) is read via optional IntelliJ YAML PSI
+(`org.jetbrains.plugins.yaml`, `ArmeriaYamlSpringConfigReader`). When the YAML plugin is
+not loaded, YAML config files are skipped; `.properties` still work.
 
-### YAML
+Prefer key-level `PsiElement` navigation targets from YAML PSI (`YAMLKeyValue`) when emitting
+config routes — do not attach the whole `PsiFile` if a more specific node is available.
+
+`.properties` remain on a lightweight text/regex parser in `ArmeriaSpringConfigRouteCollector`.
+Copilot repeatedly flags the same gaps (PR #211) for that path:
+
+### YAML PSI
 
 | Rule | Why |
 |------|-----|
-| Strip trailing `# …` on **unquoted** scalars, list items, and inline mapping values | Otherwise `protocols: http # primary` becomes tokens `http`, `#`, `primary` |
-| Treat comment-only values (`include: # comment`) as empty | Leading `#` is not matched by `\s+#.*$` alone |
-| Do **not** strip inside quoted strings | `"# not a comment"` must stay intact |
-| Match nested keys only at the **parent block’s indentation level** | First-anywhere `ports:` can pick up `armeria:\n  foo:\n    ports:` |
-| List scalars with `:` are **not** always inline mappings (PR #212) | `- http://example.com` must stay a scalar; require `:` + whitespace (or EOL) before treating as `key: value` |
-| Guard empty indent stack before `stack.last()` | Top-level YAML lists (or bad indentation) otherwise throw / skip the whole list silently |
-
-Apply stripping in **every** scalar path (inline mapping, nested list, `readYamlScalar`, include
-tokens) — fixing one call site while leaving siblings is a recurring miss.
-
-Add a regression test for colon-bearing list scalars (`- http://…`) whenever the flattener
-changes — this edge case has already slipped past review once.
+| Gate with `PluginManagerCore.isLoaded("org.jetbrains.plugins.yaml")` before calling the reader | Classloader only exposes YAML APIs when our optional `depends` is active |
+| Keep YAML PSI imports in `ArmeriaYamlSpringConfigReader` (not the always-loaded collector entry) | Same optional-plugin isolation pattern as Kotlin helpers |
+| Read only **top-level** `armeria` mappings (walk all YAML documents) | Nested `wrapper.armeria` / `armeria.foo.ports` must not emit routes |
+| Prefer `YAMLScalar.textValue` / sequence items over raw node text | Quotes and comments are already stripped by the PSI |
 
 ### Spring / Java `.properties`
 
@@ -183,9 +182,10 @@ When emitting routes that are not PSI call-site registrations:
 
 - gRPC/proto routes: use Proto Editor PSI when available; cache merged proto routes
   (`mergeProtoRoutesIfEnabled`) to avoid repeated merges.
-- Spring Boot config collectors: `ArmeriaSpringConfigRouteCollector` (YAML/properties) and
-  `ArmeriaSpringBootRouteCollector` (Java `@Bean` PSI walks) — follow the hand-rolled parser and
-  synthetic-route rules above; guard optional Spring/Kotlin PSI behind availability checks.
+- Spring Boot config collectors: `ArmeriaSpringConfigRouteCollector` (YAML via optional YAML PSI,
+  properties via text/regex) and `ArmeriaSpringBootRouteCollector` (Java `@Bean` PSI walks) —
+  follow the config YAML/properties and synthetic-route rules above; guard optional Spring/Kotlin
+  PSI behind availability checks.
 - GraphQL / Thrift deduplication: align dedupe keys with HTTP route keys (path + method + host).
 
 ## Regression tests

--- a/.cursor/skills/copilot-review-preflight/SKILL.md
+++ b/.cursor/skills/copilot-review-preflight/SKILL.md
@@ -65,12 +65,10 @@ final pass before requesting review.
 - [ ] “First wins” collectors sort inputs; dedupe keys include all distinguishing fields
 - [ ] Test plan uses `:plugin-route-analysis:test` or `fastTest`, not `:plugin:test`
 
-### Hand-rolled Spring YAML / `.properties` parsers
+### Spring Boot config YAML / `.properties`
 
-- [ ] Unquoted YAML scalars/lists strip trailing `# …`; comment-only values are empty
-- [ ] Nested YAML keys matched only at parent indentation (not first-anywhere)
-- [ ] YAML list items with `:` (e.g. `- http://…`) stay scalars unless `:` is followed by whitespace/EOL
-- [ ] Flatten/stack walks guard empty indent stack (top-level lists must not throw / silently skip)
+- [ ] YAML via optional IntelliJ YAML PSI (`ArmeriaYamlSpringConfigReader`); gate with `PluginManagerCore.isLoaded`; keep YAML imports out of always-loaded collector entry
+- [ ] Top-level `armeria` only (all YAML documents); Plain Text-typed YAML uses dummy PSI with file-level navigation fallback
 - [ ] `.properties`: last-wins (including indexed keys); `=` and `:` delimiters; line-anchored regexes that skip `#`/`!` comments
 - [ ] HTTP config routes use an HTTP-capable `RouteMatch` (not `NON_HTTP`); use `NON_HTTP` only for true non-HTTP protocols (DocService, Thrift, port bindings); note “Generate HTTP Request” for `NON_HTTP` is enabled **only for gRPC**
 - [ ] Synthetic routes use distinct display paths (e.g. `":8080"`, not `"/"` for port bindings)
@@ -96,7 +94,7 @@ final pass before requesting review.
 | Hard-coded / non-localized UI strings | 16+ (PR #212 docs maps) | `intellij-armeria-plugin` |
 | PSI literal fallback / misleading paths | 15+ | `armeria-route-psi-analysis` |
 | Annotated service / decorator parsing | 30+ | `armeria-route-psi-analysis` |
-| Hand-rolled YAML/properties parsing (comments, last-wins, delimiters, `:` in list scalars) | 14+ (PR #211/#212) | `armeria-route-psi-analysis` |
+| Hand-rolled `.properties` / YAML PSI Spring config (last-wins, optional plugin gate) | 14+ (PR #211/#212/#285) | `armeria-route-psi-analysis` |
 | Synthetic route emission (`RouteMatch`, display path, dedupe keys) | 6+ (PR #211) | `armeria-route-psi-analysis` |
 | FilenameIndex scan vs name-driven lookup / non-deterministic order | 3+ (PR #211) | `armeria-route-psi-analysis` |
 | Optional dependency config owning core UI (`*-integration.xml`) | 2+ (PR #212) | `intellij-armeria-plugin` |

--- a/.github/skills/armeria-route-psi-analysis/SKILL.md
+++ b/.github/skills/armeria-route-psi-analysis/SKILL.md
@@ -127,27 +127,28 @@ FilenameIndex.getAllFilenames(project)
 Sort candidates before any “first wins” dedupe — `FilenameIndex` iteration order is not stable,
 so unsorted first-wins produces non-deterministic Route Explorer output across refreshes.
 
-## Hand-rolled YAML / `.properties` parsers
+## Spring Boot config YAML / `.properties`
 
-Prefer a real parser when available. When keeping a lightweight text parser (as in
-`ArmeriaSpringConfigRouteCollector`), Copilot repeatedly flags the same gaps (PR #211):
+YAML (`application.yml` / `.yaml`) is read via optional IntelliJ YAML PSI
+(`org.jetbrains.plugins.yaml`, `ArmeriaYamlSpringConfigReader`). When the YAML plugin is
+not loaded, YAML config files are skipped; `.properties` still work.
 
-### YAML
+Prefer key-level `PsiElement` navigation targets from YAML PSI (`YAMLKeyValue`) when emitting
+config routes — do not attach the whole `PsiFile` if a more specific node is available.
+
+`.properties` remain on a lightweight text/regex parser in `ArmeriaSpringConfigRouteCollector`.
+Copilot repeatedly flags the same gaps (PR #211) for that path:
+
+### YAML PSI
 
 | Rule | Why |
 |------|-----|
-| Strip trailing `# …` on **unquoted** scalars, list items, and inline mapping values | Otherwise `protocols: http # primary` becomes tokens `http`, `#`, `primary` |
-| Treat comment-only values (`include: # comment`) as empty | Leading `#` is not matched by `\s+#.*$` alone |
-| Do **not** strip inside quoted strings | `"# not a comment"` must stay intact |
-| Match nested keys only at the **parent block’s indentation level** | First-anywhere `ports:` can pick up `armeria:\n  foo:\n    ports:` |
-| List scalars with `:` are **not** always inline mappings (PR #212) | `- http://example.com` must stay a scalar; require `:` + whitespace (or EOL) before treating as `key: value` |
-| Guard empty indent stack before `stack.last()` | Top-level YAML lists (or bad indentation) otherwise throw / skip the whole list silently |
-
-Apply stripping in **every** scalar path (inline mapping, nested list, `readYamlScalar`, include
-tokens) — fixing one call site while leaving siblings is a recurring miss.
-
-Add a regression test for colon-bearing list scalars (`- http://…`) whenever the flattener
-changes — this edge case has already slipped past review once.
+| Gate with `PluginManagerCore.isLoaded("org.jetbrains.plugins.yaml")` before calling the reader | Classloader only exposes YAML APIs when our optional `depends` is active |
+| Keep YAML PSI imports in `ArmeriaYamlSpringConfigReader` (not the always-loaded collector entry) | Same optional-plugin isolation pattern as Kotlin helpers |
+| Read only **top-level** `armeria` mappings (walk all YAML documents) | Nested `wrapper.armeria` / `armeria.foo.ports` must not emit routes |
+| Prefer `YAMLScalar.textValue` / sequence items over raw node text | Quotes and comments are already stripped by the PSI |
+| If the file is not a `YAMLFile` (e.g. Plain Text), parse via `YAMLElementGenerator.createDummyYamlWithText` and leave navigation on the original `PsiFile` | Restores discovery without pointing at a disposable PSI tree |
+| Shared defaults / include expansion live in `SpringArmeriaConfigSemantics` | Keeps the optional YAML reader from depending on collector orchestration |
 
 ### Spring / Java `.properties`
 
@@ -183,9 +184,10 @@ When emitting routes that are not PSI call-site registrations:
 
 - gRPC/proto routes: use Proto Editor PSI when available; cache merged proto routes
   (`mergeProtoRoutesIfEnabled`) to avoid repeated merges.
-- Spring Boot config collectors: `ArmeriaSpringConfigRouteCollector` (YAML/properties) and
-  `ArmeriaSpringBootRouteCollector` (Java `@Bean` PSI walks) — follow the hand-rolled parser and
-  synthetic-route rules above; guard optional Spring/Kotlin PSI behind availability checks.
+- Spring Boot config collectors: `ArmeriaSpringConfigRouteCollector` (YAML via optional YAML PSI,
+  properties via text/regex) and `ArmeriaSpringBootRouteCollector` (Java `@Bean` PSI walks) —
+  follow the config YAML/properties and synthetic-route rules above; guard optional Spring/Kotlin
+  PSI behind availability checks.
 - GraphQL / Thrift deduplication: align dedupe keys with HTTP route keys (path + method + host).
 
 ## Regression tests

--- a/.github/skills/copilot-review-preflight/SKILL.md
+++ b/.github/skills/copilot-review-preflight/SKILL.md
@@ -65,12 +65,10 @@ final pass before requesting review.
 - [ ] “First wins” collectors sort inputs; dedupe keys include all distinguishing fields
 - [ ] Test plan uses `:plugin-route-analysis:test` or `fastTest`, not `:plugin:test`
 
-### Hand-rolled Spring YAML / `.properties` parsers
+### Spring Boot config YAML / `.properties`
 
-- [ ] Unquoted YAML scalars/lists strip trailing `# …`; comment-only values are empty
-- [ ] Nested YAML keys matched only at parent indentation (not first-anywhere)
-- [ ] YAML list items with `:` (e.g. `- http://…`) stay scalars unless `:` is followed by whitespace/EOL
-- [ ] Flatten/stack walks guard empty indent stack (top-level lists must not throw / silently skip)
+- [ ] YAML via optional IntelliJ YAML PSI (`ArmeriaYamlSpringConfigReader`); gate with `PluginManagerCore.isLoaded`; keep YAML imports out of always-loaded collector entry
+- [ ] Top-level `armeria` only (all YAML documents); Plain Text-typed YAML uses dummy PSI with file-level navigation fallback
 - [ ] `.properties`: last-wins (including indexed keys); `=` and `:` delimiters; line-anchored regexes that skip `#`/`!` comments
 - [ ] HTTP config routes use an HTTP-capable `RouteMatch` (not `NON_HTTP`); use `NON_HTTP` only for true non-HTTP protocols (DocService, Thrift, port bindings); note “Generate HTTP Request” for `NON_HTTP` is enabled **only for gRPC**
 - [ ] Synthetic routes use distinct display paths (e.g. `":8080"`, not `"/"` for port bindings)
@@ -96,7 +94,7 @@ final pass before requesting review.
 | Hard-coded / non-localized UI strings | 16+ (PR #212 docs maps) | `intellij-armeria-plugin` |
 | PSI literal fallback / misleading paths | 15+ | `armeria-route-psi-analysis` |
 | Annotated service / decorator parsing | 30+ | `armeria-route-psi-analysis` |
-| Hand-rolled YAML/properties parsing (comments, last-wins, delimiters, `:` in list scalars) | 14+ (PR #211/#212) | `armeria-route-psi-analysis` |
+| Hand-rolled `.properties` / YAML PSI Spring config (last-wins, optional plugin gate) | 14+ (PR #211/#212/#285) | `armeria-route-psi-analysis` |
 | Synthetic route emission (`RouteMatch`, display path, dedupe keys) | 6+ (PR #211) | `armeria-route-psi-analysis` |
 | FilenameIndex scan vs name-driven lookup / non-deterministic order | 3+ (PR #211) | `armeria-route-psi-analysis` |
 | Optional dependency config owning core UI (`*-integration.xml`) | 2+ (PR #212) | `intellij-armeria-plugin` |

--- a/plugin-route-analysis/build.gradle.kts
+++ b/plugin-route-analysis/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
         intellijIdeaUltimate(libs.versions.idea.platform.get())
         bundledPlugin("com.intellij.java")
         bundledPlugin("org.jetbrains.kotlin")
+        bundledPlugin("org.jetbrains.plugins.yaml")
         testFramework(TestFrameworkType.Plugin.Java)
         testFramework(TestFrameworkType.Plugin.Java, configurationName = "testFixturesImplementation")
     }

--- a/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollectorParseTest.kt
+++ b/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollectorParseTest.kt
@@ -207,8 +207,8 @@ class ArmeriaSpringConfigRouteCollectorParseTest {
     @Test
     fun internalServiceIdsStayAlignedWithSemantics() {
         assertEquals(
-            setOf("docs", "health", "metrics", "actuator"),
             SpringArmeriaConfigSemantics.INTERNAL_SERVICE_IDS,
+            ArmeriaSpringConfigRouteCollector.internalServiceSpecIds(),
         )
         assertEquals(
             SpringArmeriaConfigSemantics.INTERNAL_SERVICE_IDS,

--- a/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollectorParseTest.kt
+++ b/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollectorParseTest.kt
@@ -210,11 +210,18 @@ class ArmeriaSpringConfigRouteCollectorParseTest {
             SpringArmeriaConfigSemantics.INTERNAL_SERVICE_IDS,
             ArmeriaSpringConfigRouteCollector.internalServiceSpecIds(),
         )
-        assertEquals(
-            SpringArmeriaConfigSemantics.INTERNAL_SERVICE_IDS,
-            SpringArmeriaConfigSemantics.expandIncludes(
-                SpringArmeriaConfigSemantics.parseIncludeTokens("all"),
-            ),
+    }
+
+    @Test
+    fun parseProperties_absentPathsStayNullUntilResolved() {
+        val config = ArmeriaSpringConfigRouteCollector.parseProperties(
+            "armeria.internal-services.include=docs",
         )
+        assertEquals(null, config.docsPath)
+        assertEquals(null, config.healthPath)
+        assertEquals(null, config.metricsPath)
+        assertEquals(SpringArmeriaConfigSemantics.DEFAULT_DOCS_PATH, config.resolvedDocsPath())
+        assertEquals(SpringArmeriaConfigSemantics.DEFAULT_HEALTH_PATH, config.resolvedHealthPath())
+        assertEquals(SpringArmeriaConfigSemantics.DEFAULT_METRICS_PATH, config.resolvedMetricsPath())
     }
 }

--- a/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollectorParseTest.kt
+++ b/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollectorParseTest.kt
@@ -203,4 +203,16 @@ class ArmeriaSpringConfigRouteCollectorParseTest {
             config.ports,
         )
     }
+
+    @Test
+    fun internalServiceIdsStayAlignedWithSemantics() {
+        assertEquals(
+            setOf("docs", "health", "metrics", "actuator"),
+            SpringArmeriaConfigSemantics.INTERNAL_SERVICE_IDS,
+        )
+        assertEquals(
+            SpringArmeriaConfigSemantics.INTERNAL_SERVICE_IDS,
+            SpringArmeriaConfigSemantics.expandIncludes(setOf("all")),
+        )
+    }
 }

--- a/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollectorParseTest.kt
+++ b/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollectorParseTest.kt
@@ -1,133 +1,9 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ArmeriaSpringConfigRouteCollectorParseTest {
-    @Test
-    fun parseYaml_scalarProtocolsAndAddressFirst() {
-        val config = ArmeriaSpringConfigRouteCollector.parseYaml(
-            """
-            armeria:
-              ports:
-                - port: 8080
-                  protocols: HTTP
-                - address: 127.0.0.1
-                  port: 8081
-                  protocols: HTTP
-                - port: 8443
-                  protocols: HTTPS
-            """.trimIndent(),
-        )
-
-        assertEquals(
-            listOf(
-                SpringArmeriaPortBinding("8080", listOf("HTTP")),
-                SpringArmeriaPortBinding("8081", listOf("HTTP")),
-                SpringArmeriaPortBinding("8443", listOf("HTTPS")),
-            ),
-            config.ports,
-        )
-    }
-
-    @Test
-    fun parseYaml_protocolsBeforePortAndMultiProtocol() {
-        val config = ArmeriaSpringConfigRouteCollector.parseYaml(
-            """
-            armeria:
-              ports:
-                - protocols:
-                    - http
-                    - https
-                  port: 8080
-            """.trimIndent(),
-        )
-
-        assertEquals(
-            listOf(SpringArmeriaPortBinding("8080", listOf("HTTP", "HTTPS"))),
-            config.ports,
-        )
-    }
-
-    @Test
-    fun parseYaml_blockAndFlowIncludeLists() {
-        val block = ArmeriaSpringConfigRouteCollector.parseYaml(
-            """
-            armeria:
-              internal-services:
-                include:
-                  - docs
-                  - health
-            """.trimIndent(),
-        )
-        assertEquals(setOf("docs", "health"), block.includes)
-
-        val flow = ArmeriaSpringConfigRouteCollector.parseYaml(
-            """
-            armeria:
-              internal-services:
-                include: [docs, metrics]
-            """.trimIndent(),
-        )
-        assertEquals(setOf("docs", "metrics"), flow.includes)
-    }
-
-    @Test
-    fun parseYaml_includeAllExpandsActuator() {
-        val config = ArmeriaSpringConfigRouteCollector.parseYaml(
-            """
-            armeria:
-              internal-services:
-                include: all
-                port: 18080
-              docs-path: /custom/docs
-            """.trimIndent(),
-        )
-
-        assertEquals(setOf("docs", "health", "metrics", "actuator"), config.includes)
-        assertEquals("18080", config.internalServicesPort)
-        assertEquals("/custom/docs", config.docsPath)
-    }
-
-    @Test
-    fun parseYaml_scopesPathKeysToArmeriaBlock() {
-        val config = ArmeriaSpringConfigRouteCollector.parseYaml(
-            """
-            other:
-              docs-path: /wrong
-              health-check-path: /also-wrong
-            armeria:
-              docs-path: /internal/docs
-              health-check-path: /internal/healthcheck
-              metrics-path: /internal/metrics
-            """.trimIndent(),
-        )
-
-        assertEquals("/internal/docs", config.docsPath)
-        assertEquals("/internal/healthcheck", config.healthPath)
-        assertEquals("/internal/metrics", config.metricsPath)
-    }
-
-    @Test
-    fun parseYaml_acceptsCamelCaseInternalServices() {
-        val config = ArmeriaSpringConfigRouteCollector.parseYaml(
-            """
-            armeria:
-              internalServices:
-                include: docs
-              docsPath: /docs
-              healthCheckPath: /health
-              metricsPath: /metrics
-            """.trimIndent(),
-        )
-
-        assertEquals(setOf("docs"), config.includes)
-        assertEquals("/docs", config.docsPath)
-        assertEquals("/health", config.healthPath)
-        assertEquals("/metrics", config.metricsPath)
-    }
-
     @Test
     fun parseProperties_sparsePortIndexes() {
         val config = ArmeriaSpringConfigRouteCollector.parseProperties(
@@ -233,24 +109,6 @@ class ArmeriaSpringConfigRouteCollectorParseTest {
     }
 
     @Test
-    fun parseYaml_ignoresServerPortOutsideArmeria() {
-        val config = ArmeriaSpringConfigRouteCollector.parseYaml(
-            """
-            server:
-              port: 9999
-            armeria:
-              ports:
-                - port: 8080
-                  protocols:
-                    - http
-            """.trimIndent(),
-        )
-
-        assertEquals(listOf(SpringArmeriaPortBinding("8080", listOf("HTTP"))), config.ports)
-        assertTrue(config.ports.none { it.port == "9999" })
-    }
-
-    @Test
     fun parseProperties_lastDuplicateKeyWins() {
         val config = ArmeriaSpringConfigRouteCollector.parseProperties(
             """
@@ -313,81 +171,6 @@ class ArmeriaSpringConfigRouteCollectorParseTest {
     }
 
     @Test
-    fun parseYaml_inlineScalarCommentsStrippedBeforeTokenization() {
-        val config = ArmeriaSpringConfigRouteCollector.parseYaml(
-            """
-            armeria:
-              ports:
-                - port: 8080
-                  protocols: http # primary
-            """.trimIndent(),
-        )
-
-        assertEquals(
-            listOf(SpringArmeriaPortBinding("8080", listOf("HTTP"))),
-            config.ports,
-        )
-    }
-
-    @Test
-    fun parseYaml_ignoresNestedArmeriaKey() {
-        val config = ArmeriaSpringConfigRouteCollector.parseYaml(
-            """
-            wrapper:
-              armeria:
-                ports:
-                  - port: 9999
-                    protocols: HTTP
-            armeria:
-              ports:
-                - port: 8080
-                  protocols: HTTP
-            """.trimIndent(),
-        )
-
-        assertEquals(listOf(SpringArmeriaPortBinding("8080", listOf("HTTP"))), config.ports)
-    }
-
-    @Test
-    fun parseYaml_ignoresNestedPortsUnderArmeriaChild() {
-        val config = ArmeriaSpringConfigRouteCollector.parseYaml(
-            """
-            armeria:
-              foo:
-                ports:
-                  - port: 9999
-                    protocols: HTTP
-              ports:
-                - port: 8080
-                  protocols: HTTPS
-              bar:
-                internal-services:
-                  include: docs
-              internal-services:
-                include: health
-            """.trimIndent(),
-        )
-
-        assertEquals(listOf(SpringArmeriaPortBinding("8080", listOf("HTTPS"))), config.ports)
-        assertEquals(setOf("health"), config.includes)
-    }
-
-    @Test
-    fun parseYaml_ignoresNestedIncludeUnderInternalServicesChild() {
-        val config = ArmeriaSpringConfigRouteCollector.parseYaml(
-            """
-            armeria:
-              internal-services:
-                foo:
-                  include: docs
-                include: health
-            """.trimIndent(),
-        )
-
-        assertEquals(setOf("health"), config.includes)
-    }
-
-    @Test
     fun parseProperties_protocolIndexLastWins() {
         val config = ArmeriaSpringConfigRouteCollector.parseProperties(
             """
@@ -419,32 +202,5 @@ class ArmeriaSpringConfigRouteCollectorParseTest {
             listOf(SpringArmeriaPortBinding("8080", listOf("H2C"))),
             config.ports,
         )
-    }
-
-    @Test
-    fun parseYaml_commentOnlyScalarValueTreatedAsEmpty() {
-        val config = ArmeriaSpringConfigRouteCollector.parseYaml(
-            """
-            armeria:
-              internal-services:
-                include: # commented out
-                  - health
-            """.trimIndent(),
-        )
-
-        assertEquals(setOf("health"), config.includes)
-    }
-
-    @Test
-    fun parseYaml_commentOnlyInlineIncludeIgnored() {
-        val config = ArmeriaSpringConfigRouteCollector.parseYaml(
-            """
-            armeria:
-              internal-services:
-                include: # docs disabled
-            """.trimIndent(),
-        )
-
-        assertTrue(config.includes.isEmpty())
     }
 }

--- a/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollectorParseTest.kt
+++ b/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollectorParseTest.kt
@@ -212,7 +212,9 @@ class ArmeriaSpringConfigRouteCollectorParseTest {
         )
         assertEquals(
             SpringArmeriaConfigSemantics.INTERNAL_SERVICE_IDS,
-            SpringArmeriaConfigSemantics.expandIncludes(setOf("all")),
+            SpringArmeriaConfigSemantics.expandIncludes(
+                SpringArmeriaConfigSemantics.parseIncludeTokens("all"),
+            ),
         )
     }
 }

--- a/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/SpringArmeriaConfigSemanticsTest.kt
+++ b/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/SpringArmeriaConfigSemanticsTest.kt
@@ -1,0 +1,55 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SpringArmeriaConfigSemanticsTest {
+    @Test
+    fun expandIncludes_allExpandsToCanonicalIds() {
+        assertEquals(
+            SpringArmeriaConfigSemantics.INTERNAL_SERVICE_IDS,
+            SpringArmeriaConfigSemantics.expandIncludes(setOf("all")),
+        )
+        assertEquals(
+            SpringArmeriaConfigSemantics.INTERNAL_SERVICE_IDS,
+            SpringArmeriaConfigSemantics.expandIncludes(setOf("ALL", "docs")),
+        )
+    }
+
+    @Test
+    fun expandIncludes_filtersUnknownAndLowercases() {
+        assertEquals(
+            setOf("docs", "health"),
+            SpringArmeriaConfigSemantics.expandIncludes(setOf("Docs", "HEALTH", "unknown")),
+        )
+    }
+
+    @Test
+    fun parseIncludeTokens_splitsCommaAndSpace() {
+        assertEquals(
+            setOf("docs", "health", "metrics"),
+            SpringArmeriaConfigSemantics.parseIncludeTokens("docs, health metrics"),
+        )
+    }
+
+    @Test
+    fun normalizeProtocols_uppercasesDistinctAndDefaults() {
+        assertEquals(
+            listOf("HTTP", "HTTPS"),
+            SpringArmeriaConfigSemantics.normalizeProtocols(listOf("http", "HTTPS", "http")),
+        )
+        assertEquals(
+            listOf("HTTP"),
+            SpringArmeriaConfigSemantics.normalizeProtocols(emptyList()),
+        )
+    }
+
+    @Test
+    fun splitScalarList_stripsBracketsAndQuotes() {
+        assertEquals(
+            listOf("http", "https"),
+            SpringArmeriaConfigSemantics.splitScalarList("[\"http\", 'https']"),
+        )
+        assertEquals(emptyList<String>(), SpringArmeriaConfigSemantics.splitScalarList("[]"))
+    }
+}

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollector.kt
@@ -67,7 +67,7 @@ internal object ArmeriaSpringConfigRouteCollector {
     private val INTERNAL_SERVICE_SPECS = listOf(
         InternalServiceSpec(
             id = SpringArmeriaConfigSemantics.ID_DOCS,
-            path = { it.docsPath },
+            path = { it.resolvedDocsPath() },
             pathElement = { it.docsPathElement },
             messageKey = "route.explorer.spring.docService",
             protocol = RouteProtocol.DOC_SERVICE.presentableName(),
@@ -77,7 +77,7 @@ internal object ArmeriaSpringConfigRouteCollector {
         ),
         InternalServiceSpec(
             id = SpringArmeriaConfigSemantics.ID_HEALTH,
-            path = { it.healthPath },
+            path = { it.resolvedHealthPath() },
             pathElement = { it.healthPathElement },
             messageKey = "route.explorer.spring.healthCheck",
             protocol = RouteProtocol.HTTP.presentableName(),
@@ -87,7 +87,7 @@ internal object ArmeriaSpringConfigRouteCollector {
         ),
         InternalServiceSpec(
             id = SpringArmeriaConfigSemantics.ID_METRICS,
-            path = { it.metricsPath },
+            path = { it.resolvedMetricsPath() },
             pathElement = { it.metricsPathElement },
             messageKey = "route.explorer.spring.metrics",
             protocol = RouteProtocol.HTTP.presentableName(),
@@ -218,14 +218,11 @@ internal object ArmeriaSpringConfigRouteCollector {
             ports = ports,
             includes = SpringArmeriaConfigSemantics.expandIncludes(includes),
             docsPath = lastPropertiesMatch(PROPERTIES_DOCS_PATH_PATTERN, text)
-                ?.let { SpringArmeriaConfigSemantics.trimQuotes(stripPropertiesInlineComment(it)) }
-                ?: SpringArmeriaConfigSemantics.DEFAULT_DOCS_PATH,
+                ?.let { SpringArmeriaConfigSemantics.trimQuotes(stripPropertiesInlineComment(it)) },
             healthPath = lastPropertiesMatch(PROPERTIES_HEALTH_PATH_PATTERN, text)
-                ?.let { SpringArmeriaConfigSemantics.trimQuotes(stripPropertiesInlineComment(it)) }
-                ?: SpringArmeriaConfigSemantics.DEFAULT_HEALTH_PATH,
+                ?.let { SpringArmeriaConfigSemantics.trimQuotes(stripPropertiesInlineComment(it)) },
             metricsPath = lastPropertiesMatch(PROPERTIES_METRICS_PATH_PATTERN, text)
-                ?.let { SpringArmeriaConfigSemantics.trimQuotes(stripPropertiesInlineComment(it)) }
-                ?: SpringArmeriaConfigSemantics.DEFAULT_METRICS_PATH,
+                ?.let { SpringArmeriaConfigSemantics.trimQuotes(stripPropertiesInlineComment(it)) },
             internalServicesPort = lastPropertiesMatch(PROPERTIES_INTERNAL_PORT_PATTERN, text)
                 ?.let { stripPropertiesInlineComment(it) },
         )

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollector.kt
@@ -89,7 +89,7 @@ internal object ArmeriaSpringConfigRouteCollector {
 
     private val INTERNAL_SERVICE_SPECS = listOf(
         InternalServiceSpec(
-            id = "docs",
+            id = SpringArmeriaConfigSemantics.ID_DOCS,
             path = { it.docsPath },
             pathElement = { it.docsPathElement ?: it.includeElement },
             messageKey = "route.explorer.spring.docService",
@@ -99,7 +99,7 @@ internal object ArmeriaSpringConfigRouteCollector {
             routeMatch = RouteMatch.NON_HTTP,
         ),
         InternalServiceSpec(
-            id = "health",
+            id = SpringArmeriaConfigSemantics.ID_HEALTH,
             path = { it.healthPath },
             pathElement = { it.healthPathElement ?: it.includeElement },
             messageKey = "route.explorer.spring.healthCheck",
@@ -109,7 +109,7 @@ internal object ArmeriaSpringConfigRouteCollector {
             routeMatch = RouteMatch.CONFIG,
         ),
         InternalServiceSpec(
-            id = "metrics",
+            id = SpringArmeriaConfigSemantics.ID_METRICS,
             path = { it.metricsPath },
             pathElement = { it.metricsPathElement ?: it.includeElement },
             messageKey = "route.explorer.spring.metrics",
@@ -119,7 +119,7 @@ internal object ArmeriaSpringConfigRouteCollector {
             routeMatch = RouteMatch.CONFIG,
         ),
         InternalServiceSpec(
-            id = "actuator",
+            id = SpringArmeriaConfigSemantics.ID_ACTUATOR,
             path = { "/actuator" },
             pathElement = { it.includeElement },
             messageKey = "route.explorer.spring.actuator",
@@ -129,6 +129,10 @@ internal object ArmeriaSpringConfigRouteCollector {
             routeMatch = RouteMatch.CONFIG,
         ),
     )
+
+    /** Exposed for tests — must stay equal to [SpringArmeriaConfigSemantics.INTERNAL_SERVICE_IDS]. */
+    internal fun internalServiceSpecIds(): Set<String> =
+        INTERNAL_SERVICE_SPECS.mapTo(linkedSetOf()) { it.id }
 
     fun collect(
         project: Project,

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollector.kt
@@ -10,25 +10,6 @@ import com.intellij.psi.search.FilenameIndex
 import com.intellij.psi.search.GlobalSearchScope
 import com.linecorp.intellij.plugins.armeria.message
 
-internal data class SpringArmeriaPortBinding(
-    val port: String,
-    val protocols: List<String>,
-    val element: PsiElement? = null,
-)
-
-internal data class SpringArmeriaConfig(
-    val ports: List<SpringArmeriaPortBinding> = emptyList(),
-    val includes: Set<String> = emptySet(),
-    val docsPath: String = SpringArmeriaConfigSemantics.DEFAULT_DOCS_PATH,
-    val healthPath: String = SpringArmeriaConfigSemantics.DEFAULT_HEALTH_PATH,
-    val metricsPath: String = SpringArmeriaConfigSemantics.DEFAULT_METRICS_PATH,
-    val internalServicesPort: String? = null,
-    val includeElement: PsiElement? = null,
-    val docsPathElement: PsiElement? = null,
-    val healthPathElement: PsiElement? = null,
-    val metricsPathElement: PsiElement? = null,
-)
-
 internal object ArmeriaSpringConfigRouteCollector {
     private val YAML_PLUGIN_ID = PluginId.getId("org.jetbrains.plugins.yaml")
 
@@ -183,7 +164,6 @@ internal object ArmeriaSpringConfigRouteCollector {
             val protocolIndex = match.groupValues[2].toIntOrNull()
             val protocols = SpringArmeriaConfigSemantics
                 .splitScalarList(stripPropertiesInlineComment(match.groupValues[3]))
-                .map { it.uppercase() }
                 .filter { it.isNotEmpty() }
             if (protocols.isEmpty()) {
                 return@forEach

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollector.kt
@@ -19,9 +19,9 @@ internal data class SpringArmeriaPortBinding(
 internal data class SpringArmeriaConfig(
     val ports: List<SpringArmeriaPortBinding> = emptyList(),
     val includes: Set<String> = emptySet(),
-    val docsPath: String = ArmeriaSpringConfigRouteCollector.DEFAULT_DOCS_PATH,
-    val healthPath: String = ArmeriaSpringConfigRouteCollector.DEFAULT_HEALTH_PATH,
-    val metricsPath: String = ArmeriaSpringConfigRouteCollector.DEFAULT_METRICS_PATH,
+    val docsPath: String = SpringArmeriaConfigSemantics.DEFAULT_DOCS_PATH,
+    val healthPath: String = SpringArmeriaConfigSemantics.DEFAULT_HEALTH_PATH,
+    val metricsPath: String = SpringArmeriaConfigSemantics.DEFAULT_METRICS_PATH,
     val internalServicesPort: String? = null,
     val includeElement: PsiElement? = null,
     val docsPathElement: PsiElement? = null,
@@ -30,9 +30,9 @@ internal data class SpringArmeriaConfig(
 )
 
 internal object ArmeriaSpringConfigRouteCollector {
-    const val DEFAULT_DOCS_PATH = "/internal/docs"
-    const val DEFAULT_HEALTH_PATH = "/internal/healthcheck"
-    const val DEFAULT_METRICS_PATH = "/internal/metrics"
+    const val DEFAULT_DOCS_PATH = SpringArmeriaConfigSemantics.DEFAULT_DOCS_PATH
+    const val DEFAULT_HEALTH_PATH = SpringArmeriaConfigSemantics.DEFAULT_HEALTH_PATH
+    const val DEFAULT_METRICS_PATH = SpringArmeriaConfigSemantics.DEFAULT_METRICS_PATH
 
     private val YAML_PLUGIN_ID = PluginId.getId("org.jetbrains.plugins.yaml")
 
@@ -130,9 +130,6 @@ internal object ArmeriaSpringConfigRouteCollector {
         ),
     )
 
-    private val INTERNAL_SERVICE_IDS: Set<String> =
-        INTERNAL_SERVICE_SPECS.mapTo(linkedSetOf()) { it.id }
-
     fun collect(
         project: Project,
         scope: GlobalSearchScope,
@@ -164,7 +161,7 @@ internal object ArmeriaSpringConfigRouteCollector {
         }
         val config = when {
             psiFile.name.endsWith(".properties") -> parseProperties(text)
-            isYamlPluginAvailable() -> ArmeriaYamlSpringConfigReader.read(psiFile) ?: return
+            isYamlPluginAvailable() -> ArmeriaYamlSpringConfigReader.read(psiFile)
             else -> return
         }
         emitRoutes(config, psiFile, profileFromFileName(psiFile.name), routes, seenConfigRoutes)
@@ -184,7 +181,9 @@ internal object ArmeriaSpringConfigRouteCollector {
         PROPERTIES_PROTOCOL_PATTERN.findAll(text).forEach { match ->
             val portIndex = match.groupValues[1].toIntOrNull() ?: return@forEach
             val protocolIndex = match.groupValues[2].toIntOrNull()
-            val protocols = splitScalarList(stripPropertiesInlineComment(match.groupValues[3])).map { it.uppercase() }
+            val protocols = SpringArmeriaConfigSemantics
+                .splitScalarList(stripPropertiesInlineComment(match.groupValues[3]))
+                .map { it.uppercase() }
             if (protocols.isEmpty()) {
                 return@forEach
             }
@@ -218,7 +217,7 @@ internal object ArmeriaSpringConfigRouteCollector {
         var unindexedIncludes: Set<String>? = null
         PROPERTIES_INCLUDE_PATTERN.findAll(text).forEach { match ->
             val rawValue = stripPropertiesInlineComment(match.groupValues[2])
-            val tokens = parseIncludeTokens(rawValue)
+            val tokens = SpringArmeriaConfigSemantics.parseIncludeTokens(rawValue)
             val indexGroup = match.groupValues[1]
             if (indexGroup.isEmpty()) {
                 unindexedIncludes = tokens
@@ -236,7 +235,7 @@ internal object ArmeriaSpringConfigRouteCollector {
         }
         return SpringArmeriaConfig(
             ports = ports,
-            includes = expandIncludes(includes),
+            includes = SpringArmeriaConfigSemantics.expandIncludes(includes),
             docsPath = lastPropertiesMatch(PROPERTIES_DOCS_PATH_PATTERN, text)
                 ?.let { stripPropertiesInlineComment(it).trimQuotes() }
                 ?: DEFAULT_DOCS_PATH,
@@ -309,29 +308,6 @@ internal object ArmeriaSpringConfigRouteCollector {
         }
     }
 
-    internal fun expandIncludes(raw: Set<String>): Set<String> {
-        if (raw.any { it.equals("all", ignoreCase = true) }) {
-            return INTERNAL_SERVICE_IDS
-        }
-        return raw.map { it.lowercase() }.filter { it in INTERNAL_SERVICE_IDS }.toSet()
-    }
-
-    internal fun parseIncludeTokens(raw: String): Set<String> =
-        splitScalarList(raw).map { it.lowercase() }.toSet()
-
-    internal fun splitScalarList(raw: String): List<String> {
-        val normalized = raw.trim()
-            .removePrefix("[")
-            .removeSuffix("]")
-            .trim()
-        if (normalized.isEmpty()) {
-            return emptyList()
-        }
-        return normalized.split(',', ' ', '\t')
-            .map { stripInlineComment(it).trimQuotes() }
-            .filter { it.isNotEmpty() }
-    }
-
     private fun isYamlPluginAvailable(): Boolean =
         PluginManagerCore.isLoaded(YAML_PLUGIN_ID)
 
@@ -380,27 +356,10 @@ internal object ArmeriaSpringConfigRouteCollector {
         trim().removeSurrounding("\"").removeSurrounding("'")
 
     private val PROPERTIES_INLINE_COMMENT = Regex("""\s+[#!].*$""")
-    private val INLINE_COMMENT = Regex("""\s+#.*$""")
 
     private fun lastPropertiesMatch(pattern: Regex, text: String): String? =
         pattern.findAll(text).lastOrNull()?.groupValues?.get(1)
 
     private fun stripPropertiesInlineComment(raw: String): String =
         raw.trim().replace(PROPERTIES_INLINE_COMMENT, "").trimEnd()
-
-    private fun stripInlineComment(raw: String): String {
-        val trimmed = raw.trim()
-        if (trimmed.isEmpty()) {
-            return trimmed
-        }
-        if ((trimmed.startsWith("\"") && trimmed.endsWith("\"")) ||
-            (trimmed.startsWith("'") && trimmed.endsWith("'"))
-        ) {
-            return trimmed
-        }
-        if (trimmed.startsWith("#")) {
-            return ""
-        }
-        return trimmed.replace(INLINE_COMMENT, "").trimEnd()
-    }
 }

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollector.kt
@@ -30,10 +30,6 @@ internal data class SpringArmeriaConfig(
 )
 
 internal object ArmeriaSpringConfigRouteCollector {
-    const val DEFAULT_DOCS_PATH = SpringArmeriaConfigSemantics.DEFAULT_DOCS_PATH
-    const val DEFAULT_HEALTH_PATH = SpringArmeriaConfigSemantics.DEFAULT_HEALTH_PATH
-    const val DEFAULT_METRICS_PATH = SpringArmeriaConfigSemantics.DEFAULT_METRICS_PATH
-
     private val YAML_PLUGIN_ID = PluginId.getId("org.jetbrains.plugins.yaml")
 
     private val APPLICATION_FILE_PATTERN = Regex("""^application(-[\w.-]+)?\.(yml|yaml|properties)$""")
@@ -91,7 +87,7 @@ internal object ArmeriaSpringConfigRouteCollector {
         InternalServiceSpec(
             id = SpringArmeriaConfigSemantics.ID_DOCS,
             path = { it.docsPath },
-            pathElement = { it.docsPathElement ?: it.includeElement },
+            pathElement = { it.docsPathElement },
             messageKey = "route.explorer.spring.docService",
             protocol = RouteProtocol.DOC_SERVICE.presentableName(),
             httpMethod = "",
@@ -101,7 +97,7 @@ internal object ArmeriaSpringConfigRouteCollector {
         InternalServiceSpec(
             id = SpringArmeriaConfigSemantics.ID_HEALTH,
             path = { it.healthPath },
-            pathElement = { it.healthPathElement ?: it.includeElement },
+            pathElement = { it.healthPathElement },
             messageKey = "route.explorer.spring.healthCheck",
             protocol = RouteProtocol.HTTP.presentableName(),
             httpMethod = "GET",
@@ -111,7 +107,7 @@ internal object ArmeriaSpringConfigRouteCollector {
         InternalServiceSpec(
             id = SpringArmeriaConfigSemantics.ID_METRICS,
             path = { it.metricsPath },
-            pathElement = { it.metricsPathElement ?: it.includeElement },
+            pathElement = { it.metricsPathElement },
             messageKey = "route.explorer.spring.metrics",
             protocol = RouteProtocol.HTTP.presentableName(),
             httpMethod = "GET",
@@ -121,7 +117,7 @@ internal object ArmeriaSpringConfigRouteCollector {
         InternalServiceSpec(
             id = SpringArmeriaConfigSemantics.ID_ACTUATOR,
             path = { "/actuator" },
-            pathElement = { it.includeElement },
+            pathElement = { null },
             messageKey = "route.explorer.spring.actuator",
             protocol = RouteProtocol.HTTP.presentableName(),
             httpMethod = "GET",
@@ -242,13 +238,13 @@ internal object ArmeriaSpringConfigRouteCollector {
             includes = SpringArmeriaConfigSemantics.expandIncludes(includes),
             docsPath = lastPropertiesMatch(PROPERTIES_DOCS_PATH_PATTERN, text)
                 ?.let { stripPropertiesInlineComment(it).trimQuotes() }
-                ?: DEFAULT_DOCS_PATH,
+                ?: SpringArmeriaConfigSemantics.DEFAULT_DOCS_PATH,
             healthPath = lastPropertiesMatch(PROPERTIES_HEALTH_PATH_PATTERN, text)
                 ?.let { stripPropertiesInlineComment(it).trimQuotes() }
-                ?: DEFAULT_HEALTH_PATH,
+                ?: SpringArmeriaConfigSemantics.DEFAULT_HEALTH_PATH,
             metricsPath = lastPropertiesMatch(PROPERTIES_METRICS_PATH_PATTERN, text)
                 ?.let { stripPropertiesInlineComment(it).trimQuotes() }
-                ?: DEFAULT_METRICS_PATH,
+                ?: SpringArmeriaConfigSemantics.DEFAULT_METRICS_PATH,
             internalServicesPort = lastPropertiesMatch(PROPERTIES_INTERNAL_PORT_PATTERN, text)
                 ?.let { stripPropertiesInlineComment(it) },
         )
@@ -295,7 +291,9 @@ internal object ArmeriaSpringConfigRouteCollector {
             }
             val path = spec.path(config)
             addConfigRoute(
-                element = spec.pathElement(config) ?: fallbackElement,
+                element = spec.pathElement(config)
+                    ?: config.includeElement
+                    ?: fallbackElement,
                 path = path,
                 target = profileAwareTarget(message(spec.messageKey) + portSuffix, profile),
                 protocol = spec.protocol,

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollector.kt
@@ -1,5 +1,7 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
@@ -11,6 +13,7 @@ import com.linecorp.intellij.plugins.armeria.message
 internal data class SpringArmeriaPortBinding(
     val port: String,
     val protocols: List<String>,
+    val element: PsiElement? = null,
 )
 
 internal data class SpringArmeriaConfig(
@@ -20,12 +23,18 @@ internal data class SpringArmeriaConfig(
     val healthPath: String = ArmeriaSpringConfigRouteCollector.DEFAULT_HEALTH_PATH,
     val metricsPath: String = ArmeriaSpringConfigRouteCollector.DEFAULT_METRICS_PATH,
     val internalServicesPort: String? = null,
+    val includeElement: PsiElement? = null,
+    val docsPathElement: PsiElement? = null,
+    val healthPathElement: PsiElement? = null,
+    val metricsPathElement: PsiElement? = null,
 )
 
 internal object ArmeriaSpringConfigRouteCollector {
     const val DEFAULT_DOCS_PATH = "/internal/docs"
     const val DEFAULT_HEALTH_PATH = "/internal/healthcheck"
     const val DEFAULT_METRICS_PATH = "/internal/metrics"
+
+    private val YAML_PLUGIN_ID = PluginId.getId("org.jetbrains.plugins.yaml")
 
     private val APPLICATION_FILE_PATTERN = Regex("""^application(-[\w.-]+)?\.(yml|yaml|properties)$""")
     private val PROPERTIES_DELIMITER = """[:=]"""
@@ -70,6 +79,7 @@ internal object ArmeriaSpringConfigRouteCollector {
     private data class InternalServiceSpec(
         val id: String,
         val path: (SpringArmeriaConfig) -> String,
+        val pathElement: (SpringArmeriaConfig) -> PsiElement?,
         val messageKey: String,
         val protocol: String,
         val httpMethod: String,
@@ -81,6 +91,7 @@ internal object ArmeriaSpringConfigRouteCollector {
         InternalServiceSpec(
             id = "docs",
             path = { it.docsPath },
+            pathElement = { it.docsPathElement ?: it.includeElement },
             messageKey = "route.explorer.spring.docService",
             protocol = RouteProtocol.DOC_SERVICE.presentableName(),
             httpMethod = "",
@@ -90,6 +101,7 @@ internal object ArmeriaSpringConfigRouteCollector {
         InternalServiceSpec(
             id = "health",
             path = { it.healthPath },
+            pathElement = { it.healthPathElement ?: it.includeElement },
             messageKey = "route.explorer.spring.healthCheck",
             protocol = RouteProtocol.HTTP.presentableName(),
             httpMethod = "GET",
@@ -99,6 +111,7 @@ internal object ArmeriaSpringConfigRouteCollector {
         InternalServiceSpec(
             id = "metrics",
             path = { it.metricsPath },
+            pathElement = { it.metricsPathElement ?: it.includeElement },
             messageKey = "route.explorer.spring.metrics",
             protocol = RouteProtocol.HTTP.presentableName(),
             httpMethod = "GET",
@@ -108,6 +121,7 @@ internal object ArmeriaSpringConfigRouteCollector {
         InternalServiceSpec(
             id = "actuator",
             path = { "/actuator" },
+            pathElement = { it.includeElement },
             messageKey = "route.explorer.spring.actuator",
             protocol = RouteProtocol.HTTP.presentableName(),
             httpMethod = "GET",
@@ -148,29 +162,12 @@ internal object ArmeriaSpringConfigRouteCollector {
         if (!text.contains("armeria")) {
             return
         }
-        val config = if (psiFile.name.endsWith(".properties")) {
-            parseProperties(text)
-        } else {
-            parseYaml(text)
+        val config = when {
+            psiFile.name.endsWith(".properties") -> parseProperties(text)
+            isYamlPluginAvailable() -> ArmeriaYamlSpringConfigReader.read(psiFile) ?: return
+            else -> return
         }
         emitRoutes(config, psiFile, profileFromFileName(psiFile.name), routes, seenConfigRoutes)
-    }
-
-    internal fun parseYaml(text: String): SpringArmeriaConfig {
-        val armeriaBlock = extractTopLevelBlock(text, "armeria") ?: return SpringArmeriaConfig()
-        val ports = parseYamlPorts(extractChildBlock(armeriaBlock, "ports"))
-        val internalServicesBlock = extractChildBlock(armeriaBlock, "internal-services", "internalServices")
-        val includes = parseYamlInclude(internalServicesBlock)
-        val internalServicesPort = readYamlScalar(internalServicesBlock, "port")
-        return SpringArmeriaConfig(
-            ports = ports,
-            includes = includes,
-            docsPath = readYamlScalar(armeriaBlock, "docs-path", "docsPath") ?: DEFAULT_DOCS_PATH,
-            healthPath = readYamlScalar(armeriaBlock, "health-check-path", "healthCheckPath")
-                ?: DEFAULT_HEALTH_PATH,
-            metricsPath = readYamlScalar(armeriaBlock, "metrics-path", "metricsPath") ?: DEFAULT_METRICS_PATH,
-            internalServicesPort = internalServicesPort,
-        )
     }
 
     internal fun parseProperties(text: String): SpringArmeriaConfig {
@@ -256,7 +253,7 @@ internal object ArmeriaSpringConfigRouteCollector {
 
     internal fun emitRoutes(
         config: SpringArmeriaConfig,
-        element: PsiElement,
+        fallbackElement: PsiElement,
         profile: String?,
         routes: MutableList<ArmeriaRoute>,
         seenConfigRoutes: MutableSet<String>,
@@ -266,7 +263,7 @@ internal object ArmeriaSpringConfigRouteCollector {
             // Synthetic path so the tree row (pill + path) shows the port; "/" collides with
             // real root mounts and hides the binding in the explorer list.
             addConfigRoute(
-                element = element,
+                element = binding.element ?: fallbackElement,
                 path = ":${binding.port}",
                 target = profileAwareTarget(
                     message("route.explorer.spring.port", binding.port, protocolLabel),
@@ -295,7 +292,7 @@ internal object ArmeriaSpringConfigRouteCollector {
             }
             val path = spec.path(config)
             addConfigRoute(
-                element = element,
+                element = spec.pathElement(config) ?: fallbackElement,
                 path = path,
                 target = profileAwareTarget(message(spec.messageKey) + portSuffix, profile),
                 protocol = spec.protocol,
@@ -312,95 +309,17 @@ internal object ArmeriaSpringConfigRouteCollector {
         }
     }
 
-    private fun isApplicationConfigFile(name: String): Boolean = APPLICATION_FILE_PATTERN.matches(name)
-
-    private fun profileFromFileName(name: String): String? {
-        val match = APPLICATION_FILE_PATTERN.matchEntire(name) ?: return null
-        val suffix = match.groupValues[1]
-        return suffix.removePrefix("-").takeIf { it.isNotEmpty() }
-    }
-
-    private fun parseYamlPorts(portsBlock: String?): List<SpringArmeriaPortBinding> {
-        if (portsBlock.isNullOrBlank()) {
-            return emptyList()
-        }
-        val items = splitYamlListItems(portsBlock)
-        val bindings = mutableListOf<SpringArmeriaPortBinding>()
-        val seenPorts = mutableSetOf<String>()
-        for (item in items) {
-            val values = parseYamlMapping(item)
-            val port = values["port"]?.firstOrNull() ?: continue
-            if (!seenPorts.add(port)) {
-                continue
-            }
-            val protocols = values["protocols"]
-                ?.map { it.uppercase() }
-                ?.distinct()
-                .orEmpty()
-                .ifEmpty { listOf("HTTP") }
-            bindings += SpringArmeriaPortBinding(port = port, protocols = protocols)
-        }
-        return bindings
-    }
-
-    private fun parseYamlInclude(internalServicesBlock: String?): Set<String> {
-        if (internalServicesBlock.isNullOrBlank()) {
-            return emptySet()
-        }
-        val lines = internalServicesBlock.lineSequence().toList()
-        var topIndent: Int? = null
-        val includeIndex = lines.indexOfFirst { line ->
-            if (line.isBlank() || line.trimStart().startsWith("#")) {
-                return@indexOfFirst false
-            }
-            val indent = line.takeWhile { it.isWhitespace() }.length
-            if (topIndent == null) {
-                topIndent = indent
-            } else if (indent > topIndent) {
-                // Nested under another child of internal-services — skip.
-                return@indexOfFirst false
-            }
-            val trimmed = line.trim()
-            trimmed == "include:" || trimmed.startsWith("include:")
-        }
-        if (includeIndex < 0) {
-            return emptySet()
-        }
-        val includeLine = lines[includeIndex]
-        val inline = stripYamlInlineComment(includeLine.substringAfter("include:", missingDelimiterValue = ""))
-        val tokens = mutableListOf<String>()
-        if (inline.isNotEmpty()) {
-            tokens += parseIncludeTokens(inline)
-        }
-        val includeIndent = includeLine.takeWhile { it.isWhitespace() }.length
-        for (index in includeIndex + 1 until lines.size) {
-            val line = lines[index]
-            if (line.isBlank() || line.trimStart().startsWith("#")) {
-                continue
-            }
-            val indent = line.takeWhile { it.isWhitespace() }.length
-            if (indent <= includeIndent) {
-                break
-            }
-            val trimmed = line.trim()
-            if (trimmed.startsWith("- ")) {
-                tokens += parseIncludeTokens(stripYamlInlineComment(trimmed.removePrefix("- ")))
-            }
-        }
-        return expandIncludes(tokens.toSet())
-    }
-
-    private fun expandIncludes(raw: Set<String>): Set<String> {
+    internal fun expandIncludes(raw: Set<String>): Set<String> {
         if (raw.any { it.equals("all", ignoreCase = true) }) {
             return INTERNAL_SERVICE_IDS
         }
         return raw.map { it.lowercase() }.filter { it in INTERNAL_SERVICE_IDS }.toSet()
     }
 
-    private fun parseIncludeTokens(raw: String): Set<String> =
+    internal fun parseIncludeTokens(raw: String): Set<String> =
         splitScalarList(raw).map { it.lowercase() }.toSet()
 
-    private fun splitScalarList(raw: String): List<String> {
+    internal fun splitScalarList(raw: String): List<String> {
         val normalized = raw.trim()
             .removePrefix("[")
             .removeSuffix("]")
@@ -409,201 +328,20 @@ internal object ArmeriaSpringConfigRouteCollector {
             return emptyList()
         }
         return normalized.split(',', ' ', '\t')
-            .map { stripYamlInlineComment(it).trimQuotes() }
+            .map { stripInlineComment(it).trimQuotes() }
             .filter { it.isNotEmpty() }
     }
 
-    private fun extractTopLevelBlock(text: String, key: String): String? {
-        val lines = text.lineSequence().toList()
-        val startIndex = lines.indexOfFirst { line ->
-            if (line.takeWhile { it.isWhitespace() }.isNotEmpty()) {
-                return@indexOfFirst false
-            }
-            val trimmed = line.trim()
-            !trimmed.startsWith("#") && matchesYamlKey(trimmed, key)
-        }
-        if (startIndex < 0) {
-            return null
-        }
-        return collectIndentedBlock(lines, startIndex, parentIndent = 0)
+    private fun isYamlPluginAvailable(): Boolean =
+        PluginManagerCore.isLoaded(YAML_PLUGIN_ID)
+
+    private fun isApplicationConfigFile(name: String): Boolean = APPLICATION_FILE_PATTERN.matches(name)
+
+    private fun profileFromFileName(name: String): String? {
+        val match = APPLICATION_FILE_PATTERN.matchEntire(name) ?: return null
+        val suffix = match.groupValues[1]
+        return suffix.removePrefix("-").takeIf { it.isNotEmpty() }
     }
-
-    private fun extractChildBlock(parentBlock: String, vararg keys: String): String? {
-        val lines = parentBlock.lineSequence().toList()
-        var topIndent: Int? = null
-        val startIndex = lines.indexOfFirst { line ->
-            if (line.isBlank() || line.trimStart().startsWith("#")) {
-                return@indexOfFirst false
-            }
-            val indent = line.takeWhile { it.isWhitespace() }.length
-            if (topIndent == null) {
-                topIndent = indent
-            } else if (indent > topIndent) {
-                // Nested under another child of the parent — skip (e.g. armeria.foo.ports).
-                return@indexOfFirst false
-            }
-            val trimmed = line.trim()
-            keys.any { matchesYamlKey(trimmed, it) }
-        }
-        if (startIndex < 0) {
-            return null
-        }
-        val childIndent = lines[startIndex].takeWhile { it.isWhitespace() }.length
-        return collectIndentedBlock(lines, startIndex, childIndent)
-    }
-
-    private fun collectIndentedBlock(lines: List<String>, startIndex: Int, parentIndent: Int): String {
-        val childLines = mutableListOf<String>()
-        for (index in startIndex + 1 until lines.size) {
-            val line = lines[index]
-            if (line.isBlank() || line.trimStart().startsWith("#")) {
-                if (childLines.isNotEmpty()) {
-                    childLines += line
-                }
-                continue
-            }
-            val indent = line.takeWhile { it.isWhitespace() }.length
-            if (indent <= parentIndent) {
-                break
-            }
-            childLines += line
-        }
-        return childLines.joinToString("\n")
-    }
-
-    private fun splitYamlListItems(block: String): List<String> {
-        val lines = block.lineSequence().toList()
-        val items = mutableListOf<String>()
-        var current = mutableListOf<String>()
-        var itemIndent = -1
-        for (line in lines) {
-            if (line.isBlank() || line.trimStart().startsWith("#")) {
-                if (current.isNotEmpty()) {
-                    current += line
-                }
-                continue
-            }
-            val indent = line.takeWhile { it.isWhitespace() }.length
-            val trimmed = line.trimStart()
-            if (trimmed.startsWith("- ")) {
-                if (itemIndent < 0 || indent <= itemIndent) {
-                    if (current.isNotEmpty()) {
-                        items += current.joinToString("\n")
-                    }
-                    current = mutableListOf(line)
-                    itemIndent = indent
-                } else {
-                    current += line
-                }
-                continue
-            }
-            if (itemIndent >= 0 && indent > itemIndent) {
-                current += line
-            }
-        }
-        if (current.isNotEmpty()) {
-            items += current.joinToString("\n")
-        }
-        return items
-    }
-
-    private fun parseYamlMapping(itemText: String): Map<String, List<String>> {
-        val values = linkedMapOf<String, MutableList<String>>()
-        // Normalize only the leading list marker on the first line so sibling keys share indent.
-        val rawLines = itemText.lineSequence().toList()
-        val lines = rawLines.mapIndexed { index, line ->
-            if (index != 0) {
-                return@mapIndexed line
-            }
-            val match = LIST_ITEM_PREFIX.find(line) ?: return@mapIndexed line
-            match.groupValues[1] + "  " + line.substring(match.range.last + 1)
-        }
-        var index = 0
-        while (index < lines.size) {
-            val line = lines[index]
-            if (line.isBlank() || line.trimStart().startsWith("#")) {
-                index++
-                continue
-            }
-            val trimmed = line.trim()
-            if (!trimmed.contains(':')) {
-                index++
-                continue
-            }
-            val key = trimmed.substringBefore(':').trim()
-            val inlineValue = stripYamlInlineComment(trimmed.substringAfter(':', missingDelimiterValue = ""))
-            val keyIndent = line.takeWhile { it.isWhitespace() }.length
-            if (inlineValue.isNotEmpty()) {
-                values.getOrPut(key) { mutableListOf() } += splitScalarList(inlineValue)
-                index++
-                continue
-            }
-            val nested = mutableListOf<String>()
-            var nestedIndex = index + 1
-            while (nestedIndex < lines.size) {
-                val nestedLine = lines[nestedIndex]
-                if (nestedLine.isBlank() || nestedLine.trimStart().startsWith("#")) {
-                    nestedIndex++
-                    continue
-                }
-                val nestedIndent = nestedLine.takeWhile { it.isWhitespace() }.length
-                if (nestedIndent <= keyIndent) {
-                    break
-                }
-                val nestedTrimmed = nestedLine.trim()
-                if (nestedTrimmed.startsWith("- ")) {
-                    nested += stripYamlInlineComment(nestedTrimmed.removePrefix("- ")).trimQuotes()
-                } else if (nestedTrimmed.contains(':')) {
-                    break
-                } else {
-                    nested += stripYamlInlineComment(nestedTrimmed).trimQuotes()
-                }
-                nestedIndex++
-            }
-            if (nested.isNotEmpty()) {
-                values.getOrPut(key) { mutableListOf() } += nested
-            }
-            index = nestedIndex
-        }
-        return values
-    }
-
-    private val LIST_ITEM_PREFIX = Regex("""^(\s*)- """)
-
-    private fun readYamlScalar(block: String?, vararg keys: String): String? {
-        if (block.isNullOrBlank()) {
-            return null
-        }
-        val keySet = keys.toSet()
-        var topIndent: Int? = null
-        for (line in block.lineSequence()) {
-            if (line.isBlank() || line.trimStart().startsWith("#")) {
-                continue
-            }
-            val indent = line.takeWhile { it.isWhitespace() }.length
-            if (topIndent == null) {
-                topIndent = indent
-            } else if (indent > topIndent) {
-                continue
-            }
-            val trimmed = line.trim()
-            if (!trimmed.contains(':')) {
-                continue
-            }
-            val key = trimmed.substringBefore(':').trim()
-            if (key !in keySet) {
-                continue
-            }
-            val value = stripYamlInlineComment(trimmed.substringAfter(':', missingDelimiterValue = ""))
-            if (value.isNotEmpty()) {
-                return value.trimQuotes()
-            }
-        }
-        return null
-    }
-
-    private fun matchesYamlKey(trimmed: String, key: String): Boolean =
-        trimmed == "$key:" || trimmed.startsWith("$key:")
 
     private fun addConfigRoute(
         element: PsiElement,
@@ -641,8 +379,8 @@ internal object ArmeriaSpringConfigRouteCollector {
     private fun String.trimQuotes(): String =
         trim().removeSurrounding("\"").removeSurrounding("'")
 
-    private val YAML_INLINE_COMMENT = Regex("""\s+#.*$""")
     private val PROPERTIES_INLINE_COMMENT = Regex("""\s+[#!].*$""")
+    private val INLINE_COMMENT = Regex("""\s+#.*$""")
 
     private fun lastPropertiesMatch(pattern: Regex, text: String): String? =
         pattern.findAll(text).lastOrNull()?.groupValues?.get(1)
@@ -650,7 +388,7 @@ internal object ArmeriaSpringConfigRouteCollector {
     private fun stripPropertiesInlineComment(raw: String): String =
         raw.trim().replace(PROPERTIES_INLINE_COMMENT, "").trimEnd()
 
-    private fun stripYamlInlineComment(raw: String): String {
+    private fun stripInlineComment(raw: String): String {
         val trimmed = raw.trim()
         if (trimmed.isEmpty()) {
             return trimmed
@@ -663,6 +401,6 @@ internal object ArmeriaSpringConfigRouteCollector {
         if (trimmed.startsWith("#")) {
             return ""
         }
-        return trimmed.replace(YAML_INLINE_COMMENT, "").trimEnd()
+        return trimmed.replace(INLINE_COMMENT, "").trimEnd()
     }
 }

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollector.kt
@@ -184,6 +184,7 @@ internal object ArmeriaSpringConfigRouteCollector {
             val protocols = SpringArmeriaConfigSemantics
                 .splitScalarList(stripPropertiesInlineComment(match.groupValues[3]))
                 .map { it.uppercase() }
+                .filter { it.isNotEmpty() }
             if (protocols.isEmpty()) {
                 return@forEach
             }
@@ -202,13 +203,13 @@ internal object ArmeriaSpringConfigRouteCollector {
         val ports = portsByIndex.entries
             .sortedBy { it.key }
             .map { (index, port) ->
-                val protocols = protocolsByIndex[index]
-                    ?.entries
-                    ?.sortedBy { it.key }
-                    ?.map { it.value }
-                    ?.distinct()
-                    .orEmpty()
-                    .ifEmpty { listOf("HTTP") }
+                val protocols = SpringArmeriaConfigSemantics.normalizeProtocols(
+                    protocolsByIndex[index]
+                        ?.entries
+                        ?.sortedBy { it.key }
+                        ?.map { it.value }
+                        .orEmpty(),
+                )
                 SpringArmeriaPortBinding(port = port, protocols = protocols)
             }
 
@@ -237,13 +238,13 @@ internal object ArmeriaSpringConfigRouteCollector {
             ports = ports,
             includes = SpringArmeriaConfigSemantics.expandIncludes(includes),
             docsPath = lastPropertiesMatch(PROPERTIES_DOCS_PATH_PATTERN, text)
-                ?.let { stripPropertiesInlineComment(it).trimQuotes() }
+                ?.let { SpringArmeriaConfigSemantics.trimQuotes(stripPropertiesInlineComment(it)) }
                 ?: SpringArmeriaConfigSemantics.DEFAULT_DOCS_PATH,
             healthPath = lastPropertiesMatch(PROPERTIES_HEALTH_PATH_PATTERN, text)
-                ?.let { stripPropertiesInlineComment(it).trimQuotes() }
+                ?.let { SpringArmeriaConfigSemantics.trimQuotes(stripPropertiesInlineComment(it)) }
                 ?: SpringArmeriaConfigSemantics.DEFAULT_HEALTH_PATH,
             metricsPath = lastPropertiesMatch(PROPERTIES_METRICS_PATH_PATTERN, text)
-                ?.let { stripPropertiesInlineComment(it).trimQuotes() }
+                ?.let { SpringArmeriaConfigSemantics.trimQuotes(stripPropertiesInlineComment(it)) }
                 ?: SpringArmeriaConfigSemantics.DEFAULT_METRICS_PATH,
             internalServicesPort = lastPropertiesMatch(PROPERTIES_INTERNAL_PORT_PATTERN, text)
                 ?.let { stripPropertiesInlineComment(it) },
@@ -262,7 +263,7 @@ internal object ArmeriaSpringConfigRouteCollector {
             // Synthetic path so the tree row (pill + path) shows the port; "/" collides with
             // real root mounts and hides the binding in the explorer list.
             addConfigRoute(
-                element = binding.element ?: fallbackElement,
+                element = navigationElement(binding.element, fallbackElement),
                 path = ":${binding.port}",
                 target = profileAwareTarget(
                     message("route.explorer.spring.port", binding.port, protocolLabel),
@@ -291,9 +292,10 @@ internal object ArmeriaSpringConfigRouteCollector {
             }
             val path = spec.path(config)
             addConfigRoute(
-                element = spec.pathElement(config)
-                    ?: config.includeElement
-                    ?: fallbackElement,
+                element = navigationElement(
+                    spec.pathElement(config) ?: config.includeElement,
+                    fallbackElement,
+                ),
                 path = path,
                 target = profileAwareTarget(message(spec.messageKey) + portSuffix, profile),
                 protocol = spec.protocol,
@@ -308,6 +310,27 @@ internal object ArmeriaSpringConfigRouteCollector {
                 seenConfigRoutes = seenConfigRoutes,
             )
         }
+    }
+
+    /**
+     * Keep key-level YAML PSI only when it lives in the same file the user opened. Dummy trees
+     * from Plain Text-typed YAML share no virtual file with [fallback], so navigation falls back.
+     */
+    private fun navigationElement(candidate: PsiElement?, fallback: PsiElement): PsiElement {
+        if (candidate == null) {
+            return fallback
+        }
+        val candidateFile = candidate.containingFile
+        val fallbackFile = fallback.containingFile
+        if (candidateFile === fallbackFile) {
+            return candidate
+        }
+        val candidateVf = candidateFile?.virtualFile
+        val fallbackVf = fallbackFile?.virtualFile
+        if (candidateVf != null && candidateVf == fallbackVf) {
+            return candidate
+        }
+        return fallback
     }
 
     private fun isYamlPluginAvailable(): Boolean =
@@ -353,9 +376,6 @@ internal object ArmeriaSpringConfigRouteCollector {
 
     private fun profileAwareKey(base: String, profile: String?): String =
         if (profile.isNullOrEmpty()) base else "$base@$profile"
-
-    private fun String.trimQuotes(): String =
-        trim().removeSurrounding("\"").removeSurrounding("'")
 
     private val PROPERTIES_INLINE_COMMENT = Regex("""\s+[#!].*$""")
 

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaYamlSpringConfigReader.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaYamlSpringConfigReader.kt
@@ -1,6 +1,8 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
 import com.intellij.psi.PsiFile
+import org.jetbrains.yaml.YAMLElementGenerator
+import org.jetbrains.yaml.YAMLLanguage
 import org.jetbrains.yaml.psi.YAMLFile
 import org.jetbrains.yaml.psi.YAMLKeyValue
 import org.jetbrains.yaml.psi.YAMLMapping
@@ -13,10 +15,36 @@ import org.jetbrains.yaml.psi.YAMLValue
  * Call only when `org.jetbrains.plugins.yaml` is loaded.
  */
 internal object ArmeriaYamlSpringConfigReader {
-    fun read(psiFile: PsiFile): SpringArmeriaConfig? {
-        val yamlFile = psiFile as? YAMLFile ?: return null
+    fun read(psiFile: PsiFile): SpringArmeriaConfig {
+        val resolved = resolveYamlFile(psiFile)
+        return readYamlFile(resolved.file, attachElements = resolved.attachElements)
+    }
+
+    private data class ResolvedYamlFile(
+        val file: YAMLFile,
+        val attachElements: Boolean,
+    )
+
+    /**
+     * Prefer the real YAML PSI for the file (key-level navigation). If the file is not a
+     * [YAMLFile] — e.g. marked as Plain Text — parse a throwaway tree from text and leave
+     * navigation on the original [PsiFile] via null element fields.
+     */
+    private fun resolveYamlFile(psiFile: PsiFile): ResolvedYamlFile {
+        (psiFile as? YAMLFile)?.let {
+            return ResolvedYamlFile(it, attachElements = true)
+        }
+        (psiFile.viewProvider.getPsi(YAMLLanguage.INSTANCE) as? YAMLFile)?.let {
+            return ResolvedYamlFile(it, attachElements = true)
+        }
+        val dummy = YAMLElementGenerator.getInstance(psiFile.project)
+            .createDummyYamlWithText(psiFile.text)
+        return ResolvedYamlFile(dummy, attachElements = false)
+    }
+
+    private fun readYamlFile(yamlFile: YAMLFile, attachElements: Boolean): SpringArmeriaConfig {
         val armeria = findTopLevelArmeriaMapping(yamlFile) ?: return SpringArmeriaConfig()
-        val ports = readPorts(armeria)
+        val ports = readPorts(armeria, attachElements)
         val internalServices = childMapping(armeria, "internal-services", "internalServices")
         val includeKv = internalServices?.let { childKeyValue(it, "include") }
         val includes = readIncludes(includeKv)
@@ -28,16 +56,16 @@ internal object ArmeriaYamlSpringConfigReader {
             ports = ports,
             includes = includes,
             docsPath = scalarText(docsPathKv?.value)
-                ?: ArmeriaSpringConfigRouteCollector.DEFAULT_DOCS_PATH,
+                ?: SpringArmeriaConfigSemantics.DEFAULT_DOCS_PATH,
             healthPath = scalarText(healthPathKv?.value)
-                ?: ArmeriaSpringConfigRouteCollector.DEFAULT_HEALTH_PATH,
+                ?: SpringArmeriaConfigSemantics.DEFAULT_HEALTH_PATH,
             metricsPath = scalarText(metricsPathKv?.value)
-                ?: ArmeriaSpringConfigRouteCollector.DEFAULT_METRICS_PATH,
+                ?: SpringArmeriaConfigSemantics.DEFAULT_METRICS_PATH,
             internalServicesPort = internalServicesPort,
-            includeElement = includeKv,
-            docsPathElement = docsPathKv,
-            healthPathElement = healthPathKv,
-            metricsPathElement = metricsPathKv,
+            includeElement = includeKv.takeIf { attachElements },
+            docsPathElement = docsPathKv.takeIf { attachElements },
+            healthPathElement = healthPathKv.takeIf { attachElements },
+            metricsPathElement = metricsPathKv.takeIf { attachElements },
         )
     }
 
@@ -51,7 +79,7 @@ internal object ArmeriaYamlSpringConfigReader {
         return null
     }
 
-    private fun readPorts(armeria: YAMLMapping): List<SpringArmeriaPortBinding> {
+    private fun readPorts(armeria: YAMLMapping, attachElements: Boolean): List<SpringArmeriaPortBinding> {
         val portsKv = childKeyValue(armeria, "ports") ?: return emptyList()
         val sequence = portsKv.value as? YAMLSequence ?: return emptyList()
         val bindings = mutableListOf<SpringArmeriaPortBinding>()
@@ -67,7 +95,7 @@ internal object ArmeriaYamlSpringConfigReader {
             bindings += SpringArmeriaPortBinding(
                 port = port,
                 protocols = protocols,
-                element = portKv ?: item,
+                element = if (attachElements) (portKv ?: item) else null,
             )
         }
         return bindings
@@ -77,7 +105,7 @@ internal object ArmeriaYamlSpringConfigReader {
         val value = protocolsKv?.value
         val tokens = when (value) {
             is YAMLSequence -> value.items.mapNotNull { scalarText(it.value) }
-            is YAMLScalar -> ArmeriaSpringConfigRouteCollector.splitScalarList(value.textValue)
+            is YAMLScalar -> SpringArmeriaConfigSemantics.splitScalarList(value.textValue)
             else -> emptyList()
         }
         return tokens
@@ -94,11 +122,11 @@ internal object ArmeriaYamlSpringConfigReader {
         val value = includeKv.value
         val tokens = when (value) {
             is YAMLSequence -> value.items.mapNotNull { scalarText(it.value) }.map { it.lowercase() }.toSet()
-            is YAMLScalar -> ArmeriaSpringConfigRouteCollector.parseIncludeTokens(value.textValue)
+            is YAMLScalar -> SpringArmeriaConfigSemantics.parseIncludeTokens(value.textValue)
             null -> emptySet()
             else -> emptySet()
         }
-        return ArmeriaSpringConfigRouteCollector.expandIncludes(tokens)
+        return SpringArmeriaConfigSemantics.expandIncludes(tokens)
     }
 
     private fun childMapping(parent: YAMLMapping, vararg keys: String): YAMLMapping? {

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaYamlSpringConfigReader.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaYamlSpringConfigReader.kt
@@ -45,12 +45,9 @@ internal object ArmeriaYamlSpringConfigReader {
         return SpringArmeriaConfig(
             ports = ports,
             includes = includes,
-            docsPath = scalarText(docsPathKv?.value)
-                ?: SpringArmeriaConfigSemantics.DEFAULT_DOCS_PATH,
-            healthPath = scalarText(healthPathKv?.value)
-                ?: SpringArmeriaConfigSemantics.DEFAULT_HEALTH_PATH,
-            metricsPath = scalarText(metricsPathKv?.value)
-                ?: SpringArmeriaConfigSemantics.DEFAULT_METRICS_PATH,
+            docsPath = scalarText(docsPathKv?.value),
+            healthPath = scalarText(healthPathKv?.value),
+            metricsPath = scalarText(metricsPathKv?.value),
             internalServicesPort = internalServicesPort,
             includeElement = includeKv,
             docsPathElement = docsPathKv,

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaYamlSpringConfigReader.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaYamlSpringConfigReader.kt
@@ -16,35 +16,25 @@ import org.jetbrains.yaml.psi.YAMLValue
  */
 internal object ArmeriaYamlSpringConfigReader {
     fun read(psiFile: PsiFile): SpringArmeriaConfig {
-        val resolved = resolveYamlFile(psiFile)
-        return readYamlFile(resolved.file, attachElements = resolved.attachElements)
+        val yamlFile = resolveYamlFile(psiFile)
+        return readYamlFile(yamlFile)
     }
-
-    private data class ResolvedYamlFile(
-        val file: YAMLFile,
-        val attachElements: Boolean,
-    )
 
     /**
      * Prefer the real YAML PSI for the file (key-level navigation). If the file is not a
-     * [YAMLFile] — e.g. marked as Plain Text — parse a throwaway tree from text and leave
-     * navigation on the original [PsiFile] via null element fields.
+     * [YAMLFile] — e.g. marked as Plain Text — parse a throwaway tree from text. Emit-time
+     * navigation keeps only elements whose containing file matches the original config file.
      */
-    private fun resolveYamlFile(psiFile: PsiFile): ResolvedYamlFile {
-        (psiFile as? YAMLFile)?.let {
-            return ResolvedYamlFile(it, attachElements = true)
-        }
-        (psiFile.viewProvider.getPsi(YAMLLanguage.INSTANCE) as? YAMLFile)?.let {
-            return ResolvedYamlFile(it, attachElements = true)
-        }
-        val dummy = YAMLElementGenerator.getInstance(psiFile.project)
+    private fun resolveYamlFile(psiFile: PsiFile): YAMLFile {
+        (psiFile as? YAMLFile)?.let { return it }
+        (psiFile.viewProvider.getPsi(YAMLLanguage.INSTANCE) as? YAMLFile)?.let { return it }
+        return YAMLElementGenerator.getInstance(psiFile.project)
             .createDummyYamlWithText(psiFile.text)
-        return ResolvedYamlFile(dummy, attachElements = false)
     }
 
-    private fun readYamlFile(yamlFile: YAMLFile, attachElements: Boolean): SpringArmeriaConfig {
+    private fun readYamlFile(yamlFile: YAMLFile): SpringArmeriaConfig {
         val armeria = findTopLevelArmeriaMapping(yamlFile) ?: return SpringArmeriaConfig()
-        val ports = readPorts(armeria, attachElements)
+        val ports = readPorts(armeria)
         val internalServices = childMapping(armeria, "internal-services", "internalServices")
         val includeKv = internalServices?.let { childKeyValue(it, "include") }
         val includes = readIncludes(includeKv)
@@ -62,10 +52,10 @@ internal object ArmeriaYamlSpringConfigReader {
             metricsPath = scalarText(metricsPathKv?.value)
                 ?: SpringArmeriaConfigSemantics.DEFAULT_METRICS_PATH,
             internalServicesPort = internalServicesPort,
-            includeElement = includeKv.takeIf { attachElements },
-            docsPathElement = docsPathKv.takeIf { attachElements },
-            healthPathElement = healthPathKv.takeIf { attachElements },
-            metricsPathElement = metricsPathKv.takeIf { attachElements },
+            includeElement = includeKv,
+            docsPathElement = docsPathKv,
+            healthPathElement = healthPathKv,
+            metricsPathElement = metricsPathKv,
         )
     }
 
@@ -79,7 +69,7 @@ internal object ArmeriaYamlSpringConfigReader {
         return null
     }
 
-    private fun readPorts(armeria: YAMLMapping, attachElements: Boolean): List<SpringArmeriaPortBinding> {
+    private fun readPorts(armeria: YAMLMapping): List<SpringArmeriaPortBinding> {
         val portsKv = childKeyValue(armeria, "ports") ?: return emptyList()
         val sequence = portsKv.value as? YAMLSequence ?: return emptyList()
         val bindings = mutableListOf<SpringArmeriaPortBinding>()
@@ -96,7 +86,7 @@ internal object ArmeriaYamlSpringConfigReader {
                 port = port,
                 protocols = protocols,
                 // portKv is non-null here: scalarText(portKv?.value) already continued otherwise.
-                element = if (attachElements) portKv else null,
+                element = portKv,
             )
         }
         return bindings
@@ -109,11 +99,7 @@ internal object ArmeriaYamlSpringConfigReader {
             is YAMLScalar -> SpringArmeriaConfigSemantics.splitScalarList(value.textValue)
             else -> emptyList()
         }
-        return tokens
-            .map { it.uppercase() }
-            .filter { it.isNotEmpty() }
-            .distinct()
-            .ifEmpty { listOf("HTTP") }
+        return SpringArmeriaConfigSemantics.normalizeProtocols(tokens)
     }
 
     private fun readIncludes(includeKv: YAMLKeyValue?): Set<String> {
@@ -121,6 +107,7 @@ internal object ArmeriaYamlSpringConfigReader {
             return emptySet()
         }
         val value = includeKv.value
+        // Sequence items are already discrete tokens; scalars need comma/space tokenization.
         val tokens = when (value) {
             is YAMLSequence -> value.items.mapNotNull { scalarText(it.value) }.toSet()
             is YAMLScalar -> SpringArmeriaConfigSemantics.parseIncludeTokens(value.textValue)

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaYamlSpringConfigReader.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaYamlSpringConfigReader.kt
@@ -95,7 +95,8 @@ internal object ArmeriaYamlSpringConfigReader {
             bindings += SpringArmeriaPortBinding(
                 port = port,
                 protocols = protocols,
-                element = if (attachElements) (portKv ?: item) else null,
+                // portKv is non-null here: scalarText(portKv?.value) already continued otherwise.
+                element = if (attachElements) portKv else null,
             )
         }
         return bindings
@@ -121,9 +122,8 @@ internal object ArmeriaYamlSpringConfigReader {
         }
         val value = includeKv.value
         val tokens = when (value) {
-            is YAMLSequence -> value.items.mapNotNull { scalarText(it.value) }.map { it.lowercase() }.toSet()
+            is YAMLSequence -> value.items.mapNotNull { scalarText(it.value) }.toSet()
             is YAMLScalar -> SpringArmeriaConfigSemantics.parseIncludeTokens(value.textValue)
-            null -> emptySet()
             else -> emptySet()
         }
         return SpringArmeriaConfigSemantics.expandIncludes(tokens)

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaYamlSpringConfigReader.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaYamlSpringConfigReader.kt
@@ -1,0 +1,124 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.intellij.psi.PsiFile
+import org.jetbrains.yaml.psi.YAMLFile
+import org.jetbrains.yaml.psi.YAMLKeyValue
+import org.jetbrains.yaml.psi.YAMLMapping
+import org.jetbrains.yaml.psi.YAMLScalar
+import org.jetbrains.yaml.psi.YAMLSequence
+import org.jetbrains.yaml.psi.YAMLValue
+
+/**
+ * Reads `armeria.*` Spring Boot settings from application YAML via the bundled YAML plugin PSI.
+ * Call only when `org.jetbrains.plugins.yaml` is loaded.
+ */
+internal object ArmeriaYamlSpringConfigReader {
+    fun read(psiFile: PsiFile): SpringArmeriaConfig? {
+        val yamlFile = psiFile as? YAMLFile ?: return null
+        val armeria = findTopLevelArmeriaMapping(yamlFile) ?: return SpringArmeriaConfig()
+        val ports = readPorts(armeria)
+        val internalServices = childMapping(armeria, "internal-services", "internalServices")
+        val includeKv = internalServices?.let { childKeyValue(it, "include") }
+        val includes = readIncludes(includeKv)
+        val internalServicesPort = scalarText(childKeyValue(internalServices, "port")?.value)
+        val docsPathKv = childKeyValue(armeria, "docs-path", "docsPath")
+        val healthPathKv = childKeyValue(armeria, "health-check-path", "healthCheckPath")
+        val metricsPathKv = childKeyValue(armeria, "metrics-path", "metricsPath")
+        return SpringArmeriaConfig(
+            ports = ports,
+            includes = includes,
+            docsPath = scalarText(docsPathKv?.value)
+                ?: ArmeriaSpringConfigRouteCollector.DEFAULT_DOCS_PATH,
+            healthPath = scalarText(healthPathKv?.value)
+                ?: ArmeriaSpringConfigRouteCollector.DEFAULT_HEALTH_PATH,
+            metricsPath = scalarText(metricsPathKv?.value)
+                ?: ArmeriaSpringConfigRouteCollector.DEFAULT_METRICS_PATH,
+            internalServicesPort = internalServicesPort,
+            includeElement = includeKv,
+            docsPathElement = docsPathKv,
+            healthPathElement = healthPathKv,
+            metricsPathElement = metricsPathKv,
+        )
+    }
+
+    private fun findTopLevelArmeriaMapping(yamlFile: YAMLFile): YAMLMapping? {
+        for (document in yamlFile.documents) {
+            val root = document.topLevelValue as? YAMLMapping ?: continue
+            val armeria = root.getKeyValueByKey("armeria") ?: continue
+            val mapping = armeria.value as? YAMLMapping ?: continue
+            return mapping
+        }
+        return null
+    }
+
+    private fun readPorts(armeria: YAMLMapping): List<SpringArmeriaPortBinding> {
+        val portsKv = childKeyValue(armeria, "ports") ?: return emptyList()
+        val sequence = portsKv.value as? YAMLSequence ?: return emptyList()
+        val bindings = mutableListOf<SpringArmeriaPortBinding>()
+        val seenPorts = mutableSetOf<String>()
+        for (item in sequence.items) {
+            val itemMapping = item.value as? YAMLMapping ?: continue
+            val portKv = childKeyValue(itemMapping, "port")
+            val port = scalarText(portKv?.value) ?: continue
+            if (!seenPorts.add(port)) {
+                continue
+            }
+            val protocols = readProtocols(childKeyValue(itemMapping, "protocols"))
+            bindings += SpringArmeriaPortBinding(
+                port = port,
+                protocols = protocols,
+                element = portKv ?: item,
+            )
+        }
+        return bindings
+    }
+
+    private fun readProtocols(protocolsKv: YAMLKeyValue?): List<String> {
+        val value = protocolsKv?.value
+        val tokens = when (value) {
+            is YAMLSequence -> value.items.mapNotNull { scalarText(it.value) }
+            is YAMLScalar -> ArmeriaSpringConfigRouteCollector.splitScalarList(value.textValue)
+            else -> emptyList()
+        }
+        return tokens
+            .map { it.uppercase() }
+            .filter { it.isNotEmpty() }
+            .distinct()
+            .ifEmpty { listOf("HTTP") }
+    }
+
+    private fun readIncludes(includeKv: YAMLKeyValue?): Set<String> {
+        if (includeKv == null) {
+            return emptySet()
+        }
+        val value = includeKv.value
+        val tokens = when (value) {
+            is YAMLSequence -> value.items.mapNotNull { scalarText(it.value) }.map { it.lowercase() }.toSet()
+            is YAMLScalar -> ArmeriaSpringConfigRouteCollector.parseIncludeTokens(value.textValue)
+            null -> emptySet()
+            else -> emptySet()
+        }
+        return ArmeriaSpringConfigRouteCollector.expandIncludes(tokens)
+    }
+
+    private fun childMapping(parent: YAMLMapping, vararg keys: String): YAMLMapping? {
+        val kv = childKeyValue(parent, *keys) ?: return null
+        return kv.value as? YAMLMapping
+    }
+
+    private fun childKeyValue(parent: YAMLMapping?, vararg keys: String): YAMLKeyValue? {
+        if (parent == null) {
+            return null
+        }
+        for (key in keys) {
+            parent.getKeyValueByKey(key)?.let { return it }
+        }
+        return null
+    }
+
+    private fun scalarText(value: YAMLValue?): String? {
+        val scalar = value as? YAMLScalar ?: return null
+        val text = scalar.textValue.trim()
+        return text.takeIf { it.isNotEmpty() }
+    }
+}

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/SpringArmeriaConfig.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/SpringArmeriaConfig.kt
@@ -1,0 +1,22 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.intellij.psi.PsiElement
+
+internal data class SpringArmeriaPortBinding(
+    val port: String,
+    val protocols: List<String>,
+    val element: PsiElement? = null,
+)
+
+internal data class SpringArmeriaConfig(
+    val ports: List<SpringArmeriaPortBinding> = emptyList(),
+    val includes: Set<String> = emptySet(),
+    val docsPath: String = SpringArmeriaConfigSemantics.DEFAULT_DOCS_PATH,
+    val healthPath: String = SpringArmeriaConfigSemantics.DEFAULT_HEALTH_PATH,
+    val metricsPath: String = SpringArmeriaConfigSemantics.DEFAULT_METRICS_PATH,
+    val internalServicesPort: String? = null,
+    val includeElement: PsiElement? = null,
+    val docsPathElement: PsiElement? = null,
+    val healthPathElement: PsiElement? = null,
+    val metricsPathElement: PsiElement? = null,
+)

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/SpringArmeriaConfig.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/SpringArmeriaConfig.kt
@@ -8,15 +8,32 @@ internal data class SpringArmeriaPortBinding(
     val element: PsiElement? = null,
 )
 
+/**
+ * Parsed Spring Boot `armeria.*` settings.
+ *
+ * Path fields are nullable: absent keys stay `null` and are resolved to
+ * [SpringArmeriaConfigSemantics] defaults only at emit time via [resolvedDocsPath] /
+ * [resolvedHealthPath] / [resolvedMetricsPath]. PSI navigation anchors are populated by the
+ * YAML reader only; the properties parser leaves them null.
+ */
 internal data class SpringArmeriaConfig(
     val ports: List<SpringArmeriaPortBinding> = emptyList(),
     val includes: Set<String> = emptySet(),
-    val docsPath: String = SpringArmeriaConfigSemantics.DEFAULT_DOCS_PATH,
-    val healthPath: String = SpringArmeriaConfigSemantics.DEFAULT_HEALTH_PATH,
-    val metricsPath: String = SpringArmeriaConfigSemantics.DEFAULT_METRICS_PATH,
+    val docsPath: String? = null,
+    val healthPath: String? = null,
+    val metricsPath: String? = null,
     val internalServicesPort: String? = null,
     val includeElement: PsiElement? = null,
     val docsPathElement: PsiElement? = null,
     val healthPathElement: PsiElement? = null,
     val metricsPathElement: PsiElement? = null,
-)
+) {
+    fun resolvedDocsPath(): String =
+        docsPath ?: SpringArmeriaConfigSemantics.DEFAULT_DOCS_PATH
+
+    fun resolvedHealthPath(): String =
+        healthPath ?: SpringArmeriaConfigSemantics.DEFAULT_HEALTH_PATH
+
+    fun resolvedMetricsPath(): String =
+        metricsPath ?: SpringArmeriaConfigSemantics.DEFAULT_METRICS_PATH
+}

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/SpringArmeriaConfigSemantics.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/SpringArmeriaConfigSemantics.kt
@@ -1,5 +1,7 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
+import java.util.Collections
+
 /**
  * Shared Spring Boot `armeria.*` config semantics used by both the properties parser and the
  * optional YAML PSI reader. Keep this free of format-specific PSI so either path can depend on it.
@@ -9,8 +11,15 @@ internal object SpringArmeriaConfigSemantics {
     const val DEFAULT_HEALTH_PATH = "/internal/healthcheck"
     const val DEFAULT_METRICS_PATH = "/internal/metrics"
 
-    /** Must stay aligned with [ArmeriaSpringConfigRouteCollector] internal-service specs. */
-    val INTERNAL_SERVICE_IDS: Set<String> = linkedSetOf("docs", "health", "metrics", "actuator")
+    /** Canonical internal-service ids — also used by [ArmeriaSpringConfigRouteCollector] specs. */
+    const val ID_DOCS = "docs"
+    const val ID_HEALTH = "health"
+    const val ID_METRICS = "metrics"
+    const val ID_ACTUATOR = "actuator"
+
+    val INTERNAL_SERVICE_IDS: Set<String> = Collections.unmodifiableSet(
+        linkedSetOf(ID_DOCS, ID_HEALTH, ID_METRICS, ID_ACTUATOR),
+    )
 
     fun expandIncludes(raw: Set<String>): Set<String> {
         if (raw.any { it.equals("all", ignoreCase = true) }) {

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/SpringArmeriaConfigSemantics.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/SpringArmeriaConfigSemantics.kt
@@ -1,0 +1,58 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+/**
+ * Shared Spring Boot `armeria.*` config semantics used by both the properties parser and the
+ * optional YAML PSI reader. Keep this free of format-specific PSI so either path can depend on it.
+ */
+internal object SpringArmeriaConfigSemantics {
+    const val DEFAULT_DOCS_PATH = "/internal/docs"
+    const val DEFAULT_HEALTH_PATH = "/internal/healthcheck"
+    const val DEFAULT_METRICS_PATH = "/internal/metrics"
+
+    /** Must stay aligned with [ArmeriaSpringConfigRouteCollector] internal-service specs. */
+    val INTERNAL_SERVICE_IDS: Set<String> = linkedSetOf("docs", "health", "metrics", "actuator")
+
+    fun expandIncludes(raw: Set<String>): Set<String> {
+        if (raw.any { it.equals("all", ignoreCase = true) }) {
+            return INTERNAL_SERVICE_IDS
+        }
+        return raw.map { it.lowercase() }.filter { it in INTERNAL_SERVICE_IDS }.toSet()
+    }
+
+    fun parseIncludeTokens(raw: String): Set<String> =
+        splitScalarList(raw).map { it.lowercase() }.toSet()
+
+    fun splitScalarList(raw: String): List<String> {
+        val normalized = raw.trim()
+            .removePrefix("[")
+            .removeSuffix("]")
+            .trim()
+        if (normalized.isEmpty()) {
+            return emptyList()
+        }
+        return normalized.split(',', ' ', '\t')
+            .map { stripInlineComment(it).trimQuotes() }
+            .filter { it.isNotEmpty() }
+    }
+
+    private val INLINE_COMMENT = Regex("""\s+#.*$""")
+
+    private fun stripInlineComment(raw: String): String {
+        val trimmed = raw.trim()
+        if (trimmed.isEmpty()) {
+            return trimmed
+        }
+        if ((trimmed.startsWith("\"") && trimmed.endsWith("\"")) ||
+            (trimmed.startsWith("'") && trimmed.endsWith("'"))
+        ) {
+            return trimmed
+        }
+        if (trimmed.startsWith("#")) {
+            return ""
+        }
+        return trimmed.replace(INLINE_COMMENT, "").trimEnd()
+    }
+
+    private fun String.trimQuotes(): String =
+        trim().removeSurrounding("\"").removeSurrounding("'")
+}

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/SpringArmeriaConfigSemantics.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/SpringArmeriaConfigSemantics.kt
@@ -42,28 +42,10 @@ internal object SpringArmeriaConfigSemantics {
             return emptyList()
         }
         return normalized.split(',', ' ', '\t')
-            .map { stripInlineComment(it).let(::trimQuotes) }
+            .map(::trimQuotes)
             .filter { it.isNotEmpty() }
     }
 
     fun trimQuotes(raw: String): String =
         raw.trim().removeSurrounding("\"").removeSurrounding("'")
-
-    private val INLINE_COMMENT = Regex("""\s+#.*$""")
-
-    private fun stripInlineComment(raw: String): String {
-        val trimmed = raw.trim()
-        if (trimmed.isEmpty()) {
-            return trimmed
-        }
-        if ((trimmed.startsWith("\"") && trimmed.endsWith("\"")) ||
-            (trimmed.startsWith("'") && trimmed.endsWith("'"))
-        ) {
-            return trimmed
-        }
-        if (trimmed.startsWith("#")) {
-            return ""
-        }
-        return trimmed.replace(INLINE_COMMENT, "").trimEnd()
-    }
 }

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/SpringArmeriaConfigSemantics.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/SpringArmeriaConfigSemantics.kt
@@ -1,7 +1,5 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
-import java.util.Collections
-
 /**
  * Shared Spring Boot `armeria.*` config semantics used by both the properties parser and the
  * optional YAML PSI reader. Keep this free of format-specific PSI so either path can depend on it.
@@ -17,9 +15,7 @@ internal object SpringArmeriaConfigSemantics {
     const val ID_METRICS = "metrics"
     const val ID_ACTUATOR = "actuator"
 
-    val INTERNAL_SERVICE_IDS: Set<String> = Collections.unmodifiableSet(
-        linkedSetOf(ID_DOCS, ID_HEALTH, ID_METRICS, ID_ACTUATOR),
-    )
+    val INTERNAL_SERVICE_IDS: Set<String> = setOf(ID_DOCS, ID_HEALTH, ID_METRICS, ID_ACTUATOR)
 
     fun expandIncludes(raw: Set<String>): Set<String> {
         if (raw.any { it.equals("all", ignoreCase = true) }) {
@@ -31,6 +27,12 @@ internal object SpringArmeriaConfigSemantics {
     fun parseIncludeTokens(raw: String): Set<String> =
         splitScalarList(raw).map { it.lowercase() }.toSet()
 
+    fun normalizeProtocols(tokens: Iterable<String>): List<String> =
+        tokens.map { it.uppercase() }
+            .filter { it.isNotEmpty() }
+            .distinct()
+            .ifEmpty { listOf("HTTP") }
+
     fun splitScalarList(raw: String): List<String> {
         val normalized = raw.trim()
             .removePrefix("[")
@@ -40,9 +42,12 @@ internal object SpringArmeriaConfigSemantics {
             return emptyList()
         }
         return normalized.split(',', ' ', '\t')
-            .map { stripInlineComment(it).trimQuotes() }
+            .map { stripInlineComment(it).let(::trimQuotes) }
             .filter { it.isNotEmpty() }
     }
+
+    fun trimQuotes(raw: String): String =
+        raw.trim().removeSurrounding("\"").removeSurrounding("'")
 
     private val INLINE_COMMENT = Regex("""\s+#.*$""")
 
@@ -61,7 +66,4 @@ internal object SpringArmeriaConfigSemantics {
         }
         return trimmed.replace(INLINE_COMMENT, "").trimEnd()
     }
-
-    private fun String.trimQuotes(): String =
-        trim().removeSurrounding("\"").removeSurrounding("'")
 }

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollectorTest.kt
@@ -1,8 +1,12 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
+import com.intellij.openapi.fileTypes.PlainTextFileType
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.search.GlobalSearchScope
-import com.linecorp.intellij.plugins.armeria.test.ArmeriaLightJavaCodeInsightFixtureTestCase
 import com.linecorp.intellij.plugins.armeria.message
+import com.linecorp.intellij.plugins.armeria.test.ArmeriaLightJavaCodeInsightFixtureTestCase
+import org.jetbrains.yaml.psi.YAMLFile
 
 class ArmeriaSpringConfigRouteCollectorTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {
     fun testCollectPortsAndInternalServicesFromYaml() {
@@ -370,7 +374,7 @@ class ArmeriaSpringConfigRouteCollectorTest : ArmeriaLightJavaCodeInsightFixture
         val portRoute = routes.single { it.path == ":8080" }
         val element = portRoute.pointer.element
         assertNotNull(element)
-        assertFalse(element is com.intellij.psi.PsiFile)
+        assertFalse(element is PsiFile)
         assertTrue(portRoute.resolveSourceHint().contains(":"))
         assertFalse(portRoute.resolveSourceHint().endsWith(":1"))
         assertSame(psiFile, element!!.containingFile)
@@ -509,5 +513,82 @@ class ArmeriaSpringConfigRouteCollectorTest : ArmeriaLightJavaCodeInsightFixture
 
         assertEquals("HTTP, HTTPS", routes.single { it.path == ":8080" }.protocol)
         assertEquals("HTTP", routes.single { it.path == ":8081" }.protocol)
+    }
+
+    fun testYamlInternalServiceNavigationTargetsKeyElements() {
+        val psiFile = myFixture.configureByText(
+            "application.yml",
+            """
+            # preamble
+            armeria:
+              docs-path: /custom/docs
+              health-check-path: /custom/health
+              metrics-path: /custom/metrics
+              internal-services:
+                include: docs, health, metrics
+            """.trimIndent(),
+        )
+
+        val routes = mutableListOf<ArmeriaRoute>()
+        ArmeriaSpringConfigRouteCollector.collectFromPsiFile(psiFile, routes, mutableSetOf())
+
+        val docs = routes.single { it.isDocService }
+        val health = routes.single { it.path == "/custom/health" }
+        val metrics = routes.single { it.path == "/custom/metrics" }
+        assertFalse(docs.pointer.element is PsiFile)
+        assertFalse(health.pointer.element is PsiFile)
+        assertFalse(metrics.pointer.element is PsiFile)
+        assertFalse(docs.resolveSourceHint().endsWith(":1"))
+        assertFalse(health.resolveSourceHint().endsWith(":1"))
+        assertFalse(metrics.resolveSourceHint().endsWith(":1"))
+        assertSame(psiFile, docs.pointer.element!!.containingFile)
+    }
+
+    fun testYamlCommentOnlyIncludeThenBlockList() {
+        val psiFile = myFixture.configureByText(
+            "application.yml",
+            """
+            armeria:
+              internal-services:
+                include: # docs disabled
+                  - docs
+                  - health
+            """.trimIndent(),
+        )
+
+        val routes = mutableListOf<ArmeriaRoute>()
+        ArmeriaSpringConfigRouteCollector.collectFromPsiFile(psiFile, routes, mutableSetOf())
+
+        assertTrue(routes.any { it.isDocService })
+        assertTrue(routes.any { it.path == "/internal/healthcheck" })
+    }
+
+    fun testYamlPlainTextFileTypeStillDiscoversRoutes() {
+        val content =
+            """
+            armeria:
+              ports:
+                - port: 8080
+                  protocols: HTTP
+              internal-services:
+                include: docs
+            """.trimIndent()
+        val psiFile = PsiFileFactory.getInstance(project).createFileFromText(
+            "application.yml",
+            PlainTextFileType.INSTANCE,
+            content,
+        )
+        assertFalse(
+            "Fixture must not be YAMLFile for this regression",
+            psiFile is YAMLFile,
+        )
+
+        val routes = mutableListOf<ArmeriaRoute>()
+        ArmeriaSpringConfigRouteCollector.collectFromPsiFile(psiFile, routes, mutableSetOf())
+
+        assertTrue(routes.any { it.path == ":8080" })
+        assertTrue(routes.any { it.isDocService })
+        // Dummy YAML tree is not attached; navigation stays on the original file.
+        assertSame(psiFile, routes.single { it.path == ":8080" }.pointer.element)
     }
 }

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollectorTest.kt
@@ -351,4 +351,163 @@ class ArmeriaSpringConfigRouteCollectorTest : ArmeriaLightJavaCodeInsightFixture
         assertFalse(ArmeriaRouteDetailFormatter.statusLine(health).contains(message("route.explorer.badge.runtime")))
         assertTrue(ArmeriaRouteDetailFormatter.statusLine(health).contains(message("route.explorer.badge.staticAnalysis")))
     }
+
+    fun testYamlPortNavigationTargetsKeyElement() {
+        val psiFile = myFixture.configureByText(
+            "application.yml",
+            """
+            # preamble
+            armeria:
+              ports:
+                - port: 8080
+                  protocols: HTTP
+            """.trimIndent(),
+        )
+
+        val routes = mutableListOf<ArmeriaRoute>()
+        ArmeriaSpringConfigRouteCollector.collectFromPsiFile(psiFile, routes, mutableSetOf())
+
+        val portRoute = routes.single { it.path == ":8080" }
+        val element = portRoute.pointer.element
+        assertNotNull(element)
+        assertFalse(element is com.intellij.psi.PsiFile)
+        assertTrue(portRoute.resolveSourceHint().contains(":"))
+        assertFalse(portRoute.resolveSourceHint().endsWith(":1"))
+        assertSame(psiFile, element!!.containingFile)
+    }
+
+    fun testYamlMultiDocumentFindsArmeriaInLaterDocument() {
+        val psiFile = myFixture.configureByText(
+            "application.yml",
+            """
+            spring:
+              application:
+                name: demo
+            ---
+            armeria:
+              ports:
+                - port: 8080
+                  protocols: HTTP
+              internal-services:
+                include: docs
+            """.trimIndent(),
+        )
+
+        val routes = mutableListOf<ArmeriaRoute>()
+        ArmeriaSpringConfigRouteCollector.collectFromPsiFile(psiFile, routes, mutableSetOf())
+
+        assertTrue(routes.any { it.path == ":8080" })
+        assertTrue(routes.any { it.isDocService })
+    }
+
+    fun testYamlAcceptsCamelCaseKeysAndFlowIncludes() {
+        val psiFile = myFixture.configureByText(
+            "application.yml",
+            """
+            armeria:
+              internalServices:
+                include: [docs, metrics]
+              docsPath: /docs
+              healthCheckPath: /health
+              metricsPath: /metrics
+            """.trimIndent(),
+        )
+
+        val routes = mutableListOf<ArmeriaRoute>()
+        ArmeriaSpringConfigRouteCollector.collectFromPsiFile(psiFile, routes, mutableSetOf())
+
+        assertTrue(routes.any { it.isDocService && it.path == "/docs" })
+        assertTrue(routes.any { it.path == "/metrics" })
+        assertFalse(routes.any { it.path == "/health" || it.path == "/internal/healthcheck" })
+    }
+
+    fun testYamlIgnoresNestedArmeriaAndNestedPorts() {
+        val psiFile = myFixture.configureByText(
+            "application.yml",
+            """
+            wrapper:
+              armeria:
+                ports:
+                  - port: 9999
+                    protocols: HTTP
+            armeria:
+              foo:
+                ports:
+                  - port: 8888
+                    protocols: HTTP
+              ports:
+                - port: 8080
+                  protocols: HTTPS
+              bar:
+                internal-services:
+                  include: docs
+              internal-services:
+                include: health
+            """.trimIndent(),
+        )
+
+        val routes = mutableListOf<ArmeriaRoute>()
+        ArmeriaSpringConfigRouteCollector.collectFromPsiFile(psiFile, routes, mutableSetOf())
+
+        assertTrue(routes.any { it.path == ":8080" && it.protocol == "HTTPS" })
+        assertFalse(routes.any { it.path == ":9999" || it.path == ":8888" })
+        assertTrue(routes.any { it.path == "/internal/healthcheck" })
+        assertFalse(routes.any { it.isDocService })
+    }
+
+    fun testYamlBlockIncludeListAndCommentOnlyInlineIgnored() {
+        val withBlock = myFixture.configureByText(
+            "application.yml",
+            """
+            armeria:
+              internal-services:
+                include:
+                  - docs
+                  - health
+            """.trimIndent(),
+        )
+        val blockRoutes = mutableListOf<ArmeriaRoute>()
+        ArmeriaSpringConfigRouteCollector.collectFromPsiFile(withBlock, blockRoutes, mutableSetOf())
+        assertTrue(blockRoutes.any { it.isDocService })
+        assertTrue(blockRoutes.any { it.path == "/internal/healthcheck" })
+
+        val commentOnly = myFixture.configureByText(
+            "application-empty.yml",
+            """
+            armeria:
+              internal-services:
+                include: # docs disabled
+              ports:
+                - port: 8080
+                  protocols: HTTP
+            """.trimIndent(),
+        )
+        val emptyIncludeRoutes = mutableListOf<ArmeriaRoute>()
+        ArmeriaSpringConfigRouteCollector.collectFromPsiFile(commentOnly, emptyIncludeRoutes, mutableSetOf())
+        assertTrue(emptyIncludeRoutes.any { it.path == ":8080" })
+        assertFalse(emptyIncludeRoutes.any { it.isDocService })
+    }
+
+    fun testYamlProtocolsBeforePortAndMultiProtocol() {
+        val psiFile = myFixture.configureByText(
+            "application.yml",
+            """
+            armeria:
+              ports:
+                - protocols:
+                    - http
+                    - https
+                  port: 8080
+                - address: 127.0.0.1
+                  port: 8081
+                  protocols: HTTP
+            """.trimIndent(),
+        )
+
+        val routes = mutableListOf<ArmeriaRoute>()
+        ArmeriaSpringConfigRouteCollector.collectFromPsiFile(psiFile, routes, mutableSetOf())
+
+        assertEquals("HTTP, HTTPS", routes.single { it.path == ":8080" }.protocol)
+        assertEquals("HTTP", routes.single { it.path == ":8081" }.protocol)
+    }
 }

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollectorTest.kt
@@ -7,6 +7,7 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.linecorp.intellij.plugins.armeria.message
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaLightJavaCodeInsightFixtureTestCase
 import org.jetbrains.yaml.psi.YAMLFile
+import org.jetbrains.yaml.psi.YAMLKeyValue
 
 class ArmeriaSpringConfigRouteCollectorTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {
     fun testCollectPortsAndInternalServicesFromYaml() {
@@ -178,6 +179,27 @@ class ArmeriaSpringConfigRouteCollectorTest : ArmeriaLightJavaCodeInsightFixture
         assertTrue(routes.any { it.path == "/internal/metrics" })
         assertTrue(routes.any { it.path == "/actuator" })
         assertTrue(routes.all { !it.isDocService || it.target.contains(":18080") })
+    }
+
+    fun testYamlIncludeAllExpandsAndSurfacesInternalPort() {
+        val psiFile = myFixture.configureByText(
+            "application.yml",
+            """
+            armeria:
+              internal-services:
+                include: all
+                port: 18080
+              docs-path: /custom/docs
+            """.trimIndent(),
+        )
+
+        val routes = mutableListOf<ArmeriaRoute>()
+        ArmeriaSpringConfigRouteCollector.collectFromPsiFile(psiFile, routes, mutableSetOf())
+
+        assertTrue(routes.any { it.isDocService && it.path == "/custom/docs" && it.target.contains(":18080") })
+        assertTrue(routes.any { it.path == "/internal/healthcheck" && it.target.contains(":18080") })
+        assertTrue(routes.any { it.path == "/internal/metrics" && it.target.contains(":18080") })
+        assertTrue(routes.any { it.path == "/actuator" && it.target.contains(":18080") })
     }
 
     fun testUnrelatedDocsPathDoesNotOverrideArmeriaPath() {
@@ -374,10 +396,13 @@ class ArmeriaSpringConfigRouteCollectorTest : ArmeriaLightJavaCodeInsightFixture
         val portRoute = routes.single { it.path == ":8080" }
         val element = portRoute.pointer.element
         assertNotNull(element)
-        assertFalse(element is PsiFile)
-        assertTrue(portRoute.resolveSourceHint().contains(":"))
+        assertTrue(
+            "Port route should navigate to the YAML port key, not the whole file",
+            element is org.jetbrains.yaml.psi.YAMLKeyValue,
+        )
+        assertEquals("port", (element as org.jetbrains.yaml.psi.YAMLKeyValue).keyText)
         assertFalse(portRoute.resolveSourceHint().endsWith(":1"))
-        assertSame(psiFile, element!!.containingFile)
+        assertSame(psiFile, element.containingFile)
     }
 
     fun testYamlMultiDocumentFindsArmeriaInLaterDocument() {

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollectorTest.kt
@@ -160,27 +160,6 @@ class ArmeriaSpringConfigRouteCollectorTest : ArmeriaLightJavaCodeInsightFixture
         assertFalse(routes.any { it.path == "/internal/healthcheck" })
     }
 
-    fun testIncludeAllEnablesActuator() {
-        val psiFile = myFixture.configureByText(
-            "application.yml",
-            """
-            armeria:
-              internal-services:
-                include: all
-                port: 18080
-            """.trimIndent(),
-        )
-
-        val routes = mutableListOf<ArmeriaRoute>()
-        ArmeriaSpringConfigRouteCollector.collectFromPsiFile(psiFile, routes, mutableSetOf())
-
-        assertTrue(routes.any { it.isDocService })
-        assertTrue(routes.any { it.path == "/internal/healthcheck" && it.routeMatch == RouteMatch.CONFIG })
-        assertTrue(routes.any { it.path == "/internal/metrics" })
-        assertTrue(routes.any { it.path == "/actuator" })
-        assertTrue(routes.all { !it.isDocService || it.target.contains(":18080") })
-    }
-
     fun testYamlIncludeAllExpandsAndSurfacesInternalPort() {
         val psiFile = myFixture.configureByText(
             "application.yml",
@@ -192,6 +171,14 @@ class ArmeriaSpringConfigRouteCollectorTest : ArmeriaLightJavaCodeInsightFixture
               docs-path: /custom/docs
             """.trimIndent(),
         )
+
+        val config = ArmeriaYamlSpringConfigReader.read(psiFile)
+        assertEquals(
+            setOf("docs", "health", "metrics", "actuator"),
+            config.includes,
+        )
+        assertEquals("18080", config.internalServicesPort)
+        assertEquals("/custom/docs", config.docsPath)
 
         val routes = mutableListOf<ArmeriaRoute>()
         ArmeriaSpringConfigRouteCollector.collectFromPsiFile(psiFile, routes, mutableSetOf())
@@ -398,9 +385,9 @@ class ArmeriaSpringConfigRouteCollectorTest : ArmeriaLightJavaCodeInsightFixture
         assertNotNull(element)
         assertTrue(
             "Port route should navigate to the YAML port key, not the whole file",
-            element is org.jetbrains.yaml.psi.YAMLKeyValue,
+            element is YAMLKeyValue,
         )
-        assertEquals("port", (element as org.jetbrains.yaml.psi.YAMLKeyValue).keyText)
+        assertEquals("port", (element as YAMLKeyValue).keyText)
         assertFalse(portRoute.resolveSourceHint().endsWith(":1"))
         assertSame(psiFile, element.containingFile)
     }
@@ -442,6 +429,12 @@ class ArmeriaSpringConfigRouteCollectorTest : ArmeriaLightJavaCodeInsightFixture
             """.trimIndent(),
         )
 
+        val config = ArmeriaYamlSpringConfigReader.read(psiFile)
+        assertEquals(setOf("docs", "metrics"), config.includes)
+        assertEquals("/docs", config.docsPath)
+        assertEquals("/health", config.healthPath)
+        assertEquals("/metrics", config.metricsPath)
+
         val routes = mutableListOf<ArmeriaRoute>()
         ArmeriaSpringConfigRouteCollector.collectFromPsiFile(psiFile, routes, mutableSetOf())
 
@@ -475,11 +468,40 @@ class ArmeriaSpringConfigRouteCollectorTest : ArmeriaLightJavaCodeInsightFixture
             """.trimIndent(),
         )
 
+        val config = ArmeriaYamlSpringConfigReader.read(psiFile)
+        assertEquals(
+            listOf(SpringArmeriaPortBinding("8080", listOf("HTTPS"))),
+            config.ports.map { it.copy(element = null) },
+        )
+        assertEquals(setOf("health"), config.includes)
+
         val routes = mutableListOf<ArmeriaRoute>()
         ArmeriaSpringConfigRouteCollector.collectFromPsiFile(psiFile, routes, mutableSetOf())
 
         assertTrue(routes.any { it.path == ":8080" && it.protocol == "HTTPS" })
         assertFalse(routes.any { it.path == ":9999" || it.path == ":8888" })
+        assertTrue(routes.any { it.path == "/internal/healthcheck" })
+        assertFalse(routes.any { it.isDocService })
+    }
+
+    fun testYamlIgnoresNestedIncludeUnderInternalServicesChild() {
+        val psiFile = myFixture.configureByText(
+            "application.yml",
+            """
+            armeria:
+              internal-services:
+                foo:
+                  include: docs
+                include: health
+            """.trimIndent(),
+        )
+
+        val config = ArmeriaYamlSpringConfigReader.read(psiFile)
+        assertEquals(setOf("health"), config.includes)
+
+        val routes = mutableListOf<ArmeriaRoute>()
+        ArmeriaSpringConfigRouteCollector.collectFromPsiFile(psiFile, routes, mutableSetOf())
+
         assertTrue(routes.any { it.path == "/internal/healthcheck" })
         assertFalse(routes.any { it.isDocService })
     }

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Route Explorer reads Spring Boot `application.yml` / `.yaml` via IntelliJ YAML PSI (key-level navigation); `.properties` parsing is unchanged. YAML config is skipped when the YAML plugin is unavailable.
+
 ### Deprecated
 
 ### Removed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Route Explorer’s Spring Boot config collector no longer uses a handwritten indentation scraper for `application.yml` / `.yaml`. YAML is read through the optional IntelliJ YAML plugin PSI (`org.jetbrains.plugins.yaml`), matching other collectors and enabling key-level navigation. `.properties` stay on the existing regex parser. When the YAML plugin is disabled, YAML config files are skipped (properties still work). If a YAML-named file is not a `YAMLFile` (for example Plain Text), content is still parsed via a disposable YAML PSI tree while navigation stays on the original file.

Closes #255.

## Changes

- Add `ArmeriaYamlSpringConfigReader` to walk top-level `armeria` mappings across YAML documents
- Add `SpringArmeriaConfig` / `SpringArmeriaPortBinding` model types and `SpringArmeriaConfigSemantics` for shared defaults, include expansion, protocol normalization, and scalar-list parsing (canonical internal-service id constants shared with collector specs)
- Keep parsed path fields nullable and resolve `DEFAULT_*` paths only at emit time via `resolvedDocsPath` / `resolvedHealthPath` / `resolvedMetricsPath`
- Gate YAML collection on `PluginManagerCore.isLoaded("org.jetbrains.plugins.yaml")`
- Attach key-level `PsiElement`s when emitting config routes; keep only elements whose containing file matches the original config file (dummy Plain Text trees fall back to file-level navigation)
- Fall back to `YAMLElementGenerator.createDummyYamlWithText` for non-`YAMLFile` application YAML
- Remove the handwritten YAML scraper from `ArmeriaSpringConfigRouteCollector`
- Declare `bundledPlugin("org.jetbrains.plugins.yaml")` on `plugin-route-analysis`
- Move YAML edge-case coverage to fixture tests (including `include: all`, nested-include ignore, and direct reader asserts); keep properties coverage in `fastTest`, plus `SpringArmeriaConfigSemanticsTest` for pure include/protocol helpers
- Assert collector spec ids stay aligned with `SpringArmeriaConfigSemantics.INTERNAL_SERVICE_IDS`
- Sync `.cursor` / `.github` agent skills and Copilot preflight for the YAML PSI approach
- Document the change under `plugin/CHANGELOG.md` Unreleased

## Test plan

- [ ] `:plugin-route-analysis:fastTest` (properties parse tests + semantics helpers + id alignment)
- [ ] `:plugin-route-analysis:test` — `ArmeriaSpringConfigRouteCollectorTest`
- [ ] Confirm Route Explorer navigates to YAML keys (not file line 1) for port / internal-service routes
- [ ] Confirm multi-document YAML with `armeria:` in a later document is discovered
- [ ] Confirm Plain Text-typed `application.yml` still discovers routes (file-level navigation)
- [ ] Confirm `.properties` routes still appear when YAML plugin is irrelevant

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7466-0884-7080-90e3-1609cd265417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7466-0884-7080-90e3-1609cd265417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

