### PR TITLE
feat: resolve Spring MVC mappings on base classes and interfaces

### DIFF
--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollector.kt
@@ -5,7 +5,11 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.linecorp.intellij.plugins.armeria.message
 
 internal object ArmeriaDelegatedRouteCollector {
-    fun collect(project: Project, scope: GlobalSearchScope, routes: MutableList<ArmeriaRoute>) {
+    fun collect(
+        project: Project,
+        scope: GlobalSearchScope,
+        routes: MutableList<ArmeriaRoute>,
+    ) {
         // Prefix mounts only: .service() is exact-match and must not invent child paths.
         val springCapableMounts = routes.filter(ArmeriaServletMountSupport::isExpandableSpringMvcMount)
         if (springCapableMounts.isEmpty()) {
@@ -34,17 +38,18 @@ internal object ArmeriaDelegatedRouteCollector {
                 }
                 // Navigate to the mapping-owning method; attribute the tree module to the concrete
                 // controller so inherited mappings from other modules still expand under the mount.
-                delegatedRoutes += ArmeriaRoute.create(
-                    element = springMvcRoute.element,
-                    protocol = RouteProtocol.HTTP.presentableName(),
-                    httpMethod = springMvcRoute.httpMethod,
-                    path = combinedPath,
-                    target = springMvcRoute.target,
-                    routeMatch = RouteMatch.DELEGATED_SPRING_MVC,
-                    virtualHostName = mountRoute.virtualHostName,
-                    delegationMountPath = mountRoute.path,
-                    moduleName = ArmeriaRouteMetadata.moduleName(springMvcRoute.controller),
-                )
+                delegatedRoutes +=
+                    ArmeriaRoute.create(
+                        element = springMvcRoute.element,
+                        protocol = RouteProtocol.HTTP.presentableName(),
+                        httpMethod = springMvcRoute.httpMethod,
+                        path = combinedPath,
+                        target = springMvcRoute.target,
+                        routeMatch = RouteMatch.DELEGATED_SPRING_MVC,
+                        virtualHostName = mountRoute.virtualHostName,
+                        delegationMountPath = mountRoute.path,
+                        moduleName = ArmeriaRouteMetadata.moduleName(springMvcRoute.controller),
+                    )
             }
         }
 

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollector.kt
@@ -48,7 +48,7 @@ internal object ArmeriaDelegatedRouteCollector {
                         routeMatch = RouteMatch.DELEGATED_SPRING_MVC,
                         virtualHostName = mountRoute.virtualHostName,
                         delegationMountPath = mountRoute.path,
-                        moduleName = ArmeriaRouteMetadata.moduleName(springMvcRoute.controller),
+                        moduleName = springMvcRoute.moduleName(),
                     )
             }
         }
@@ -66,7 +66,7 @@ internal object ArmeriaDelegatedRouteCollector {
             return springMvcRoutes
         }
         return springMvcRoutes.filter { route ->
-            ArmeriaRouteMetadata.moduleName(route.controller) == mountModule
+            route.moduleName() == mountModule
         }
     }
 }

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollector.kt
@@ -5,11 +5,7 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.linecorp.intellij.plugins.armeria.message
 
 internal object ArmeriaDelegatedRouteCollector {
-    fun collect(
-        project: Project,
-        scope: GlobalSearchScope,
-        routes: MutableList<ArmeriaRoute>,
-    ) {
+    fun collect(project: Project, scope: GlobalSearchScope, routes: MutableList<ArmeriaRoute>) {
         // Prefix mounts only: .service() is exact-match and must not invent child paths.
         val springCapableMounts = routes.filter(ArmeriaServletMountSupport::isExpandableSpringMvcMount)
         if (springCapableMounts.isEmpty()) {
@@ -36,17 +32,18 @@ internal object ArmeriaDelegatedRouteCollector {
                 if (!seenDelegatedKeys.add(dedupeKey)) {
                     continue
                 }
-                delegatedRoutes +=
-                    ArmeriaRoute.create(
-                        element = springMvcRoute.element,
-                        protocol = RouteProtocol.HTTP.presentableName(),
-                        httpMethod = springMvcRoute.httpMethod,
-                        path = combinedPath,
-                        target = springMvcRoute.target,
-                        routeMatch = RouteMatch.DELEGATED_SPRING_MVC,
-                        virtualHostName = mountRoute.virtualHostName,
-                        delegationMountPath = mountRoute.path,
-                    )
+                // Navigate to the mapping-owning method; attribute the tree module to the concrete
+                // controller so inherited mappings from other modules still expand under the mount.
+                delegatedRoutes += ArmeriaRoute.create(
+                    element = springMvcRoute.element,
+                    protocol = RouteProtocol.HTTP.presentableName(),
+                    httpMethod = springMvcRoute.httpMethod,
+                    path = combinedPath,
+                    target = springMvcRoute.target,
+                    routeMatch = RouteMatch.DELEGATED_SPRING_MVC,
+                    virtualHostName = mountRoute.virtualHostName,
+                    delegationMountPath = mountRoute.path,
+                ).copy(moduleName = ArmeriaRouteMetadata.moduleName(springMvcRoute.controller))
             }
         }
 
@@ -63,7 +60,7 @@ internal object ArmeriaDelegatedRouteCollector {
             return springMvcRoutes
         }
         return springMvcRoutes.filter { route ->
-            ArmeriaRouteMetadata.moduleName(route.element) == mountModule
+            ArmeriaRouteMetadata.moduleName(route.controller) == mountModule
         }
     }
 }

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollector.kt
@@ -43,7 +43,8 @@ internal object ArmeriaDelegatedRouteCollector {
                     routeMatch = RouteMatch.DELEGATED_SPRING_MVC,
                     virtualHostName = mountRoute.virtualHostName,
                     delegationMountPath = mountRoute.path,
-                ).copy(moduleName = ArmeriaRouteMetadata.moduleName(springMvcRoute.controller))
+                    moduleName = ArmeriaRouteMetadata.moduleName(springMvcRoute.controller),
+                )
             }
         }
 

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRoute.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRoute.kt
@@ -39,46 +39,43 @@ data class ArmeriaRoute(
     fun resolveRegistrationSummary(): String = ArmeriaRouteDetailFormatter.registrationSummary(this)
 
     val methodLabel: String
-        get() =
-            when (routeMatch) {
-                RouteMatch.ANNOTATED_HTTP -> httpMethod
-                RouteMatch.ANNOTATED_SERVICE -> message("route.explorer.method.annotatedService")
-                RouteMatch.SERVICE -> message("route.explorer.method.allHttp")
-                RouteMatch.SERVICE_UNDER -> message("route.explorer.method.prefix")
-                RouteMatch.FILE_SERVICE -> message("route.explorer.method.fileService")
-                RouteMatch.HEALTH_CHECK -> message("route.explorer.method.healthCheck")
-                RouteMatch.VIRTUAL_HOST -> message("route.explorer.method.virtualHost")
-                RouteMatch.ROUTE_DECORATOR -> message("route.explorer.method.routeDecorator")
-                RouteMatch.ROUTE_FLUENT -> httpMethod.ifBlank { message("route.explorer.method.allHttp") }
-                RouteMatch.DECORATOR_UNDER -> message("route.explorer.method.decoratorUnder")
-                RouteMatch.DELEGATED_SPRING_MVC ->
-                    httpMethod.ifBlank { message("route.explorer.method.allHttp") }
-                RouteMatch.NON_HTTP -> protocol
-                RouteMatch.RUNTIME, RouteMatch.CONFIG -> httpMethod
-            }
+        get() = when (routeMatch) {
+            RouteMatch.ANNOTATED_HTTP -> httpMethod
+            RouteMatch.ANNOTATED_SERVICE -> message("route.explorer.method.annotatedService")
+            RouteMatch.SERVICE -> message("route.explorer.method.allHttp")
+            RouteMatch.SERVICE_UNDER -> message("route.explorer.method.prefix")
+            RouteMatch.FILE_SERVICE -> message("route.explorer.method.fileService")
+            RouteMatch.HEALTH_CHECK -> message("route.explorer.method.healthCheck")
+            RouteMatch.VIRTUAL_HOST -> message("route.explorer.method.virtualHost")
+            RouteMatch.ROUTE_DECORATOR -> message("route.explorer.method.routeDecorator")
+            RouteMatch.ROUTE_FLUENT -> httpMethod.ifBlank { message("route.explorer.method.allHttp") }
+            RouteMatch.DECORATOR_UNDER -> message("route.explorer.method.decoratorUnder")
+            RouteMatch.DELEGATED_SPRING_MVC ->
+                httpMethod.ifBlank { message("route.explorer.method.allHttp") }
+            RouteMatch.NON_HTTP -> protocol
+            RouteMatch.RUNTIME, RouteMatch.CONFIG -> httpMethod
+        }
 
     val shortTarget: String
         get() = truncateTarget(target)
 
     val speedSearchText: String
-        get() =
-            buildString {
-                append(methodLabel)
-                append(' ')
-                append(path)
-                append(' ')
-                append(target)
-                append(' ')
-                append(moduleName)
-            }
+        get() = buildString {
+            append(methodLabel)
+            append(' ')
+            append(path)
+            append(' ')
+            append(target)
+            append(' ')
+            append(moduleName)
+        }
 
     val detailHandlerLabel: String
-        get() =
-            when {
-                routeMatch == RouteMatch.RUNTIME -> message("route.explorer.detail.service")
-                targetUnresolved -> message("route.explorer.label.unresolvedExpression")
-                else -> message("route.explorer.detail.handler")
-            }
+        get() = when {
+            routeMatch == RouteMatch.RUNTIME -> message("route.explorer.detail.service")
+            targetUnresolved -> message("route.explorer.label.unresolvedExpression")
+            else -> message("route.explorer.detail.handler")
+        }
 
     companion object {
         private const val TARGET_DISPLAY_LIMIT = 60
@@ -101,14 +98,16 @@ data class ArmeriaRoute(
             timeoutHints: List<String> = emptyList(),
             contentHints: List<String> = emptyList(),
             delegationMountPath: String = "",
-        ): ArmeriaRoute =
-            ArmeriaRoute(
+            /** When set, overrides module attribution derived from [element] (e.g. concrete controller). */
+            moduleName: String? = null,
+        ): ArmeriaRoute {
+            return ArmeriaRoute(
                 protocol = protocol,
                 httpMethod = httpMethod,
                 path = path,
                 target = target,
                 routeMatch = routeMatch,
-                moduleName = ArmeriaRouteMetadata.moduleName(element),
+                moduleName = moduleName ?: ArmeriaRouteMetadata.moduleName(element),
                 targetUnresolved = targetUnresolved,
                 isDocService = isDocService,
                 annotatedServiceHasPathPrefix = annotatedServiceHasPathPrefix,
@@ -122,6 +121,7 @@ data class ArmeriaRoute(
                 delegationMountPath = delegationMountPath,
                 pointer = SmartPointerManager.createPointer(element),
             )
+        }
 
         fun createRuntime(
             httpMethod: String,
@@ -130,8 +130,8 @@ data class ArmeriaRoute(
             moduleName: String,
             protocol: String,
             project: Project? = null,
-        ): ArmeriaRoute =
-            ArmeriaRoute(
+        ): ArmeriaRoute {
+            return ArmeriaRoute(
                 protocol = protocol,
                 httpMethod = httpMethod,
                 path = path,
@@ -144,11 +144,9 @@ data class ArmeriaRoute(
                 exceptionHandlers = emptyList(),
                 pointer = project?.let(::ArmeriaRuntimeRoutePointer) ?: ArmeriaRuntimeRoutePointer.withoutProject(),
             )
+        }
 
-        fun truncateTarget(
-            value: String,
-            limit: Int = TARGET_DISPLAY_LIMIT,
-        ): String {
+        fun truncateTarget(value: String, limit: Int = TARGET_DISPLAY_LIMIT): String {
             if (value.length <= limit) {
                 return value
             }

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRoute.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRoute.kt
@@ -39,43 +39,46 @@ data class ArmeriaRoute(
     fun resolveRegistrationSummary(): String = ArmeriaRouteDetailFormatter.registrationSummary(this)
 
     val methodLabel: String
-        get() = when (routeMatch) {
-            RouteMatch.ANNOTATED_HTTP -> httpMethod
-            RouteMatch.ANNOTATED_SERVICE -> message("route.explorer.method.annotatedService")
-            RouteMatch.SERVICE -> message("route.explorer.method.allHttp")
-            RouteMatch.SERVICE_UNDER -> message("route.explorer.method.prefix")
-            RouteMatch.FILE_SERVICE -> message("route.explorer.method.fileService")
-            RouteMatch.HEALTH_CHECK -> message("route.explorer.method.healthCheck")
-            RouteMatch.VIRTUAL_HOST -> message("route.explorer.method.virtualHost")
-            RouteMatch.ROUTE_DECORATOR -> message("route.explorer.method.routeDecorator")
-            RouteMatch.ROUTE_FLUENT -> httpMethod.ifBlank { message("route.explorer.method.allHttp") }
-            RouteMatch.DECORATOR_UNDER -> message("route.explorer.method.decoratorUnder")
-            RouteMatch.DELEGATED_SPRING_MVC ->
-                httpMethod.ifBlank { message("route.explorer.method.allHttp") }
-            RouteMatch.NON_HTTP -> protocol
-            RouteMatch.RUNTIME, RouteMatch.CONFIG -> httpMethod
-        }
+        get() =
+            when (routeMatch) {
+                RouteMatch.ANNOTATED_HTTP -> httpMethod
+                RouteMatch.ANNOTATED_SERVICE -> message("route.explorer.method.annotatedService")
+                RouteMatch.SERVICE -> message("route.explorer.method.allHttp")
+                RouteMatch.SERVICE_UNDER -> message("route.explorer.method.prefix")
+                RouteMatch.FILE_SERVICE -> message("route.explorer.method.fileService")
+                RouteMatch.HEALTH_CHECK -> message("route.explorer.method.healthCheck")
+                RouteMatch.VIRTUAL_HOST -> message("route.explorer.method.virtualHost")
+                RouteMatch.ROUTE_DECORATOR -> message("route.explorer.method.routeDecorator")
+                RouteMatch.ROUTE_FLUENT -> httpMethod.ifBlank { message("route.explorer.method.allHttp") }
+                RouteMatch.DECORATOR_UNDER -> message("route.explorer.method.decoratorUnder")
+                RouteMatch.DELEGATED_SPRING_MVC ->
+                    httpMethod.ifBlank { message("route.explorer.method.allHttp") }
+                RouteMatch.NON_HTTP -> protocol
+                RouteMatch.RUNTIME, RouteMatch.CONFIG -> httpMethod
+            }
 
     val shortTarget: String
         get() = truncateTarget(target)
 
     val speedSearchText: String
-        get() = buildString {
-            append(methodLabel)
-            append(' ')
-            append(path)
-            append(' ')
-            append(target)
-            append(' ')
-            append(moduleName)
-        }
+        get() =
+            buildString {
+                append(methodLabel)
+                append(' ')
+                append(path)
+                append(' ')
+                append(target)
+                append(' ')
+                append(moduleName)
+            }
 
     val detailHandlerLabel: String
-        get() = when {
-            routeMatch == RouteMatch.RUNTIME -> message("route.explorer.detail.service")
-            targetUnresolved -> message("route.explorer.label.unresolvedExpression")
-            else -> message("route.explorer.detail.handler")
-        }
+        get() =
+            when {
+                routeMatch == RouteMatch.RUNTIME -> message("route.explorer.detail.service")
+                targetUnresolved -> message("route.explorer.label.unresolvedExpression")
+                else -> message("route.explorer.detail.handler")
+            }
 
     companion object {
         private const val TARGET_DISPLAY_LIMIT = 60
@@ -100,8 +103,8 @@ data class ArmeriaRoute(
             delegationMountPath: String = "",
             /** When set, overrides module attribution derived from [element] (e.g. concrete controller). */
             moduleName: String? = null,
-        ): ArmeriaRoute {
-            return ArmeriaRoute(
+        ): ArmeriaRoute =
+            ArmeriaRoute(
                 protocol = protocol,
                 httpMethod = httpMethod,
                 path = path,
@@ -121,7 +124,6 @@ data class ArmeriaRoute(
                 delegationMountPath = delegationMountPath,
                 pointer = SmartPointerManager.createPointer(element),
             )
-        }
 
         fun createRuntime(
             httpMethod: String,
@@ -130,8 +132,8 @@ data class ArmeriaRoute(
             moduleName: String,
             protocol: String,
             project: Project? = null,
-        ): ArmeriaRoute {
-            return ArmeriaRoute(
+        ): ArmeriaRoute =
+            ArmeriaRoute(
                 protocol = protocol,
                 httpMethod = httpMethod,
                 path = path,
@@ -144,9 +146,11 @@ data class ArmeriaRoute(
                 exceptionHandlers = emptyList(),
                 pointer = project?.let(::ArmeriaRuntimeRoutePointer) ?: ArmeriaRuntimeRoutePointer.withoutProject(),
             )
-        }
 
-        fun truncateTarget(value: String, limit: Int = TARGET_DISPLAY_LIMIT): String {
+        fun truncateTarget(
+            value: String,
+            limit: Int = TARGET_DISPLAY_LIMIT,
+        ): String {
             if (value.length <= limit) {
                 return value
             }

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcRouteCollector.kt
@@ -67,29 +67,25 @@ internal object ArmeriaSpringMvcRouteCollector {
 
     private fun collectFromController(controller: PsiClass, routes: MutableList<SpringMvcRoute>) {
         val classPrefixes = extractMergedClassRequestMappingPrefixes(controller)
-        // BFS from the concrete controller: first mapped method per signature wins (most specific).
-        val mappedBySignature = linkedMapOf<String, PsiMethod>()
-        for (type in typesInHierarchy(controller)) {
-            for (method in type.methods) {
-                if (method.containingClass != type) {
-                    continue
-                }
-                if (!hasMappingAnnotation(method)) {
-                    continue
-                }
-                val signature = methodSignatureKey(method)
-                if (signature !in mappedBySignature) {
-                    mappedBySignature[signature] = method
-                }
+        // controller.methods is most-specific per signature (overrides hide ancestors).
+        // When the override has no mapping, resolveMappedMethod looks at super methods.
+        val seenSignatures = mutableSetOf<String>()
+        for (method in controller.methods) {
+            val containing = method.containingClass
+            if (containing != null && containing.qualifiedName == JAVA_LANG_OBJECT) {
+                continue
             }
-        }
-        for (method in mappedBySignature.values) {
-            for (annotation in method.annotations) {
+            val mappedMethod = resolveMappedMethod(method) ?: continue
+            val signature = methodSignatureKey(method)
+            if (!seenSignatures.add(signature)) {
+                continue
+            }
+            for (annotation in mappedMethod.annotations) {
                 val fqn = annotation.qualifiedName ?: continue
                 val defaultMethod = MAPPING_ANNOTATIONS[fqn] ?: continue
                 addRoutesFromMethod(
                     controller = controller,
-                    method = method,
+                    method = mappedMethod,
                     mappingAnnotation = annotation,
                     defaultMethod = defaultMethod,
                     classPrefixes = classPrefixes,
@@ -97,6 +93,22 @@ internal object ArmeriaSpringMvcRouteCollector {
                 )
             }
         }
+    }
+
+    /**
+     * Prefers a mapping on [method] itself; otherwise the nearest super method (base class or
+     * interface) that declares a Spring MVC mapping annotation.
+     */
+    private fun resolveMappedMethod(method: PsiMethod): PsiMethod? {
+        if (hasMappingAnnotation(method)) {
+            return method
+        }
+        for (superMethod in method.findSuperMethods()) {
+            if (hasMappingAnnotation(superMethod)) {
+                return superMethod
+            }
+        }
+        return null
     }
 
     private fun addRoutesFromMethod(

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcRouteCollector.kt
@@ -11,7 +11,6 @@ import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiModifier
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.AnnotatedElementsSearch
-import java.util.ArrayDeque
 
 internal data class SpringMvcRoute(
     val httpMethod: String,
@@ -110,19 +109,29 @@ internal object ArmeriaSpringMvcRouteCollector {
     }
 
     /**
-     * Prefers a mapping on [method] itself; otherwise the nearest super method (base class or
-     * interface) that declares a Spring MVC mapping annotation.
+     * Prefers a mapping on [method] itself; otherwise walks super methods (recursively) until a
+     * Spring MVC mapping annotation is found. Matches Spring's TYPE_HIERARCHY walk: at each level
+     * interface supers are considered before class supers, and unannotated intermediate overrides
+     * do not stop the search.
      */
     private fun resolveMappedMethod(method: PsiMethod): PsiMethod? {
         if (hasMappingAnnotation(method)) {
             return method
         }
-        for (superMethod in method.findSuperMethods()) {
-            if (hasMappingAnnotation(superMethod)) {
-                return superMethod
-            }
+        for (superMethod in orderedSuperMethods(method)) {
+            resolveMappedMethod(superMethod)?.let { return it }
         }
         return null
+    }
+
+    /**
+     * [PsiMethod.findSuperMethods] returns only immediate supers; sort them so interface methods
+     * precede class methods (Spring AnnotationsScanner TYPE_HIERARCHY order).
+     */
+    private fun orderedSuperMethods(method: PsiMethod): List<PsiMethod> {
+        return method.findSuperMethods().sortedBy { superMethod ->
+            if (superMethod.containingClass?.isInterface == true) 0 else 1
+        }
     }
 
     private fun addRoutesFromMethod(
@@ -155,8 +164,9 @@ internal object ArmeriaSpringMvcRouteCollector {
     }
 
     /**
-     * Walks [controller] then supers/interfaces. The first type that declares `@RequestMapping`
-     * supplies prefixes (most specific wins; parent applies when the child has none).
+     * Walks [controller] then supers/interfaces (Spring TYPE_HIERARCHY DFS: interfaces before
+     * superclass). The first type that declares `@RequestMapping` supplies prefixes (most specific
+     * wins; parent applies when the child has none).
      */
     private fun extractMergedClassRequestMappingPrefixes(controller: PsiClass): List<String> {
         for (type in typesInHierarchy(controller)) {
@@ -180,22 +190,28 @@ internal object ArmeriaSpringMvcRouteCollector {
         return prefixes.ifEmpty { listOf("") }
     }
 
-    private fun typesInHierarchy(psiClass: PsiClass): Sequence<PsiClass> = sequence {
+    /**
+     * Depth-first hierarchy walk matching Spring's AnnotationsScanner TYPE_HIERARCHY:
+     * current type, then each interface (recursively), then superclass (recursively).
+     */
+    private fun typesInHierarchy(psiClass: PsiClass): Sequence<PsiClass> {
         val visited = mutableSetOf<PsiClass>()
-        val queue = ArrayDeque<PsiClass>()
-        queue.add(psiClass)
-        while (queue.isNotEmpty()) {
-            val current = queue.removeFirst()
-            if (!visited.add(current)) {
-                continue
-            }
+        val result = ArrayList<PsiClass>()
+        fun walk(current: PsiClass) {
             if (current.qualifiedName == JAVA_LANG_OBJECT) {
-                continue
+                return
             }
-            yield(current)
-            current.superClass?.let { queue.add(it) }
-            queue.addAll(current.interfaces)
+            if (!visited.add(current)) {
+                return
+            }
+            result.add(current)
+            for (iface in current.interfaces) {
+                walk(iface)
+            }
+            current.superClass?.let { walk(it) }
         }
+        walk(psiClass)
+        return result.asSequence()
     }
 
     private fun hasMappingAnnotation(method: PsiMethod): Boolean {

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcRouteCollector.kt
@@ -10,6 +10,7 @@ import com.intellij.psi.PsiEnumConstant
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.AnnotatedElementsSearch
+import java.util.ArrayDeque
 
 internal data class SpringMvcRoute(
     val httpMethod: String,
@@ -22,35 +23,30 @@ internal object ArmeriaSpringMvcRouteCollector {
     private const val REST_CONTROLLER = "org.springframework.web.bind.annotation.RestController"
     private const val CONTROLLER = "org.springframework.stereotype.Controller"
     private const val REQUEST_MAPPING = "org.springframework.web.bind.annotation.RequestMapping"
+    private const val JAVA_LANG_OBJECT = "java.lang.Object"
 
     private val CONTROLLER_STEREOTYPES = listOf(REST_CONTROLLER, CONTROLLER)
 
-    private val MAPPING_ANNOTATIONS =
-        mapOf(
-            "org.springframework.web.bind.annotation.GetMapping" to "GET",
-            "org.springframework.web.bind.annotation.PostMapping" to "POST",
-            "org.springframework.web.bind.annotation.PutMapping" to "PUT",
-            "org.springframework.web.bind.annotation.DeleteMapping" to "DELETE",
-            "org.springframework.web.bind.annotation.PatchMapping" to "PATCH",
-            REQUEST_MAPPING to "",
-        )
+    private val MAPPING_ANNOTATIONS = mapOf(
+        "org.springframework.web.bind.annotation.GetMapping" to "GET",
+        "org.springframework.web.bind.annotation.PostMapping" to "POST",
+        "org.springframework.web.bind.annotation.PutMapping" to "PUT",
+        "org.springframework.web.bind.annotation.DeleteMapping" to "DELETE",
+        "org.springframework.web.bind.annotation.PatchMapping" to "PATCH",
+        REQUEST_MAPPING to "",
+    )
 
     /**
      * Stereotype annotation classes live in Spring library jars. Resolve them with [classpathScope]
      * (typically [GlobalSearchScope.allScope]); search annotated controllers only in [scope]
      * (typically project content) so library controllers are not pulled in.
      */
-    private fun isSpringWebAvailable(
-        psiFacade: JavaPsiFacade,
-        classpathScope: GlobalSearchScope,
-    ): Boolean =
-        psiFacade.findClass(REST_CONTROLLER, classpathScope) != null ||
+    private fun isSpringWebAvailable(psiFacade: JavaPsiFacade, classpathScope: GlobalSearchScope): Boolean {
+        return psiFacade.findClass(REST_CONTROLLER, classpathScope) != null ||
             psiFacade.findClass(CONTROLLER, classpathScope) != null
+    }
 
-    fun collect(
-        project: Project,
-        scope: GlobalSearchScope,
-    ): List<SpringMvcRoute> {
+    fun collect(project: Project, scope: GlobalSearchScope): List<SpringMvcRoute> {
         val psiFacade = JavaPsiFacade.getInstance(project)
         // Library jars (spring-web / spring-context) are outside projectScope.
         val classpathScope = GlobalSearchScope.allScope(project)
@@ -69,49 +65,81 @@ internal object ArmeriaSpringMvcRouteCollector {
         return routes
     }
 
-    private fun collectFromController(
-        controller: PsiClass,
-        routes: MutableList<SpringMvcRoute>,
-    ) {
-        val classPrefixes = extractClassRequestMappingPrefixes(controller)
-        for (method in controller.methods) {
-            // Inherited / interface-declared mappings are deferred (see #261).
-            if (method.containingClass != controller) {
-                continue
+    private fun collectFromController(controller: PsiClass, routes: MutableList<SpringMvcRoute>) {
+        val classPrefixes = extractMergedClassRequestMappingPrefixes(controller)
+        // BFS from the concrete controller: first mapped method per signature wins (most specific).
+        val mappedBySignature = linkedMapOf<String, PsiMethod>()
+        for (type in typesInHierarchy(controller)) {
+            for (method in type.methods) {
+                if (method.containingClass != type) {
+                    continue
+                }
+                if (!hasMappingAnnotation(method)) {
+                    continue
+                }
+                val signature = methodSignatureKey(method)
+                if (signature !in mappedBySignature) {
+                    mappedBySignature[signature] = method
+                }
             }
+        }
+        for (method in mappedBySignature.values) {
             for (annotation in method.annotations) {
                 val fqn = annotation.qualifiedName ?: continue
                 val defaultMethod = MAPPING_ANNOTATIONS[fqn] ?: continue
-                addRoutesFromMethod(method, annotation, defaultMethod, classPrefixes, routes)
+                addRoutesFromMethod(
+                    controller = controller,
+                    method = method,
+                    mappingAnnotation = annotation,
+                    defaultMethod = defaultMethod,
+                    classPrefixes = classPrefixes,
+                    routes = routes,
+                )
             }
         }
     }
 
     private fun addRoutesFromMethod(
+        controller: PsiClass,
         method: PsiMethod,
         mappingAnnotation: PsiAnnotation,
         defaultMethod: String,
         classPrefixes: List<String>,
         routes: MutableList<SpringMvcRoute>,
     ) {
-        val containingClass = method.containingClass ?: return
         val httpMethods = resolveHttpMethods(mappingAnnotation, defaultMethod)
         val paths = ArmeriaRouteSupport.extractPaths(mappingAnnotation).ifEmpty { listOf("") }
-        val target = buildMethodTarget(containingClass, method)
+        // Attribute the route to the stereotype-annotated controller, even when the mapping
+        // lives on a base class or interface.
+        val target = buildMethodTarget(controller, method)
         for (classPrefix in classPrefixes) {
             for (rawPath in paths) {
                 val combinedPath = ArmeriaRouteSupport.combinePaths(classPrefix, rawPath)
                 for (httpMethod in httpMethods) {
-                    routes +=
-                        SpringMvcRoute(
-                            httpMethod = httpMethod,
-                            path = combinedPath,
-                            target = target,
-                            element = method,
-                        )
+                    routes += SpringMvcRoute(
+                        httpMethod = httpMethod,
+                        path = combinedPath,
+                        target = target,
+                        element = method,
+                    )
                 }
             }
         }
+    }
+
+    /**
+     * Walks [controller] then supers/interfaces. The first type that declares `@RequestMapping`
+     * supplies prefixes (most specific wins; parent applies when the child has none).
+     */
+    private fun extractMergedClassRequestMappingPrefixes(controller: PsiClass): List<String> {
+        for (type in typesInHierarchy(controller)) {
+            val requestMappings = type.annotations.filter { it.qualifiedName == REQUEST_MAPPING }
+            if (requestMappings.isEmpty()) {
+                continue
+            }
+            return extractClassRequestMappingPrefixes(type)
+        }
+        return listOf("")
     }
 
     private fun extractClassRequestMappingPrefixes(psiClass: PsiClass): List<String> {
@@ -120,21 +148,48 @@ internal object ArmeriaSpringMvcRouteCollector {
         if (requestMappings.isEmpty()) {
             return listOf("")
         }
-        val prefixes =
-            requestMappings.flatMap { mapping ->
-                ArmeriaRouteSupport.extractPaths(mapping).ifEmpty { listOf("") }
-            }
+        val prefixes = requestMappings.flatMap { mapping ->
+            ArmeriaRouteSupport.extractPaths(mapping).ifEmpty { listOf("") }
+        }
         return prefixes.ifEmpty { listOf("") }
+    }
+
+    private fun typesInHierarchy(psiClass: PsiClass): Sequence<PsiClass> = sequence {
+        val visited = mutableSetOf<PsiClass>()
+        val queue = ArrayDeque<PsiClass>()
+        queue.add(psiClass)
+        while (queue.isNotEmpty()) {
+            val current = queue.removeFirst()
+            if (!visited.add(current)) {
+                continue
+            }
+            if (current.qualifiedName == JAVA_LANG_OBJECT) {
+                continue
+            }
+            yield(current)
+            current.superClass?.let { queue.add(it) }
+            queue.addAll(current.interfaces)
+        }
+    }
+
+    private fun hasMappingAnnotation(method: PsiMethod): Boolean {
+        return method.annotations.any { annotation ->
+            annotation.qualifiedName in MAPPING_ANNOTATIONS
+        }
+    }
+
+    private fun methodSignatureKey(method: PsiMethod): String {
+        val paramTypes = method.parameterList.parameters.joinToString(",") { parameter ->
+            parameter.type.canonicalText
+        }
+        return "${method.name}($paramTypes)"
     }
 
     /**
      * Returns one entry per HTTP method. Empty attribute (all methods) yields a single blank method
      * so callers keep catch-all semantics.
      */
-    private fun resolveHttpMethods(
-        annotation: PsiAnnotation,
-        defaultMethod: String,
-    ): List<String> {
+    private fun resolveHttpMethods(annotation: PsiAnnotation, defaultMethod: String): List<String> {
         if (defaultMethod.isNotEmpty()) {
             return listOf(defaultMethod)
         }
@@ -146,8 +201,8 @@ internal object ArmeriaSpringMvcRouteCollector {
      * Resolves Spring `RequestMethod` enum references (and arrays) to HTTP method names.
      * Empty attribute means all methods — returns an empty list so callers keep `httpMethod` blank.
      */
-    private fun extractRequestMethods(value: PsiAnnotationMemberValue?): List<String> =
-        when (value) {
+    private fun extractRequestMethods(value: PsiAnnotationMemberValue?): List<String> {
+        return when (value) {
             null -> emptyList()
             is PsiArrayInitializerMemberValue -> value.initializers.flatMap(::extractRequestMethods)
             else -> {
@@ -156,11 +211,9 @@ internal object ArmeriaSpringMvcRouteCollector {
                 if (!name.isNullOrEmpty()) listOf(name) else emptyList()
             }
         }
+    }
 
-    private fun buildMethodTarget(
-        psiClass: PsiClass,
-        method: PsiMethod,
-    ): String {
+    private fun buildMethodTarget(psiClass: PsiClass, method: PsiMethod): String {
         val className = psiClass.qualifiedName ?: psiClass.name ?: "<anonymous>"
         return "$className#${method.name}()"
     }

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcRouteCollector.kt
@@ -8,6 +8,7 @@ import com.intellij.psi.PsiArrayInitializerMemberValue
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiEnumConstant
 import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiModifier
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.AnnotatedElementsSearch
 import java.util.ArrayDeque
@@ -16,7 +17,10 @@ internal data class SpringMvcRoute(
     val httpMethod: String,
     val path: String,
     val target: String,
+    /** Method that owns the mapping annotation (may be on a base type or interface). */
     val element: PsiMethod,
+    /** Stereotype-annotated concrete controller used for module attribution and target. */
+    val controller: PsiClass,
 )
 
 internal object ArmeriaSpringMvcRouteCollector {
@@ -60,39 +64,42 @@ internal object ArmeriaSpringMvcRouteCollector {
         }
         val routes = mutableListOf<SpringMvcRoute>()
         for (controller in controllers) {
+            if (!isConcreteControllerBean(controller, controllers)) {
+                continue
+            }
             collectFromController(controller, routes)
         }
         return routes
     }
 
+    /**
+     * Spring does not instantiate abstract / interface stereotype types, and a superclass that is
+     * itself stereotype-annotated would otherwise emit the same inherited mappings twice.
+     */
+    private fun isConcreteControllerBean(controller: PsiClass, allControllers: Set<PsiClass>): Boolean {
+        if (controller.isInterface || controller.hasModifierProperty(PsiModifier.ABSTRACT)) {
+            return false
+        }
+        return allControllers.none { other ->
+            other != controller && other.isInheritor(controller, true)
+        }
+    }
+
     private fun collectFromController(controller: PsiClass, routes: MutableList<SpringMvcRoute>) {
         val classPrefixes = extractMergedClassRequestMappingPrefixes(controller)
-        // Most-specific mapping wins: BFS from the controller, then fill gaps from visible
-        // methods / findSuperMethods (covers unannotated overrides of interface mappings).
-        val mappedBySignature = linkedMapOf<String, PsiMethod>()
-        for (type in typesInHierarchy(controller)) {
-            for (method in declaredMethods(type)) {
-                if (!hasMappingAnnotation(method)) {
-                    continue
-                }
-                mappedBySignature.putIfAbsent(methodSignatureKey(method), method)
-            }
-        }
-        for (method in controller.methods) {
-            val containing = method.containingClass
-            if (containing != null && containing.qualifiedName == JAVA_LANG_OBJECT) {
+        // One most-specific method per visible signature; unannotated overrides resolve via supers.
+        for (signature in controller.visibleSignatures) {
+            val method = signature.method
+            if (method.containingClass?.qualifiedName == JAVA_LANG_OBJECT) {
                 continue
             }
             val mappedMethod = resolveMappedMethod(method) ?: continue
-            mappedBySignature.putIfAbsent(methodSignatureKey(method), mappedMethod)
-        }
-        for (method in mappedBySignature.values) {
-            for (annotation in method.annotations) {
+            for (annotation in mappedMethod.annotations) {
                 val fqn = annotation.qualifiedName ?: continue
                 val defaultMethod = MAPPING_ANNOTATIONS[fqn] ?: continue
                 addRoutesFromMethod(
                     controller = controller,
-                    method = method,
+                    method = mappedMethod,
                     mappingAnnotation = annotation,
                     defaultMethod = defaultMethod,
                     classPrefixes = classPrefixes,
@@ -140,6 +147,7 @@ internal object ArmeriaSpringMvcRouteCollector {
                         path = combinedPath,
                         target = target,
                         element = method,
+                        controller = controller,
                     )
                 }
             }
@@ -152,8 +160,7 @@ internal object ArmeriaSpringMvcRouteCollector {
      */
     private fun extractMergedClassRequestMappingPrefixes(controller: PsiClass): List<String> {
         for (type in typesInHierarchy(controller)) {
-            val requestMappings = type.annotations.filter { it.qualifiedName == REQUEST_MAPPING }
-            if (requestMappings.isEmpty()) {
+            if (type.annotations.none { it.qualifiedName == REQUEST_MAPPING }) {
                 continue
             }
             return extractClassRequestMappingPrefixes(type)
@@ -191,23 +198,10 @@ internal object ArmeriaSpringMvcRouteCollector {
         }
     }
 
-    private fun declaredMethods(type: PsiClass): List<PsiMethod> {
-        return type.methods.filter { method ->
-            method.containingClass?.isEquivalentTo(type) == true
-        }
-    }
-
     private fun hasMappingAnnotation(method: PsiMethod): Boolean {
         return method.annotations.any { annotation ->
             annotation.qualifiedName in MAPPING_ANNOTATIONS
         }
-    }
-
-    private fun methodSignatureKey(method: PsiMethod): String {
-        val paramTypes = method.parameterList.parameters.joinToString(",") { parameter ->
-            parameter.type.canonicalText
-        }
-        return "${method.name}($paramTypes)"
     }
 
     /**

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcRouteCollector.kt
@@ -11,6 +11,7 @@ import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiModifier
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.AnnotatedElementsSearch
+import com.intellij.psi.search.searches.ClassInheritorsSearch
 
 internal data class SpringMvcRoute(
     val httpMethod: String,
@@ -62,21 +63,37 @@ internal object ArmeriaSpringMvcRouteCollector {
         if (!isSpringWebAvailable(psiFacade, classpathScope)) {
             return emptyList()
         }
-        val controllers = linkedSetOf<PsiClass>()
+        // Direct stereotype hits plus concrete inheritors of abstract/interface stereotypes.
+        // Mirrors Spring RequestMappingHandlerMapping.isHandler (TYPE_HIERARCHY for @Controller).
+        val stereotypeTypes = linkedSetOf<PsiClass>()
         for (stereotypeFqn in CONTROLLER_STEREOTYPES) {
             val annotationClass = psiFacade.findClass(stereotypeFqn, classpathScope) ?: continue
-            AnnotatedElementsSearch.searchPsiClasses(annotationClass, scope).forEach { controllers.add(it) }
+            AnnotatedElementsSearch.searchPsiClasses(annotationClass, scope).forEach { stereotypeTypes.add(it) }
+        }
+        val controllers = linkedSetOf<PsiClass>()
+        for (type in stereotypeTypes) {
+            if (isConcreteControllerType(type)) {
+                controllers.add(type)
+                continue
+            }
+            ClassInheritorsSearch.search(type, scope, true).forEach { inheritor ->
+                if (isConcreteControllerType(inheritor)) {
+                    controllers.add(inheritor)
+                }
+            }
         }
         val routes = mutableListOf<SpringMvcRoute>()
         for (controller in controllers) {
-            // Spring does not instantiate abstract / interface stereotype types.
-            if (controller.isInterface || controller.hasModifierProperty(PsiModifier.ABSTRACT)) {
-                continue
-            }
             collectFromController(controller, routes)
         }
         return routes
     }
+
+    /** Spring does not instantiate abstract / interface stereotype types as handler beans. */
+    private fun isConcreteControllerType(psiClass: PsiClass): Boolean =
+        !psiClass.isInterface &&
+            !psiClass.hasModifierProperty(PsiModifier.ABSTRACT) &&
+            !psiClass.name.isNullOrEmpty()
 
     private fun collectFromController(
         controller: PsiClass,

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcRouteCollector.kt
@@ -67,25 +67,32 @@ internal object ArmeriaSpringMvcRouteCollector {
 
     private fun collectFromController(controller: PsiClass, routes: MutableList<SpringMvcRoute>) {
         val classPrefixes = extractMergedClassRequestMappingPrefixes(controller)
-        // controller.methods is most-specific per signature (overrides hide ancestors).
-        // When the override has no mapping, resolveMappedMethod looks at super methods.
-        val seenSignatures = mutableSetOf<String>()
+        // Most-specific mapping wins: BFS from the controller, then fill gaps from visible
+        // methods / findSuperMethods (covers unannotated overrides of interface mappings).
+        val mappedBySignature = linkedMapOf<String, PsiMethod>()
+        for (type in typesInHierarchy(controller)) {
+            for (method in declaredMethods(type)) {
+                if (!hasMappingAnnotation(method)) {
+                    continue
+                }
+                mappedBySignature.putIfAbsent(methodSignatureKey(method), method)
+            }
+        }
         for (method in controller.methods) {
             val containing = method.containingClass
             if (containing != null && containing.qualifiedName == JAVA_LANG_OBJECT) {
                 continue
             }
             val mappedMethod = resolveMappedMethod(method) ?: continue
-            val signature = methodSignatureKey(method)
-            if (!seenSignatures.add(signature)) {
-                continue
-            }
-            for (annotation in mappedMethod.annotations) {
+            mappedBySignature.putIfAbsent(methodSignatureKey(method), mappedMethod)
+        }
+        for (method in mappedBySignature.values) {
+            for (annotation in method.annotations) {
                 val fqn = annotation.qualifiedName ?: continue
                 val defaultMethod = MAPPING_ANNOTATIONS[fqn] ?: continue
                 addRoutesFromMethod(
                     controller = controller,
-                    method = mappedMethod,
+                    method = method,
                     mappingAnnotation = annotation,
                     defaultMethod = defaultMethod,
                     classPrefixes = classPrefixes,
@@ -181,6 +188,12 @@ internal object ArmeriaSpringMvcRouteCollector {
             yield(current)
             current.superClass?.let { queue.add(it) }
             queue.addAll(current.interfaces)
+        }
+    }
+
+    private fun declaredMethods(type: PsiClass): List<PsiMethod> {
+        return type.methods.filter { method ->
+            method.containingClass?.isEquivalentTo(type) == true
         }
     }
 

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcRouteCollector.kt
@@ -30,26 +30,32 @@ internal object ArmeriaSpringMvcRouteCollector {
 
     private val CONTROLLER_STEREOTYPES = listOf(REST_CONTROLLER, CONTROLLER)
 
-    private val MAPPING_ANNOTATIONS = mapOf(
-        "org.springframework.web.bind.annotation.GetMapping" to "GET",
-        "org.springframework.web.bind.annotation.PostMapping" to "POST",
-        "org.springframework.web.bind.annotation.PutMapping" to "PUT",
-        "org.springframework.web.bind.annotation.DeleteMapping" to "DELETE",
-        "org.springframework.web.bind.annotation.PatchMapping" to "PATCH",
-        REQUEST_MAPPING to "",
-    )
+    private val MAPPING_ANNOTATIONS =
+        mapOf(
+            "org.springframework.web.bind.annotation.GetMapping" to "GET",
+            "org.springframework.web.bind.annotation.PostMapping" to "POST",
+            "org.springframework.web.bind.annotation.PutMapping" to "PUT",
+            "org.springframework.web.bind.annotation.DeleteMapping" to "DELETE",
+            "org.springframework.web.bind.annotation.PatchMapping" to "PATCH",
+            REQUEST_MAPPING to "",
+        )
 
     /**
      * Stereotype annotation classes live in Spring library jars. Resolve them with [classpathScope]
      * (typically [GlobalSearchScope.allScope]); search annotated controllers only in [scope]
      * (typically project content) so library controllers are not pulled in.
      */
-    private fun isSpringWebAvailable(psiFacade: JavaPsiFacade, classpathScope: GlobalSearchScope): Boolean {
-        return psiFacade.findClass(REST_CONTROLLER, classpathScope) != null ||
+    private fun isSpringWebAvailable(
+        psiFacade: JavaPsiFacade,
+        classpathScope: GlobalSearchScope,
+    ): Boolean =
+        psiFacade.findClass(REST_CONTROLLER, classpathScope) != null ||
             psiFacade.findClass(CONTROLLER, classpathScope) != null
-    }
 
-    fun collect(project: Project, scope: GlobalSearchScope): List<SpringMvcRoute> {
+    fun collect(
+        project: Project,
+        scope: GlobalSearchScope,
+    ): List<SpringMvcRoute> {
         val psiFacade = JavaPsiFacade.getInstance(project)
         // Library jars (spring-web / spring-context) are outside projectScope.
         val classpathScope = GlobalSearchScope.allScope(project)
@@ -72,7 +78,10 @@ internal object ArmeriaSpringMvcRouteCollector {
         return routes
     }
 
-    private fun collectFromController(controller: PsiClass, routes: MutableList<SpringMvcRoute>) {
+    private fun collectFromController(
+        controller: PsiClass,
+        routes: MutableList<SpringMvcRoute>,
+    ) {
         val hierarchy = typesInHierarchy(controller)
         val classPrefixes = extractMergedClassRequestMappingPrefixes(hierarchy)
         // One most-specific method per visible signature; unannotated overrides resolve via supers.
@@ -101,7 +110,10 @@ internal object ArmeriaSpringMvcRouteCollector {
      * Walks [hierarchy] (Spring TYPE_HIERARCHY order) and returns the first same-signature method
      * that declares a Spring MVC mapping. Unannotated intermediate overrides do not stop the search.
      */
-    private fun resolveMappedMethod(hierarchy: List<PsiClass>, method: PsiMethod): PsiMethod? {
+    private fun resolveMappedMethod(
+        hierarchy: List<PsiClass>,
+        method: PsiMethod,
+    ): PsiMethod? {
         for (type in hierarchy) {
             val candidate = type.findMethodBySignature(method, false) ?: continue
             if (hasMappingAnnotation(candidate)) {
@@ -128,13 +140,14 @@ internal object ArmeriaSpringMvcRouteCollector {
             for (rawPath in paths) {
                 val combinedPath = ArmeriaRouteSupport.combinePaths(classPrefix, rawPath)
                 for (httpMethod in httpMethods) {
-                    routes += SpringMvcRoute(
-                        httpMethod = httpMethod,
-                        path = combinedPath,
-                        target = target,
-                        element = method,
-                        controller = controller,
-                    )
+                    routes +=
+                        SpringMvcRoute(
+                            httpMethod = httpMethod,
+                            path = combinedPath,
+                            target = target,
+                            element = method,
+                            controller = controller,
+                        )
                 }
             }
         }
@@ -151,9 +164,10 @@ internal object ArmeriaSpringMvcRouteCollector {
             if (requestMappings.isEmpty()) {
                 continue
             }
-            val prefixes = requestMappings.flatMap { mapping ->
-                ArmeriaRouteSupport.extractPaths(mapping).ifEmpty { listOf("") }
-            }
+            val prefixes =
+                requestMappings.flatMap { mapping ->
+                    ArmeriaRouteSupport.extractPaths(mapping).ifEmpty { listOf("") }
+                }
             return prefixes.ifEmpty { listOf("") }
         }
         return listOf("")
@@ -166,6 +180,7 @@ internal object ArmeriaSpringMvcRouteCollector {
     private fun typesInHierarchy(psiClass: PsiClass): List<PsiClass> {
         val visited = mutableSetOf<PsiClass>()
         val result = ArrayList<PsiClass>()
+
         fun walk(current: PsiClass) {
             if (current.qualifiedName == JAVA_LANG_OBJECT) {
                 return
@@ -183,17 +198,19 @@ internal object ArmeriaSpringMvcRouteCollector {
         return result
     }
 
-    private fun hasMappingAnnotation(method: PsiMethod): Boolean {
-        return method.annotations.any { annotation ->
+    private fun hasMappingAnnotation(method: PsiMethod): Boolean =
+        method.annotations.any { annotation ->
             annotation.qualifiedName in MAPPING_ANNOTATIONS
         }
-    }
 
     /**
      * Returns one entry per HTTP method. Empty attribute (all methods) yields a single blank method
      * so callers keep catch-all semantics.
      */
-    private fun resolveHttpMethods(annotation: PsiAnnotation, defaultMethod: String): List<String> {
+    private fun resolveHttpMethods(
+        annotation: PsiAnnotation,
+        defaultMethod: String,
+    ): List<String> {
         if (defaultMethod.isNotEmpty()) {
             return listOf(defaultMethod)
         }
@@ -205,8 +222,8 @@ internal object ArmeriaSpringMvcRouteCollector {
      * Resolves Spring `RequestMethod` enum references (and arrays) to HTTP method names.
      * Empty attribute means all methods — returns an empty list so callers keep `httpMethod` blank.
      */
-    private fun extractRequestMethods(value: PsiAnnotationMemberValue?): List<String> {
-        return when (value) {
+    private fun extractRequestMethods(value: PsiAnnotationMemberValue?): List<String> =
+        when (value) {
             null -> emptyList()
             is PsiArrayInitializerMemberValue -> value.initializers.flatMap(::extractRequestMethods)
             else -> {
@@ -215,9 +232,11 @@ internal object ArmeriaSpringMvcRouteCollector {
                 if (!name.isNullOrEmpty()) listOf(name) else emptyList()
             }
         }
-    }
 
-    private fun buildMethodTarget(psiClass: PsiClass, method: PsiMethod): String {
+    private fun buildMethodTarget(
+        psiClass: PsiClass,
+        method: PsiMethod,
+    ): String {
         val className = psiClass.qualifiedName ?: psiClass.name ?: "<anonymous>"
         return "$className#${method.name}()"
     }

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcRouteCollector.kt
@@ -63,7 +63,8 @@ internal object ArmeriaSpringMvcRouteCollector {
         }
         val routes = mutableListOf<SpringMvcRoute>()
         for (controller in controllers) {
-            if (!isConcreteControllerBean(controller, controllers)) {
+            // Spring does not instantiate abstract / interface stereotype types.
+            if (controller.isInterface || controller.hasModifierProperty(PsiModifier.ABSTRACT)) {
                 continue
             }
             collectFromController(controller, routes)
@@ -71,28 +72,16 @@ internal object ArmeriaSpringMvcRouteCollector {
         return routes
     }
 
-    /**
-     * Spring does not instantiate abstract / interface stereotype types, and a superclass that is
-     * itself stereotype-annotated would otherwise emit the same inherited mappings twice.
-     */
-    private fun isConcreteControllerBean(controller: PsiClass, allControllers: Set<PsiClass>): Boolean {
-        if (controller.isInterface || controller.hasModifierProperty(PsiModifier.ABSTRACT)) {
-            return false
-        }
-        return allControllers.none { other ->
-            other != controller && other.isInheritor(controller, true)
-        }
-    }
-
     private fun collectFromController(controller: PsiClass, routes: MutableList<SpringMvcRoute>) {
-        val classPrefixes = extractMergedClassRequestMappingPrefixes(controller)
+        val hierarchy = typesInHierarchy(controller)
+        val classPrefixes = extractMergedClassRequestMappingPrefixes(hierarchy)
         // One most-specific method per visible signature; unannotated overrides resolve via supers.
         for (signature in controller.visibleSignatures) {
             val method = signature.method
             if (method.containingClass?.qualifiedName == JAVA_LANG_OBJECT) {
                 continue
             }
-            val mappedMethod = resolveMappedMethod(method) ?: continue
+            val mappedMethod = resolveMappedMethod(hierarchy, method) ?: continue
             for (annotation in mappedMethod.annotations) {
                 val fqn = annotation.qualifiedName ?: continue
                 val defaultMethod = MAPPING_ANNOTATIONS[fqn] ?: continue
@@ -109,29 +98,17 @@ internal object ArmeriaSpringMvcRouteCollector {
     }
 
     /**
-     * Prefers a mapping on [method] itself; otherwise walks super methods (recursively) until a
-     * Spring MVC mapping annotation is found. Matches Spring's TYPE_HIERARCHY walk: at each level
-     * interface supers are considered before class supers, and unannotated intermediate overrides
-     * do not stop the search.
+     * Walks [hierarchy] (Spring TYPE_HIERARCHY order) and returns the first same-signature method
+     * that declares a Spring MVC mapping. Unannotated intermediate overrides do not stop the search.
      */
-    private fun resolveMappedMethod(method: PsiMethod): PsiMethod? {
-        if (hasMappingAnnotation(method)) {
-            return method
-        }
-        for (superMethod in orderedSuperMethods(method)) {
-            resolveMappedMethod(superMethod)?.let { return it }
+    private fun resolveMappedMethod(hierarchy: List<PsiClass>, method: PsiMethod): PsiMethod? {
+        for (type in hierarchy) {
+            val candidate = type.findMethodBySignature(method, false) ?: continue
+            if (hasMappingAnnotation(candidate)) {
+                return candidate
+            }
         }
         return null
-    }
-
-    /**
-     * [PsiMethod.findSuperMethods] returns only immediate supers; sort them so interface methods
-     * precede class methods (Spring AnnotationsScanner TYPE_HIERARCHY order).
-     */
-    private fun orderedSuperMethods(method: PsiMethod): List<PsiMethod> {
-        return method.findSuperMethods().sortedBy { superMethod ->
-            if (superMethod.containingClass?.isInterface == true) 0 else 1
-        }
     }
 
     private fun addRoutesFromMethod(
@@ -164,37 +141,29 @@ internal object ArmeriaSpringMvcRouteCollector {
     }
 
     /**
-     * Walks [controller] then supers/interfaces (Spring TYPE_HIERARCHY DFS: interfaces before
-     * superclass). The first type that declares `@RequestMapping` supplies prefixes (most specific
-     * wins; parent applies when the child has none).
+     * Walks [hierarchy] (Spring TYPE_HIERARCHY DFS: interfaces before superclass). The first type
+     * that declares `@RequestMapping` supplies prefixes (most specific wins; parent applies when
+     * the child has none).
      */
-    private fun extractMergedClassRequestMappingPrefixes(controller: PsiClass): List<String> {
-        for (type in typesInHierarchy(controller)) {
-            if (type.annotations.none { it.qualifiedName == REQUEST_MAPPING }) {
+    private fun extractMergedClassRequestMappingPrefixes(hierarchy: List<PsiClass>): List<String> {
+        for (type in hierarchy) {
+            val requestMappings = type.annotations.filter { it.qualifiedName == REQUEST_MAPPING }
+            if (requestMappings.isEmpty()) {
                 continue
             }
-            return extractClassRequestMappingPrefixes(type)
+            val prefixes = requestMappings.flatMap { mapping ->
+                ArmeriaRouteSupport.extractPaths(mapping).ifEmpty { listOf("") }
+            }
+            return prefixes.ifEmpty { listOf("") }
         }
         return listOf("")
-    }
-
-    private fun extractClassRequestMappingPrefixes(psiClass: PsiClass): List<String> {
-        // @RequestMapping is @Repeatable — collect every class-level mapping, not only the first.
-        val requestMappings = psiClass.annotations.filter { it.qualifiedName == REQUEST_MAPPING }
-        if (requestMappings.isEmpty()) {
-            return listOf("")
-        }
-        val prefixes = requestMappings.flatMap { mapping ->
-            ArmeriaRouteSupport.extractPaths(mapping).ifEmpty { listOf("") }
-        }
-        return prefixes.ifEmpty { listOf("") }
     }
 
     /**
      * Depth-first hierarchy walk matching Spring's AnnotationsScanner TYPE_HIERARCHY:
      * current type, then each interface (recursively), then superclass (recursively).
      */
-    private fun typesInHierarchy(psiClass: PsiClass): Sequence<PsiClass> {
+    private fun typesInHierarchy(psiClass: PsiClass): List<PsiClass> {
         val visited = mutableSetOf<PsiClass>()
         val result = ArrayList<PsiClass>()
         fun walk(current: PsiClass) {
@@ -211,7 +180,7 @@ internal object ArmeriaSpringMvcRouteCollector {
             current.superClass?.let { walk(it) }
         }
         walk(psiClass)
-        return result.asSequence()
+        return result
     }
 
     private fun hasMappingAnnotation(method: PsiMethod): Boolean {

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcRouteCollector.kt
@@ -11,7 +11,6 @@ import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiModifier
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.AnnotatedElementsSearch
-import com.intellij.psi.search.searches.ClassInheritorsSearch
 
 internal data class SpringMvcRoute(
     val httpMethod: String,
@@ -21,7 +20,10 @@ internal data class SpringMvcRoute(
     val element: PsiMethod,
     /** Stereotype-annotated concrete controller used for module attribution and target. */
     val controller: PsiClass,
-)
+) {
+    /** Module attribution always follows the concrete controller, not the mapping-owning method. */
+    fun moduleName(): String = ArmeriaRouteMetadata.moduleName(controller)
+}
 
 internal object ArmeriaSpringMvcRouteCollector {
     private const val REST_CONTROLLER = "org.springframework.web.bind.annotation.RestController"
@@ -63,22 +65,17 @@ internal object ArmeriaSpringMvcRouteCollector {
         if (!isSpringWebAvailable(psiFacade, classpathScope)) {
             return emptyList()
         }
-        // Direct stereotype hits plus concrete inheritors of abstract/interface stereotypes.
-        // Mirrors Spring RequestMappingHandlerMapping.isHandler (TYPE_HIERARCHY for @Controller).
-        val stereotypeTypes = linkedSetOf<PsiClass>()
+        // Only concrete stereotype-annotated types become controller beans. Abstract / interface
+        // stereotypes are skipped (Spring does not instantiate them). Unannotated concrete subtypes
+        // are also skipped: @Controller is not @Inherited, so default component scanning does not
+        // register them. Inherited mappings are still discovered via typesInHierarchy when a
+        // concrete annotated controller is in scope (see #261).
+        val controllers = linkedSetOf<PsiClass>()
         for (stereotypeFqn in CONTROLLER_STEREOTYPES) {
             val annotationClass = psiFacade.findClass(stereotypeFqn, classpathScope) ?: continue
-            AnnotatedElementsSearch.searchPsiClasses(annotationClass, scope).forEach { stereotypeTypes.add(it) }
-        }
-        val controllers = linkedSetOf<PsiClass>()
-        for (type in stereotypeTypes) {
-            if (isConcreteControllerType(type)) {
-                controllers.add(type)
-                continue
-            }
-            ClassInheritorsSearch.search(type, scope, true).forEach { inheritor ->
-                if (isConcreteControllerType(inheritor)) {
-                    controllers.add(inheritor)
+            AnnotatedElementsSearch.searchPsiClasses(annotationClass, scope).forEach { type ->
+                if (isConcreteControllerType(type)) {
+                    controllers.add(type)
                 }
             }
         }
@@ -100,7 +97,7 @@ internal object ArmeriaSpringMvcRouteCollector {
         routes: MutableList<SpringMvcRoute>,
     ) {
         val hierarchy = typesInHierarchy(controller)
-        val classPrefixes = extractMergedClassRequestMappingPrefixes(hierarchy)
+        val classPrefixes = resolveClassRequestMappingPrefixes(hierarchy)
         // One most-specific method per visible signature; unannotated overrides resolve via supers.
         for (signature in controller.visibleSignatures) {
             val method = signature.method
@@ -173,9 +170,9 @@ internal object ArmeriaSpringMvcRouteCollector {
     /**
      * Walks [hierarchy] (Spring TYPE_HIERARCHY DFS: interfaces before superclass). The first type
      * that declares `@RequestMapping` supplies prefixes (most specific wins; parent applies when
-     * the child has none).
+     * the child has none). Does not concatenate parent and child prefixes.
      */
-    private fun extractMergedClassRequestMappingPrefixes(hierarchy: List<PsiClass>): List<String> {
+    private fun resolveClassRequestMappingPrefixes(hierarchy: List<PsiClass>): List<String> {
         for (type in hierarchy) {
             val requestMappings = type.annotations.filter { it.qualifiedName == REQUEST_MAPPING }
             if (requestMappings.isEmpty()) {

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
@@ -733,6 +733,165 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
         assertEquals(listOf("GET"), routes.map { it.httpMethod })
     }
 
+    fun testBaseClassMappingIsDiscoveredUnderConcreteController() {
+        configureTomcatMount("/spring/")
+        myFixture.configureByText(
+            "BaseUserController.java",
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.GetMapping;
+
+            public abstract class BaseUserController {
+                @GetMapping("/{id}")
+                public String getUser() {
+                    return "ok";
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "UserController.java",
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.RequestMapping;
+            import org.springframework.web.bind.annotation.RestController;
+
+            @RestController
+            @RequestMapping("/users")
+            public class UserController extends BaseUserController {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val delegatedRoute = routes.single { it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC }
+        assertEquals("GET", delegatedRoute.httpMethod)
+        assertEquals("/spring/users/{id}", delegatedRoute.path)
+        assertEquals("example.UserController#getUser()", delegatedRoute.target)
+    }
+
+    fun testInterfaceMappingIsDiscoveredUnderConcreteController() {
+        configureTomcatMount("/spring/")
+        myFixture.configureByText(
+            "UserApi.java",
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.GetMapping;
+            import org.springframework.web.bind.annotation.RequestMapping;
+
+            @RequestMapping("/users")
+            public interface UserApi {
+                @GetMapping("/{id}")
+                String getUser();
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "UserController.java",
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.RestController;
+
+            @RestController
+            public class UserController implements UserApi {
+                @Override
+                public String getUser() {
+                    return "ok";
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val delegatedRoute = routes.single { it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC }
+        assertEquals("GET", delegatedRoute.httpMethod)
+        assertEquals("/spring/users/{id}", delegatedRoute.path)
+        assertEquals("example.UserController#getUser()", delegatedRoute.target)
+    }
+
+    fun testBaseClassRequestMappingPrefixAppliesToInheritedMethod() {
+        configureTomcatMount("/spring/")
+        myFixture.configureByText(
+            "BaseApiController.java",
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.GetMapping;
+            import org.springframework.web.bind.annotation.RequestMapping;
+
+            @RequestMapping("/api")
+            public abstract class BaseApiController {
+                @GetMapping("/hello")
+                public String hello() {
+                    return "hello";
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "HelloController.java",
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.RestController;
+
+            @RestController
+            public class HelloController extends BaseApiController {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val delegatedRoute = routes.single { it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC }
+        assertEquals("GET", delegatedRoute.httpMethod)
+        assertEquals("/spring/api/hello", delegatedRoute.path)
+        assertEquals("example.HelloController#hello()", delegatedRoute.target)
+    }
+
+    fun testKotlinControllerInheritsJavaBaseClassMapping() {
+        configureTomcatMount("/spring/")
+        myFixture.configureByText(
+            "BaseGreetingController.java",
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.GetMapping;
+
+            public abstract class BaseGreetingController {
+                @GetMapping("/hello")
+                public String hello() {
+                    return "hello";
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "HelloController.kt",
+            """
+            package example
+
+            import org.springframework.web.bind.annotation.RestController
+
+            @RestController
+            class HelloController : BaseGreetingController()
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val delegatedRoute = routes.single { it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC }
+        assertEquals("GET", delegatedRoute.httpMethod)
+        assertEquals("/spring/hello", delegatedRoute.path)
+        assertEquals("example.HelloController#hello()", delegatedRoute.target)
+    }
+
     private fun configureTomcatMount(path: String) {
         myFixture.configureByText(
             "ArmeriaConfig.java",

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
@@ -261,9 +261,10 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
         configureHelloControllerJava()
 
         val routes = ArmeriaRouteCollector.collect(project)
-        val delegated = routes.filter {
-            it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC && it.path == "/spring/hello"
-        }
+        val delegated =
+            routes.filter {
+                it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC && it.path == "/spring/hello"
+            }
         assertEquals(2, delegated.size)
         assertEquals(
             setOf("a.example.com", "b.example.com"),
@@ -539,9 +540,10 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
         )
 
         val routes = ArmeriaRouteCollector.collect(project)
-        val delegatedAtApi = routes.filter {
-            it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC && it.path == "/api"
-        }
+        val delegatedAtApi =
+            routes.filter {
+                it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC && it.path == "/api"
+            }
         assertEquals(
             setOf("/", "/api"),
             delegatedAtApi.map { it.delegationMountPath }.toSet(),
@@ -631,29 +633,32 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
         val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.allScope(project))
         val helloRoute = springMvcRoutes.single()
         val controllerModule = ArmeriaRouteMetadata.moduleName(helloRoute.controller)
-        val matchingMount = ArmeriaRoute.create(
-            element = helloRoute.controller,
-            protocol = RouteProtocol.HTTP.presentableName(),
-            httpMethod = "",
-            path = "/spring/",
-            target = "TomcatService",
-            routeMatch = RouteMatch.SERVICE_UNDER,
-        )
+        val matchingMount =
+            ArmeriaRoute.create(
+                element = helloRoute.controller,
+                protocol = RouteProtocol.HTTP.presentableName(),
+                httpMethod = "",
+                path = "/spring/",
+                target = "TomcatService",
+                routeMatch = RouteMatch.SERVICE_UNDER,
+            )
         val unassignedModule = message("route.explorer.module.unassigned")
 
-        val scopedRoutes = ArmeriaDelegatedRouteCollector.springMvcRoutesForMount(
-            mountRoute = matchingMount,
-            springMvcRoutes = springMvcRoutes,
-            unassignedModule = unassignedModule,
-        )
+        val scopedRoutes =
+            ArmeriaDelegatedRouteCollector.springMvcRoutesForMount(
+                mountRoute = matchingMount,
+                springMvcRoutes = springMvcRoutes,
+                unassignedModule = unassignedModule,
+            )
         assertEquals(springMvcRoutes, scopedRoutes)
 
         val otherModuleMount = matchingMount.copy(moduleName = "$controllerModule-other")
-        val filteredRoutes = ArmeriaDelegatedRouteCollector.springMvcRoutesForMount(
-            mountRoute = otherModuleMount,
-            springMvcRoutes = springMvcRoutes,
-            unassignedModule = unassignedModule,
-        )
+        val filteredRoutes =
+            ArmeriaDelegatedRouteCollector.springMvcRoutesForMount(
+                mountRoute = otherModuleMount,
+                springMvcRoutes = springMvcRoutes,
+                unassignedModule = unassignedModule,
+            )
         assertTrue(filteredRoutes.isEmpty())
     }
 
@@ -687,14 +692,15 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
             ArmeriaServletMountSupport.detectDelegation("TomcatService?", RouteMatch.SERVICE_UNDER),
         )
 
-        val expandable = ArmeriaRoute.create(
-            element = myFixture.addClass("public class ExpandableMountProbe {}"),
-            protocol = RouteProtocol.HTTP.presentableName(),
-            httpMethod = "",
-            path = "/spring/",
-            target = "TomcatService",
-            routeMatch = RouteMatch.SERVICE_UNDER,
-        )
+        val expandable =
+            ArmeriaRoute.create(
+                element = myFixture.addClass("public class ExpandableMountProbe {}"),
+                protocol = RouteProtocol.HTTP.presentableName(),
+                httpMethod = "",
+                path = "/spring/",
+                target = "TomcatService",
+                routeMatch = RouteMatch.SERVICE_UNDER,
+            )
         val exactMount = expandable.copy(routeMatch = RouteMatch.SERVICE, path = "/spring")
         assertTrue(ArmeriaServletMountSupport.isExpandableSpringMvcMount(expandable))
         assertFalse(ArmeriaServletMountSupport.isExpandableSpringMvcMount(exactMount))
@@ -703,23 +709,24 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
     fun testSpringMvcCollectorResolvesStereotypesOutsideSearchScope() {
         // Stereotype annotation classes live outside a controller-only search scope (same as
         // library jars vs projectScope). Collection must still resolve them via classpath scope.
-        val controllerFile = myFixture.configureByText(
-            "HelloController.java",
-            """
-            package example;
+        val controllerFile =
+            myFixture.configureByText(
+                "HelloController.java",
+                """
+                package example;
 
-            import org.springframework.web.bind.annotation.GetMapping;
-            import org.springframework.web.bind.annotation.RestController;
+                import org.springframework.web.bind.annotation.GetMapping;
+                import org.springframework.web.bind.annotation.RestController;
 
-            @RestController
-            public class HelloController {
-                @GetMapping("/hello")
-                public String hello() {
-                    return "hello";
+                @RestController
+                public class HelloController {
+                    @GetMapping("/hello")
+                    public String hello() {
+                        return "hello";
+                    }
                 }
-            }
-            """.trimIndent(),
-        )
+                """.trimIndent(),
+            )
         val controllerOnlyScope = GlobalSearchScope.fileScope(controllerFile)
         val routes = ArmeriaSpringMvcRouteCollector.collect(project, controllerOnlyScope)
         assertEquals(listOf("/hello"), routes.map { it.path })

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
@@ -726,26 +726,6 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
         assertEquals(listOf("GET"), routes.map { it.httpMethod })
     }
 
-    private fun configureTomcatMount(path: String) {
-        myFixture.configureByText(
-            "ArmeriaConfig.java",
-            """
-            package example;
-
-            import com.linecorp.armeria.server.Server;
-            import com.linecorp.armeria.server.tomcat.TomcatService;
-
-            public class ArmeriaConfig {
-                public static void main(String[] args) {
-                    Server.builder()
-                        .serviceUnder("$path", TomcatService.of(null))
-                        .build();
-                }
-            }
-            """.trimIndent(),
-        )
-    }
-
     private fun configureHelloControllerJava(path: String = "/hello") {
         myFixture.configureByText(
             "HelloController.java",
@@ -779,100 +759,6 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
             class HelloController {
                 @GetMapping("$path")
                 fun hello(): String = "hello"
-            }
-            """.trimIndent(),
-        )
-    }
-
-    private fun registerServletServiceStubs() {
-        myFixture.addClass(
-            """
-            package com.linecorp.armeria.server.tomcat;
-
-            public final class TomcatService {
-                public static TomcatService of(Object connector) {
-                    return null;
-                }
-            }
-            """.trimIndent(),
-        )
-        myFixture.addClass(
-            """
-            package com.linecorp.armeria.server.jetty;
-
-            public final class JettyService {
-                public static JettyService of(Object server) {
-                    return null;
-                }
-            }
-            """.trimIndent(),
-        )
-    }
-
-    private fun registerSpringWebMvcStubs() {
-        myFixture.addClass(
-            """
-            package org.springframework.stereotype;
-
-            public @interface Controller {
-            }
-            """.trimIndent(),
-        )
-        myFixture.addClass(
-            """
-            package org.springframework.web.bind.annotation;
-
-            public @interface RestController {
-            }
-            """.trimIndent(),
-        )
-        myFixture.addClass(
-            """
-            package org.springframework.web.bind.annotation;
-
-            public enum RequestMethod {
-                GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE
-            }
-            """.trimIndent(),
-        )
-        myFixture.addClass(
-            """
-            package org.springframework.web.bind.annotation;
-
-            public @interface RequestMappings {
-                RequestMapping[] value();
-            }
-            """.trimIndent(),
-        )
-        myFixture.addClass(
-            """
-            package org.springframework.web.bind.annotation;
-
-            @java.lang.annotation.Repeatable(RequestMappings.class)
-            public @interface RequestMapping {
-                String[] value() default {};
-                String[] path() default {};
-                RequestMethod[] method() default {};
-            }
-            """.trimIndent(),
-        )
-        myFixture.addClass(
-            """
-            package org.springframework.web.bind.annotation;
-
-            public @interface GetMapping {
-                String[] value() default {};
-                String[] path() default {};
-            }
-            """.trimIndent(),
-        )
-        myFixture.addClass(
-            """
-            package org.springframework.web.bind.annotation;
-
-            public @interface PostMapping {
-                String[] value() default {};
-                String[] path() default {};
             }
             """.trimIndent(),
         )

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
@@ -632,7 +632,7 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
 
         val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.allScope(project))
         val helloRoute = springMvcRoutes.single()
-        val controllerModule = ArmeriaRouteMetadata.moduleName(helloRoute.controller)
+        val controllerModule = helloRoute.moduleName()
         val matchingMount =
             ArmeriaRoute.create(
                 element = helloRoute.controller,

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
@@ -261,10 +261,9 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
         configureHelloControllerJava()
 
         val routes = ArmeriaRouteCollector.collect(project)
-        val delegated =
-            routes.filter {
-                it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC && it.path == "/spring/hello"
-            }
+        val delegated = routes.filter {
+            it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC && it.path == "/spring/hello"
+        }
         assertEquals(2, delegated.size)
         assertEquals(
             setOf("a.example.com", "b.example.com"),
@@ -540,10 +539,9 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
         )
 
         val routes = ArmeriaRouteCollector.collect(project)
-        val delegatedAtApi =
-            routes.filter {
-                it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC && it.path == "/api"
-            }
+        val delegatedAtApi = routes.filter {
+            it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC && it.path == "/api"
+        }
         assertEquals(
             setOf("/", "/api"),
             delegatedAtApi.map { it.delegationMountPath }.toSet(),
@@ -632,33 +630,30 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
 
         val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.allScope(project))
         val helloRoute = springMvcRoutes.single()
-        val controllerModule = ArmeriaRouteMetadata.moduleName(helloRoute.element)
-        val matchingMount =
-            ArmeriaRoute.create(
-                element = helloRoute.element,
-                protocol = RouteProtocol.HTTP.presentableName(),
-                httpMethod = "",
-                path = "/spring/",
-                target = "TomcatService",
-                routeMatch = RouteMatch.SERVICE_UNDER,
-            )
+        val controllerModule = ArmeriaRouteMetadata.moduleName(helloRoute.controller)
+        val matchingMount = ArmeriaRoute.create(
+            element = helloRoute.controller,
+            protocol = RouteProtocol.HTTP.presentableName(),
+            httpMethod = "",
+            path = "/spring/",
+            target = "TomcatService",
+            routeMatch = RouteMatch.SERVICE_UNDER,
+        )
         val unassignedModule = message("route.explorer.module.unassigned")
 
-        val scopedRoutes =
-            ArmeriaDelegatedRouteCollector.springMvcRoutesForMount(
-                mountRoute = matchingMount,
-                springMvcRoutes = springMvcRoutes,
-                unassignedModule = unassignedModule,
-            )
+        val scopedRoutes = ArmeriaDelegatedRouteCollector.springMvcRoutesForMount(
+            mountRoute = matchingMount,
+            springMvcRoutes = springMvcRoutes,
+            unassignedModule = unassignedModule,
+        )
         assertEquals(springMvcRoutes, scopedRoutes)
 
         val otherModuleMount = matchingMount.copy(moduleName = "$controllerModule-other")
-        val filteredRoutes =
-            ArmeriaDelegatedRouteCollector.springMvcRoutesForMount(
-                mountRoute = otherModuleMount,
-                springMvcRoutes = springMvcRoutes,
-                unassignedModule = unassignedModule,
-            )
+        val filteredRoutes = ArmeriaDelegatedRouteCollector.springMvcRoutesForMount(
+            mountRoute = otherModuleMount,
+            springMvcRoutes = springMvcRoutes,
+            unassignedModule = unassignedModule,
+        )
         assertTrue(filteredRoutes.isEmpty())
     }
 
@@ -692,15 +687,14 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
             ArmeriaServletMountSupport.detectDelegation("TomcatService?", RouteMatch.SERVICE_UNDER),
         )
 
-        val expandable =
-            ArmeriaRoute.create(
-                element = myFixture.addClass("public class ExpandableMountProbe {}"),
-                protocol = RouteProtocol.HTTP.presentableName(),
-                httpMethod = "",
-                path = "/spring/",
-                target = "TomcatService",
-                routeMatch = RouteMatch.SERVICE_UNDER,
-            )
+        val expandable = ArmeriaRoute.create(
+            element = myFixture.addClass("public class ExpandableMountProbe {}"),
+            protocol = RouteProtocol.HTTP.presentableName(),
+            httpMethod = "",
+            path = "/spring/",
+            target = "TomcatService",
+            routeMatch = RouteMatch.SERVICE_UNDER,
+        )
         val exactMount = expandable.copy(routeMatch = RouteMatch.SERVICE, path = "/spring")
         assertTrue(ArmeriaServletMountSupport.isExpandableSpringMvcMount(expandable))
         assertFalse(ArmeriaServletMountSupport.isExpandableSpringMvcMount(exactMount))
@@ -709,165 +703,16 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
     fun testSpringMvcCollectorResolvesStereotypesOutsideSearchScope() {
         // Stereotype annotation classes live outside a controller-only search scope (same as
         // library jars vs projectScope). Collection must still resolve them via classpath scope.
-        val controllerFile =
-            myFixture.configureByText(
-                "HelloController.java",
-                """
-                package example;
-
-                import org.springframework.web.bind.annotation.GetMapping;
-                import org.springframework.web.bind.annotation.RestController;
-
-                @RestController
-                public class HelloController {
-                    @GetMapping("/hello")
-                    public String hello() {
-                        return "hello";
-                    }
-                }
-                """.trimIndent(),
-            )
-        val controllerOnlyScope = GlobalSearchScope.fileScope(controllerFile)
-        val routes = ArmeriaSpringMvcRouteCollector.collect(project, controllerOnlyScope)
-        assertEquals(listOf("/hello"), routes.map { it.path })
-        assertEquals(listOf("GET"), routes.map { it.httpMethod })
-    }
-
-    fun testBaseClassMappingIsDiscoveredUnderConcreteController() {
-        configureTomcatMount("/spring/")
-        myFixture.addClass(
-            """
-            package example;
-
-            import org.springframework.web.bind.annotation.GetMapping;
-
-            public abstract class BaseUserController {
-                @GetMapping("/{id}")
-                public String getUser() {
-                    return "ok";
-                }
-            }
-            """.trimIndent(),
-        )
-        myFixture.configureByText(
-            "UserController.java",
-            """
-            package example;
-
-            import org.springframework.web.bind.annotation.RequestMapping;
-            import org.springframework.web.bind.annotation.RestController;
-
-            @RestController
-            @RequestMapping("/users")
-            public class UserController extends BaseUserController {
-            }
-            """.trimIndent(),
-        )
-
-        val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.projectScope(project))
-        assertEquals(
-            listOf("example.UserController#getUser()"),
-            springMvcRoutes.map { it.target },
-        )
-        assertEquals(listOf("/users/{id}"), springMvcRoutes.map { it.path })
-
-        val routes = ArmeriaRouteCollector.collect(project)
-
-        val delegatedRoute = routes.single { it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC }
-        assertEquals("GET", delegatedRoute.httpMethod)
-        assertEquals("/spring/users/{id}", delegatedRoute.path)
-        assertEquals("example.UserController#getUser()", delegatedRoute.target)
-    }
-
-    fun testInterfaceMappingIsDiscoveredUnderConcreteController() {
-        configureTomcatMount("/spring/")
-        myFixture.addClass(
-            """
-            package example;
-
-            import org.springframework.web.bind.annotation.GetMapping;
-            import org.springframework.web.bind.annotation.RequestMapping;
-
-            @RequestMapping("/users")
-            public interface UserApi {
-                @GetMapping("/{id}")
-                String getUser();
-            }
-            """.trimIndent(),
-        )
-        myFixture.configureByText(
-            "UserController.java",
-            """
-            package example;
-
-            import org.springframework.web.bind.annotation.RestController;
-
-            @RestController
-            public class UserController implements UserApi {
-                @Override
-                public String getUser() {
-                    return "ok";
-                }
-            }
-            """.trimIndent(),
-        )
-
-        val routes = ArmeriaRouteCollector.collect(project)
-
-        val delegatedRoute = routes.single { it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC }
-        assertEquals("GET", delegatedRoute.httpMethod)
-        assertEquals("/spring/users/{id}", delegatedRoute.path)
-        assertEquals("example.UserController#getUser()", delegatedRoute.target)
-    }
-
-    fun testBaseClassRequestMappingPrefixAppliesToInheritedMethod() {
-        configureTomcatMount("/spring/")
-        myFixture.addClass(
-            """
-            package example;
-
-            import org.springframework.web.bind.annotation.GetMapping;
-            import org.springframework.web.bind.annotation.RequestMapping;
-
-            @RequestMapping("/api")
-            public abstract class BaseApiController {
-                @GetMapping("/hello")
-                public String hello() {
-                    return "hello";
-                }
-            }
-            """.trimIndent(),
-        )
-        myFixture.configureByText(
+        val controllerFile = myFixture.configureByText(
             "HelloController.java",
             """
             package example;
 
+            import org.springframework.web.bind.annotation.GetMapping;
             import org.springframework.web.bind.annotation.RestController;
 
             @RestController
-            public class HelloController extends BaseApiController {
-            }
-            """.trimIndent(),
-        )
-
-        val routes = ArmeriaRouteCollector.collect(project)
-
-        val delegatedRoute = routes.single { it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC }
-        assertEquals("GET", delegatedRoute.httpMethod)
-        assertEquals("/spring/api/hello", delegatedRoute.path)
-        assertEquals("example.HelloController#hello()", delegatedRoute.target)
-    }
-
-    fun testKotlinControllerInheritsJavaBaseClassMapping() {
-        configureTomcatMount("/spring/")
-        myFixture.addClass(
-            """
-            package example;
-
-            import org.springframework.web.bind.annotation.GetMapping;
-
-            public abstract class BaseGreetingController {
+            public class HelloController {
                 @GetMapping("/hello")
                 public String hello() {
                     return "hello";
@@ -875,24 +720,10 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
             }
             """.trimIndent(),
         )
-        myFixture.configureByText(
-            "HelloController.kt",
-            """
-            package example
-
-            import org.springframework.web.bind.annotation.RestController
-
-            @RestController
-            class HelloController : BaseGreetingController()
-            """.trimIndent(),
-        )
-
-        val routes = ArmeriaRouteCollector.collect(project)
-
-        val delegatedRoute = routes.single { it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC }
-        assertEquals("GET", delegatedRoute.httpMethod)
-        assertEquals("/spring/hello", delegatedRoute.path)
-        assertEquals("example.HelloController#hello()", delegatedRoute.target)
+        val controllerOnlyScope = GlobalSearchScope.fileScope(controllerFile)
+        val routes = ArmeriaSpringMvcRouteCollector.collect(project, controllerOnlyScope)
+        assertEquals(listOf("/hello"), routes.map { it.path })
+        assertEquals(listOf("GET"), routes.map { it.httpMethod })
     }
 
     private fun configureTomcatMount(path: String) {

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
@@ -765,6 +765,13 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
             """.trimIndent(),
         )
 
+        val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.allScope(project))
+        assertEquals(
+            listOf("example.UserController#getUser()"),
+            springMvcRoutes.map { it.target },
+        )
+        assertEquals(listOf("/users/{id}"), springMvcRoutes.map { it.path })
+
         val routes = ArmeriaRouteCollector.collect(project)
 
         val delegatedRoute = routes.single { it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC }

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
@@ -735,8 +735,7 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
 
     fun testBaseClassMappingIsDiscoveredUnderConcreteController() {
         configureTomcatMount("/spring/")
-        myFixture.configureByText(
-            "BaseUserController.java",
+        myFixture.addClass(
             """
             package example;
 
@@ -765,7 +764,7 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
             """.trimIndent(),
         )
 
-        val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.allScope(project))
+        val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.projectScope(project))
         assertEquals(
             listOf("example.UserController#getUser()"),
             springMvcRoutes.map { it.target },
@@ -782,8 +781,7 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
 
     fun testInterfaceMappingIsDiscoveredUnderConcreteController() {
         configureTomcatMount("/spring/")
-        myFixture.configureByText(
-            "UserApi.java",
+        myFixture.addClass(
             """
             package example;
 
@@ -824,8 +822,7 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
 
     fun testBaseClassRequestMappingPrefixAppliesToInheritedMethod() {
         configureTomcatMount("/spring/")
-        myFixture.configureByText(
-            "BaseApiController.java",
+        myFixture.addClass(
             """
             package example;
 
@@ -864,8 +861,7 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
 
     fun testKotlinControllerInheritsJavaBaseClassMapping() {
         configureTomcatMount("/spring/")
-        myFixture.configureByText(
-            "BaseGreetingController.java",
+        myFixture.addClass(
             """
             package example;
 

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcInheritanceRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcInheritanceRouteCollectorTest.kt
@@ -51,7 +51,13 @@ class ArmeriaSpringMvcInheritanceRouteCollectorTest : ArmeriaFixtureTestBase() {
         )
         assertEquals(listOf("/users/{id}"), springMvcRoutes.map { it.path })
         assertEquals("example.UserController", springMvcRoutes.single().controller.qualifiedName)
-        assertEquals("example.BaseUserController", springMvcRoutes.single().element.containingClass?.qualifiedName)
+        assertEquals(
+            "example.BaseUserController",
+            springMvcRoutes
+                .single()
+                .element.containingClass
+                ?.qualifiedName,
+        )
 
         val routes = ArmeriaRouteCollector.collect(project)
 
@@ -228,7 +234,13 @@ class ArmeriaSpringMvcInheritanceRouteCollectorTest : ArmeriaFixtureTestBase() {
         val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.projectScope(project))
         assertEquals(listOf("/greet"), springMvcRoutes.map { it.path })
         assertEquals(listOf("example.HelloController#hello()"), springMvcRoutes.map { it.target })
-        assertEquals("example.HelloController", springMvcRoutes.single().element.containingClass?.qualifiedName)
+        assertEquals(
+            "example.HelloController",
+            springMvcRoutes
+                .single()
+                .element.containingClass
+                ?.qualifiedName,
+        )
 
         val routes = ArmeriaRouteCollector.collect(project)
         val delegatedRoute = routes.single { it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC }
@@ -345,8 +357,10 @@ class ArmeriaSpringMvcInheritanceRouteCollectorTest : ArmeriaFixtureTestBase() {
             """.trimIndent(),
         )
 
-        val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.projectScope(project))
-            .sortedBy { it.path }
+        val springMvcRoutes =
+            ArmeriaSpringMvcRouteCollector
+                .collect(project, GlobalSearchScope.projectScope(project))
+                .sortedBy { it.path }
         assertEquals(listOf("/admin/hello", "/api/hello"), springMvcRoutes.map { it.path })
         assertEquals(
             listOf("example.ChildController#hello()", "example.ParentController#hello()"),
@@ -388,29 +402,32 @@ class ArmeriaSpringMvcInheritanceRouteCollectorTest : ArmeriaFixtureTestBase() {
         assertEquals("example.HelloController", helloRoute.controller.qualifiedName)
 
         val controllerModule = ArmeriaRouteMetadata.moduleName(helloRoute.controller)
-        val matchingMount = ArmeriaRoute.create(
-            element = helloRoute.controller,
-            protocol = RouteProtocol.HTTP.presentableName(),
-            httpMethod = "",
-            path = "/spring/",
-            target = "TomcatService",
-            routeMatch = RouteMatch.SERVICE_UNDER,
-        )
+        val matchingMount =
+            ArmeriaRoute.create(
+                element = helloRoute.controller,
+                protocol = RouteProtocol.HTTP.presentableName(),
+                httpMethod = "",
+                path = "/spring/",
+                target = "TomcatService",
+                routeMatch = RouteMatch.SERVICE_UNDER,
+            )
         val unassignedModule = message("route.explorer.module.unassigned")
 
-        val scopedRoutes = ArmeriaDelegatedRouteCollector.springMvcRoutesForMount(
-            mountRoute = matchingMount,
-            springMvcRoutes = springMvcRoutes,
-            unassignedModule = unassignedModule,
-        )
+        val scopedRoutes =
+            ArmeriaDelegatedRouteCollector.springMvcRoutesForMount(
+                mountRoute = matchingMount,
+                springMvcRoutes = springMvcRoutes,
+                unassignedModule = unassignedModule,
+            )
         assertEquals(springMvcRoutes, scopedRoutes)
 
         val otherModuleMount = matchingMount.copy(moduleName = "$controllerModule-other")
-        val filteredRoutes = ArmeriaDelegatedRouteCollector.springMvcRoutesForMount(
-            mountRoute = otherModuleMount,
-            springMvcRoutes = springMvcRoutes,
-            unassignedModule = unassignedModule,
-        )
+        val filteredRoutes =
+            ArmeriaDelegatedRouteCollector.springMvcRoutesForMount(
+                mountRoute = otherModuleMount,
+                springMvcRoutes = springMvcRoutes,
+                unassignedModule = unassignedModule,
+            )
         assertTrue(filteredRoutes.isEmpty())
     }
 
@@ -461,7 +478,13 @@ class ArmeriaSpringMvcInheritanceRouteCollectorTest : ArmeriaFixtureTestBase() {
         val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.projectScope(project))
         assertEquals(listOf("/hello"), springMvcRoutes.map { it.path })
         assertEquals(listOf("example.HelloController#hello()"), springMvcRoutes.map { it.target })
-        assertEquals("example.GrandController", springMvcRoutes.single().element.containingClass?.qualifiedName)
+        assertEquals(
+            "example.GrandController",
+            springMvcRoutes
+                .single()
+                .element.containingClass
+                ?.qualifiedName,
+        )
         assertEquals("example.HelloController", springMvcRoutes.single().controller.qualifiedName)
     }
 
@@ -559,6 +582,12 @@ class ArmeriaSpringMvcInheritanceRouteCollectorTest : ArmeriaFixtureTestBase() {
 
         val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.projectScope(project))
         assertEquals(listOf("/api"), springMvcRoutes.map { it.path })
-        assertEquals("example.GreetingApi", springMvcRoutes.single().element.containingClass?.qualifiedName)
+        assertEquals(
+            "example.GreetingApi",
+            springMvcRoutes
+                .single()
+                .element.containingClass
+                ?.qualifiedName,
+        )
     }
 }

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcInheritanceRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcInheritanceRouteCollectorTest.kt
@@ -1,0 +1,451 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.intellij.psi.search.GlobalSearchScope
+import com.linecorp.intellij.plugins.armeria.message
+import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+
+class ArmeriaSpringMvcInheritanceRouteCollectorTest : ArmeriaFixtureTestBase() {
+    override fun setUp() {
+        super.setUp()
+        registerSpringAnnotationStubs()
+        registerArmeriaSpringStubs()
+        registerServletServiceStubs()
+        registerSpringWebMvcStubs()
+    }
+
+    fun testBaseClassMappingIsDiscoveredUnderConcreteController() {
+        configureTomcatMount("/spring/")
+        myFixture.addClass(
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.GetMapping;
+
+            public abstract class BaseUserController {
+                @GetMapping("/{id}")
+                public String getUser() {
+                    return "ok";
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "UserController.java",
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.RequestMapping;
+            import org.springframework.web.bind.annotation.RestController;
+
+            @RestController
+            @RequestMapping("/users")
+            public class UserController extends BaseUserController {
+            }
+            """.trimIndent(),
+        )
+
+        val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.projectScope(project))
+        assertEquals(
+            listOf("example.UserController#getUser()"),
+            springMvcRoutes.map { it.target },
+        )
+        assertEquals(listOf("/users/{id}"), springMvcRoutes.map { it.path })
+        assertEquals("example.UserController", springMvcRoutes.single().controller.qualifiedName)
+        assertEquals("example.BaseUserController", springMvcRoutes.single().element.containingClass?.qualifiedName)
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val delegatedRoute = routes.single { it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC }
+        assertEquals("GET", delegatedRoute.httpMethod)
+        assertEquals("/spring/users/{id}", delegatedRoute.path)
+        assertEquals("example.UserController#getUser()", delegatedRoute.target)
+        assertEquals(
+            ArmeriaRouteMetadata.moduleName(springMvcRoutes.single().controller),
+            delegatedRoute.moduleName,
+        )
+    }
+
+    fun testInterfaceMappingIsDiscoveredUnderConcreteController() {
+        configureTomcatMount("/spring/")
+        myFixture.addClass(
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.GetMapping;
+            import org.springframework.web.bind.annotation.RequestMapping;
+
+            @RequestMapping("/users")
+            public interface UserApi {
+                @GetMapping("/{id}")
+                String getUser();
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "UserController.java",
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.RestController;
+
+            @RestController
+            public class UserController implements UserApi {
+                @Override
+                public String getUser() {
+                    return "ok";
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.projectScope(project))
+        val springMvcRoute = springMvcRoutes.single()
+        assertEquals("example.UserController", springMvcRoute.controller.qualifiedName)
+        assertEquals("example.UserApi", springMvcRoute.element.containingClass?.qualifiedName)
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val delegatedRoute = routes.single { it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC }
+        assertEquals("GET", delegatedRoute.httpMethod)
+        assertEquals("/spring/users/{id}", delegatedRoute.path)
+        assertEquals("example.UserController#getUser()", delegatedRoute.target)
+        assertEquals(
+            ArmeriaRouteMetadata.moduleName(springMvcRoute.controller),
+            delegatedRoute.moduleName,
+        )
+    }
+
+    fun testBaseClassRequestMappingPrefixAppliesToInheritedMethod() {
+        configureTomcatMount("/spring/")
+        myFixture.addClass(
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.GetMapping;
+            import org.springframework.web.bind.annotation.RequestMapping;
+
+            @RequestMapping("/api")
+            public abstract class BaseApiController {
+                @GetMapping("/hello")
+                public String hello() {
+                    return "hello";
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "HelloController.java",
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.RestController;
+
+            @RestController
+            public class HelloController extends BaseApiController {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val delegatedRoute = routes.single { it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC }
+        assertEquals("GET", delegatedRoute.httpMethod)
+        assertEquals("/spring/api/hello", delegatedRoute.path)
+        assertEquals("example.HelloController#hello()", delegatedRoute.target)
+    }
+
+    fun testKotlinControllerInheritsJavaBaseClassMapping() {
+        configureTomcatMount("/spring/")
+        myFixture.addClass(
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.GetMapping;
+
+            public abstract class BaseGreetingController {
+                @GetMapping("/hello")
+                public String hello() {
+                    return "hello";
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "HelloController.kt",
+            """
+            package example
+
+            import org.springframework.web.bind.annotation.RestController
+
+            @RestController
+            class HelloController : BaseGreetingController()
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val delegatedRoute = routes.single { it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC }
+        assertEquals("GET", delegatedRoute.httpMethod)
+        assertEquals("/spring/hello", delegatedRoute.path)
+        assertEquals("example.HelloController#hello()", delegatedRoute.target)
+    }
+
+    fun testChildMappingOverrideWinsOverBaseClassMapping() {
+        configureTomcatMount("/spring/")
+        myFixture.addClass(
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.GetMapping;
+
+            public abstract class BaseGreetingController {
+                @GetMapping("/hello")
+                public String hello() {
+                    return "base";
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "HelloController.java",
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.GetMapping;
+            import org.springframework.web.bind.annotation.RestController;
+
+            @RestController
+            public class HelloController extends BaseGreetingController {
+                @Override
+                @GetMapping("/greet")
+                public String hello() {
+                    return "child";
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.projectScope(project))
+        assertEquals(listOf("/greet"), springMvcRoutes.map { it.path })
+        assertEquals(listOf("example.HelloController#hello()"), springMvcRoutes.map { it.target })
+        assertEquals("example.HelloController", springMvcRoutes.single().element.containingClass?.qualifiedName)
+
+        val routes = ArmeriaRouteCollector.collect(project)
+        val delegatedRoute = routes.single { it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC }
+        assertEquals("/spring/greet", delegatedRoute.path)
+    }
+
+    fun testAbstractStereotypeBaseDoesNotDoubleRegisterWithConcreteSubclass() {
+        configureTomcatMount("/spring/")
+        myFixture.addClass(
+            """
+            package example;
+
+            import org.springframework.stereotype.Controller;
+            import org.springframework.web.bind.annotation.GetMapping;
+
+            @Controller
+            public abstract class BaseGreetingController {
+                @GetMapping("/hello")
+                public String hello() {
+                    return "hello";
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "HelloController.java",
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.RestController;
+
+            @RestController
+            public class HelloController extends BaseGreetingController {
+            }
+            """.trimIndent(),
+        )
+
+        val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.projectScope(project))
+        assertEquals(listOf("/hello"), springMvcRoutes.map { it.path })
+        assertEquals(listOf("example.HelloController#hello()"), springMvcRoutes.map { it.target })
+
+        val routes = ArmeriaRouteCollector.collect(project)
+        val delegated = routes.filter { it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC }
+        assertEquals(listOf("/spring/hello"), delegated.map { it.path })
+    }
+
+    fun testMountFilterUsesControllerModuleNotMappingElement() {
+        myFixture.addClass(
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.GetMapping;
+
+            public abstract class BaseGreetingController {
+                @GetMapping("/hello")
+                public String hello() {
+                    return "hello";
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "HelloController.java",
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.RestController;
+
+            @RestController
+            public class HelloController extends BaseGreetingController {
+            }
+            """.trimIndent(),
+        )
+
+        val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.allScope(project))
+        val helloRoute = springMvcRoutes.single()
+        assertEquals("example.BaseGreetingController", helloRoute.element.containingClass?.qualifiedName)
+        assertEquals("example.HelloController", helloRoute.controller.qualifiedName)
+
+        val controllerModule = ArmeriaRouteMetadata.moduleName(helloRoute.controller)
+        val matchingMount = ArmeriaRoute.create(
+            element = helloRoute.controller,
+            protocol = RouteProtocol.HTTP.presentableName(),
+            httpMethod = "",
+            path = "/spring/",
+            target = "TomcatService",
+            routeMatch = RouteMatch.SERVICE_UNDER,
+        )
+        val unassignedModule = message("route.explorer.module.unassigned")
+
+        val scopedRoutes = ArmeriaDelegatedRouteCollector.springMvcRoutesForMount(
+            mountRoute = matchingMount,
+            springMvcRoutes = springMvcRoutes,
+            unassignedModule = unassignedModule,
+        )
+        assertEquals(springMvcRoutes, scopedRoutes)
+
+        val otherModuleMount = matchingMount.copy(moduleName = "$controllerModule-other")
+        val filteredRoutes = ArmeriaDelegatedRouteCollector.springMvcRoutesForMount(
+            mountRoute = otherModuleMount,
+            springMvcRoutes = springMvcRoutes,
+            unassignedModule = unassignedModule,
+        )
+        assertTrue(filteredRoutes.isEmpty())
+    }
+
+    private fun configureTomcatMount(path: String) {
+        myFixture.configureByText(
+            "ArmeriaConfig.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.Server;
+            import com.linecorp.armeria.server.tomcat.TomcatService;
+
+            public class ArmeriaConfig {
+                public static void main(String[] args) {
+                    Server.builder()
+                        .serviceUnder("$path", TomcatService.of(null))
+                        .build();
+                }
+            }
+            """.trimIndent(),
+        )
+    }
+
+    private fun registerServletServiceStubs() {
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.server.tomcat;
+
+            public final class TomcatService {
+                public static TomcatService of(Object connector) {
+                    return null;
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.server.jetty;
+
+            public final class JettyService {
+                public static JettyService of(Object server) {
+                    return null;
+                }
+            }
+            """.trimIndent(),
+        )
+    }
+
+    private fun registerSpringWebMvcStubs() {
+        myFixture.addClass(
+            """
+            package org.springframework.stereotype;
+
+            public @interface Controller {
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package org.springframework.web.bind.annotation;
+
+            public @interface RestController {
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package org.springframework.web.bind.annotation;
+
+            public enum RequestMethod {
+                GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package org.springframework.web.bind.annotation;
+
+            public @interface RequestMappings {
+                RequestMapping[] value();
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package org.springframework.web.bind.annotation;
+
+            @java.lang.annotation.Repeatable(RequestMappings.class)
+            public @interface RequestMapping {
+                String[] value() default {};
+                String[] path() default {};
+                RequestMethod[] method() default {};
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package org.springframework.web.bind.annotation;
+
+            public @interface GetMapping {
+                String[] value() default {};
+                String[] path() default {};
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package org.springframework.web.bind.annotation;
+
+            public @interface PostMapping {
+                String[] value() default {};
+                String[] path() default {};
+            }
+            """.trimIndent(),
+        )
+    }
+}

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcInheritanceRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcInheritanceRouteCollectorTest.kt
@@ -7,8 +7,7 @@ import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
 class ArmeriaSpringMvcInheritanceRouteCollectorTest : ArmeriaFixtureTestBase() {
     override fun setUp() {
         super.setUp()
-        registerSpringAnnotationStubs()
-        registerArmeriaSpringStubs()
+        // Tomcat mount + Spring MVC mapping stubs only — no @Bean / ArmeriaServerConfigurator.
         registerServletServiceStubs()
         registerSpringWebMvcStubs()
     }

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcInheritanceRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcInheritanceRouteCollectorTest.kt
@@ -66,7 +66,7 @@ class ArmeriaSpringMvcInheritanceRouteCollectorTest : ArmeriaFixtureTestBase() {
         assertEquals("/spring/users/{id}", delegatedRoute.path)
         assertEquals("example.UserController#getUser()", delegatedRoute.target)
         assertEquals(
-            ArmeriaRouteMetadata.moduleName(springMvcRoutes.single().controller),
+            springMvcRoutes.single().moduleName(),
             delegatedRoute.moduleName,
         )
     }
@@ -116,7 +116,7 @@ class ArmeriaSpringMvcInheritanceRouteCollectorTest : ArmeriaFixtureTestBase() {
         assertEquals("/spring/users/{id}", delegatedRoute.path)
         assertEquals("example.UserController#getUser()", delegatedRoute.target)
         assertEquals(
-            ArmeriaRouteMetadata.moduleName(springMvcRoute.controller),
+            springMvcRoute.moduleName(),
             delegatedRoute.moduleName,
         )
     }
@@ -287,7 +287,7 @@ class ArmeriaSpringMvcInheritanceRouteCollectorTest : ArmeriaFixtureTestBase() {
         assertEquals(listOf("/spring/hello"), delegated.map { it.path })
     }
 
-    fun testConcreteInheritorOfAbstractStereotypeWithoutOwnStereotype() {
+    fun testUnannotatedConcreteInheritorOfAbstractStereotypeIsNotDiscovered() {
         configureTomcatMount("/spring/")
         myFixture.addClass(
             """
@@ -315,25 +315,15 @@ class ArmeriaSpringMvcInheritanceRouteCollectorTest : ArmeriaFixtureTestBase() {
             """.trimIndent(),
         )
 
+        // @Controller is not @Inherited; default component scanning does not register UsersApi.
         val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.projectScope(project))
-        assertEquals(listOf("/hello"), springMvcRoutes.map { it.path })
-        assertEquals(listOf("example.UsersApi#hello()"), springMvcRoutes.map { it.target })
-        assertEquals("example.UsersApi", springMvcRoutes.single().controller.qualifiedName)
-        assertEquals(
-            "example.BaseApi",
-            springMvcRoutes
-                .single()
-                .element.containingClass
-                ?.qualifiedName,
-        )
+        assertTrue(springMvcRoutes.isEmpty())
 
         val routes = ArmeriaRouteCollector.collect(project)
-        val delegated = routes.filter { it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC }
-        assertEquals(listOf("/spring/hello"), delegated.map { it.path })
-        assertEquals(listOf("example.UsersApi#hello()"), delegated.map { it.target })
+        assertTrue(routes.none { it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC })
     }
 
-    fun testConcreteImplementorOfStereotypeInterfaceWithoutOwnStereotype() {
+    fun testUnannotatedConcreteImplementorOfStereotypeInterfaceIsNotDiscovered() {
         myFixture.addClass(
             """
             package example;
@@ -363,16 +353,7 @@ class ArmeriaSpringMvcInheritanceRouteCollectorTest : ArmeriaFixtureTestBase() {
         )
 
         val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.projectScope(project))
-        assertEquals(listOf("/hello"), springMvcRoutes.map { it.path })
-        assertEquals(listOf("example.GreetingService#hello()"), springMvcRoutes.map { it.target })
-        assertEquals("example.GreetingService", springMvcRoutes.single().controller.qualifiedName)
-        assertEquals(
-            "example.GreetingApi",
-            springMvcRoutes
-                .single()
-                .element.containingClass
-                ?.qualifiedName,
-        )
+        assertTrue(springMvcRoutes.isEmpty())
     }
 
     fun testAbstractStereotypeSubclassDoesNotSuppressConcreteParent() {
@@ -489,7 +470,7 @@ class ArmeriaSpringMvcInheritanceRouteCollectorTest : ArmeriaFixtureTestBase() {
         assertEquals("example.BaseGreetingController", helloRoute.element.containingClass?.qualifiedName)
         assertEquals("example.HelloController", helloRoute.controller.qualifiedName)
 
-        val controllerModule = ArmeriaRouteMetadata.moduleName(helloRoute.controller)
+        val controllerModule = helloRoute.moduleName()
         val matchingMount =
             ArmeriaRoute.create(
                 element = helloRoute.controller,

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcInheritanceRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcInheritanceRouteCollectorTest.kt
@@ -287,6 +287,94 @@ class ArmeriaSpringMvcInheritanceRouteCollectorTest : ArmeriaFixtureTestBase() {
         assertEquals(listOf("/spring/hello"), delegated.map { it.path })
     }
 
+    fun testConcreteInheritorOfAbstractStereotypeWithoutOwnStereotype() {
+        configureTomcatMount("/spring/")
+        myFixture.addClass(
+            """
+            package example;
+
+            import org.springframework.stereotype.Controller;
+            import org.springframework.web.bind.annotation.GetMapping;
+
+            @Controller
+            public abstract class BaseApi {
+                @GetMapping("/hello")
+                public String hello() {
+                    return "ok";
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "UsersApi.java",
+            """
+            package example;
+
+            public class UsersApi extends BaseApi {
+            }
+            """.trimIndent(),
+        )
+
+        val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.projectScope(project))
+        assertEquals(listOf("/hello"), springMvcRoutes.map { it.path })
+        assertEquals(listOf("example.UsersApi#hello()"), springMvcRoutes.map { it.target })
+        assertEquals("example.UsersApi", springMvcRoutes.single().controller.qualifiedName)
+        assertEquals(
+            "example.BaseApi",
+            springMvcRoutes
+                .single()
+                .element.containingClass
+                ?.qualifiedName,
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+        val delegated = routes.filter { it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC }
+        assertEquals(listOf("/spring/hello"), delegated.map { it.path })
+        assertEquals(listOf("example.UsersApi#hello()"), delegated.map { it.target })
+    }
+
+    fun testConcreteImplementorOfStereotypeInterfaceWithoutOwnStereotype() {
+        myFixture.addClass(
+            """
+            package example;
+
+            import org.springframework.stereotype.Controller;
+            import org.springframework.web.bind.annotation.GetMapping;
+
+            @Controller
+            public interface GreetingApi {
+                @GetMapping("/hello")
+                String hello();
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "GreetingService.java",
+            """
+            package example;
+
+            public class GreetingService implements GreetingApi {
+                @Override
+                public String hello() {
+                    return "ok";
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.projectScope(project))
+        assertEquals(listOf("/hello"), springMvcRoutes.map { it.path })
+        assertEquals(listOf("example.GreetingService#hello()"), springMvcRoutes.map { it.target })
+        assertEquals("example.GreetingService", springMvcRoutes.single().controller.qualifiedName)
+        assertEquals(
+            "example.GreetingApi",
+            springMvcRoutes
+                .single()
+                .element.containingClass
+                ?.qualifiedName,
+        )
+    }
+
     fun testAbstractStereotypeSubclassDoesNotSuppressConcreteParent() {
         myFixture.addClass(
             """

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcInheritanceRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcInheritanceRouteCollectorTest.kt
@@ -275,6 +275,85 @@ class ArmeriaSpringMvcInheritanceRouteCollectorTest : ArmeriaFixtureTestBase() {
         assertEquals(listOf("/spring/hello"), delegated.map { it.path })
     }
 
+    fun testAbstractStereotypeSubclassDoesNotSuppressConcreteParent() {
+        myFixture.addClass(
+            """
+            package example;
+
+            import org.springframework.stereotype.Controller;
+            import org.springframework.web.bind.annotation.GetMapping;
+
+            @Controller
+            public class ParentController {
+                @GetMapping("/parent")
+                public String parent() {
+                    return "parent";
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "MidController.java",
+            """
+            package example;
+
+            import org.springframework.stereotype.Controller;
+
+            @Controller
+            public abstract class MidController extends ParentController {
+            }
+            """.trimIndent(),
+        )
+
+        val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.projectScope(project))
+        assertEquals(listOf("/parent"), springMvcRoutes.map { it.path })
+        assertEquals(listOf("example.ParentController#parent()"), springMvcRoutes.map { it.target })
+        assertEquals("example.ParentController", springMvcRoutes.single().controller.qualifiedName)
+    }
+
+    fun testConcreteStereotypeParentAndChildBothRegisterWithDistinctPrefixes() {
+        myFixture.addClass(
+            """
+            package example;
+
+            import org.springframework.stereotype.Controller;
+            import org.springframework.web.bind.annotation.GetMapping;
+            import org.springframework.web.bind.annotation.RequestMapping;
+
+            @Controller
+            @RequestMapping("/admin")
+            public class ParentController {
+                @GetMapping("/hello")
+                public String hello() {
+                    return "parent";
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "ChildController.java",
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.RestController;
+            import org.springframework.web.bind.annotation.RequestMapping;
+
+            @RestController
+            @RequestMapping("/api")
+            public class ChildController extends ParentController {
+            }
+            """.trimIndent(),
+        )
+
+        val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.projectScope(project))
+            .sortedBy { it.path }
+        assertEquals(listOf("/admin/hello", "/api/hello"), springMvcRoutes.map { it.path })
+        assertEquals(
+            listOf("example.ChildController#hello()", "example.ParentController#hello()"),
+            springMvcRoutes.map { it.target }.sorted(),
+        )
+    }
+
     fun testMountFilterUsesControllerModuleNotMappingElement() {
         myFixture.addClass(
             """

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcInheritanceRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcInheritanceRouteCollectorTest.kt
@@ -335,117 +335,151 @@ class ArmeriaSpringMvcInheritanceRouteCollectorTest : ArmeriaFixtureTestBase() {
         assertTrue(filteredRoutes.isEmpty())
     }
 
-    private fun configureTomcatMount(path: String) {
-        myFixture.configureByText(
-            "ArmeriaConfig.java",
+    fun testMultiLevelUnannotatedOverrideResolvesGrandparentMapping() {
+        myFixture.addClass(
             """
             package example;
 
-            import com.linecorp.armeria.server.Server;
-            import com.linecorp.armeria.server.tomcat.TomcatService;
+            import org.springframework.web.bind.annotation.GetMapping;
 
-            public class ArmeriaConfig {
-                public static void main(String[] args) {
-                    Server.builder()
-                        .serviceUnder("$path", TomcatService.of(null))
-                        .build();
+            public abstract class GrandController {
+                @GetMapping("/hello")
+                public String hello() {
+                    return "grand";
                 }
             }
             """.trimIndent(),
         )
+        myFixture.addClass(
+            """
+            package example;
+
+            public abstract class MidController extends GrandController {
+                @Override
+                public String hello() {
+                    return "mid";
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "HelloController.java",
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.RestController;
+
+            @RestController
+            public class HelloController extends MidController {
+                @Override
+                public String hello() {
+                    return "child";
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.projectScope(project))
+        assertEquals(listOf("/hello"), springMvcRoutes.map { it.path })
+        assertEquals(listOf("example.HelloController#hello()"), springMvcRoutes.map { it.target })
+        assertEquals("example.GrandController", springMvcRoutes.single().element.containingClass?.qualifiedName)
+        assertEquals("example.HelloController", springMvcRoutes.single().controller.qualifiedName)
     }
 
-    private fun registerServletServiceStubs() {
+    fun testInterfaceTypePrefixWinsOverSuperclassPrefix() {
         myFixture.addClass(
             """
-            package com.linecorp.armeria.server.tomcat;
+            package example;
 
-            public final class TomcatService {
-                public static TomcatService of(Object connector) {
-                    return null;
-                }
+            import org.springframework.web.bind.annotation.RequestMapping;
+
+            @RequestMapping("/base")
+            public abstract class BaseController {
             }
             """.trimIndent(),
         )
         myFixture.addClass(
             """
-            package com.linecorp.armeria.server.jetty;
+            package example;
 
-            public final class JettyService {
-                public static JettyService of(Object server) {
-                    return null;
+            import org.springframework.web.bind.annotation.GetMapping;
+            import org.springframework.web.bind.annotation.RequestMapping;
+
+            @RequestMapping("/api")
+            public interface GreetingApi {
+                @GetMapping("/hello")
+                String hello();
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "HelloController.java",
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.RestController;
+
+            @RestController
+            public class HelloController extends BaseController implements GreetingApi {
+                @Override
+                public String hello() {
+                    return "ok";
                 }
             }
             """.trimIndent(),
         )
+
+        val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.projectScope(project))
+        assertEquals(listOf("/api/hello"), springMvcRoutes.map { it.path })
+        assertEquals(listOf("example.HelloController#hello()"), springMvcRoutes.map { it.target })
     }
 
-    private fun registerSpringWebMvcStubs() {
+    fun testInterfaceMethodMappingPreferredOverSuperclassMapping() {
         myFixture.addClass(
             """
-            package org.springframework.stereotype;
+            package example;
 
-            public @interface Controller {
+            import org.springframework.web.bind.annotation.GetMapping;
+
+            public abstract class BaseController {
+                @GetMapping("/base")
+                public String hello() {
+                    return "base";
+                }
             }
             """.trimIndent(),
         )
         myFixture.addClass(
             """
-            package org.springframework.web.bind.annotation;
+            package example;
 
-            public @interface RestController {
+            import org.springframework.web.bind.annotation.GetMapping;
+
+            public interface GreetingApi {
+                @GetMapping("/api")
+                String hello();
             }
             """.trimIndent(),
         )
-        myFixture.addClass(
+        myFixture.configureByText(
+            "HelloController.java",
             """
-            package org.springframework.web.bind.annotation;
+            package example;
 
-            public enum RequestMethod {
-                GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE
+            import org.springframework.web.bind.annotation.RestController;
+
+            @RestController
+            public class HelloController extends BaseController implements GreetingApi {
+                @Override
+                public String hello() {
+                    return "ok";
+                }
             }
             """.trimIndent(),
         )
-        myFixture.addClass(
-            """
-            package org.springframework.web.bind.annotation;
 
-            public @interface RequestMappings {
-                RequestMapping[] value();
-            }
-            """.trimIndent(),
-        )
-        myFixture.addClass(
-            """
-            package org.springframework.web.bind.annotation;
-
-            @java.lang.annotation.Repeatable(RequestMappings.class)
-            public @interface RequestMapping {
-                String[] value() default {};
-                String[] path() default {};
-                RequestMethod[] method() default {};
-            }
-            """.trimIndent(),
-        )
-        myFixture.addClass(
-            """
-            package org.springframework.web.bind.annotation;
-
-            public @interface GetMapping {
-                String[] value() default {};
-                String[] path() default {};
-            }
-            """.trimIndent(),
-        )
-        myFixture.addClass(
-            """
-            package org.springframework.web.bind.annotation;
-
-            public @interface PostMapping {
-                String[] value() default {};
-                String[] path() default {};
-            }
-            """.trimIndent(),
-        )
+        val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.projectScope(project))
+        assertEquals(listOf("/api"), springMvcRoutes.map { it.path })
+        assertEquals("example.GreetingApi", springMvcRoutes.single().element.containingClass?.qualifiedName)
     }
 }

--- a/plugin-route-analysis/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaFixtureSpringMvcStubs.kt
+++ b/plugin-route-analysis/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaFixtureSpringMvcStubs.kt
@@ -1,0 +1,117 @@
+package com.linecorp.intellij.plugins.armeria.test
+
+import com.intellij.testFramework.fixtures.JavaCodeInsightTestFixture
+
+fun JavaCodeInsightTestFixture.registerServletServiceStubs() {
+    this.addClass(
+        """
+        package com.linecorp.armeria.server.tomcat;
+
+        public final class TomcatService {
+            public static TomcatService of(Object connector) {
+                return null;
+            }
+        }
+        """.trimIndent(),
+    )
+    this.addClass(
+        """
+        package com.linecorp.armeria.server.jetty;
+
+        public final class JettyService {
+            public static JettyService of(Object server) {
+                return null;
+            }
+        }
+        """.trimIndent(),
+    )
+}
+
+fun JavaCodeInsightTestFixture.registerSpringWebMvcStubs() {
+    this.addClass(
+        """
+        package org.springframework.stereotype;
+
+        public @interface Controller {
+        }
+        """.trimIndent(),
+    )
+    this.addClass(
+        """
+        package org.springframework.web.bind.annotation;
+
+        public @interface RestController {
+        }
+        """.trimIndent(),
+    )
+    this.addClass(
+        """
+        package org.springframework.web.bind.annotation;
+
+        public enum RequestMethod {
+            GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE
+        }
+        """.trimIndent(),
+    )
+    this.addClass(
+        """
+        package org.springframework.web.bind.annotation;
+
+        public @interface RequestMappings {
+            RequestMapping[] value();
+        }
+        """.trimIndent(),
+    )
+    this.addClass(
+        """
+        package org.springframework.web.bind.annotation;
+
+        @java.lang.annotation.Repeatable(RequestMappings.class)
+        public @interface RequestMapping {
+            String[] value() default {};
+            String[] path() default {};
+            RequestMethod[] method() default {};
+        }
+        """.trimIndent(),
+    )
+    this.addClass(
+        """
+        package org.springframework.web.bind.annotation;
+
+        public @interface GetMapping {
+            String[] value() default {};
+            String[] path() default {};
+        }
+        """.trimIndent(),
+    )
+    this.addClass(
+        """
+        package org.springframework.web.bind.annotation;
+
+        public @interface PostMapping {
+            String[] value() default {};
+            String[] path() default {};
+        }
+        """.trimIndent(),
+    )
+}
+
+fun JavaCodeInsightTestFixture.configureTomcatMount(path: String) {
+    this.configureByText(
+        "ArmeriaConfig.java",
+        """
+        package example;
+
+        import com.linecorp.armeria.server.Server;
+        import com.linecorp.armeria.server.tomcat.TomcatService;
+
+        public class ArmeriaConfig {
+            public static void main(String[] args) {
+                Server.builder()
+                    .serviceUnder("$path", TomcatService.of(null))
+                    .build();
+            }
+        }
+        """.trimIndent(),
+    )
+}

--- a/plugin-route-analysis/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaFixtureTestBase.kt
+++ b/plugin-route-analysis/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaFixtureTestBase.kt
@@ -35,6 +35,12 @@ abstract class ArmeriaFixtureTestBase : ArmeriaLightJavaCodeInsightFixtureTestCa
 
     protected fun registerArmeriaSpringStubs() = myFixture.registerArmeriaSpringStubs()
 
+    protected fun registerServletServiceStubs() = myFixture.registerServletServiceStubs()
+
+    protected fun registerSpringWebMvcStubs() = myFixture.registerSpringWebMvcStubs()
+
+    protected fun configureTomcatMount(path: String) = myFixture.configureTomcatMount(path)
+
     protected fun registerRouteDetailFormatterStubs() = myFixture.registerRouteDetailFormatterStubs()
 
     protected fun registerRouteDuplicateIndexStubs() = myFixture.registerRouteDuplicateIndexStubs()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Discovers Spring MVC `@GetMapping` / `@RequestMapping` (and siblings) declared on abstract base classes and interfaces when a concrete stereotype-annotated handler is in scope, so delegated routes under Tomcat / Spring Boot mounts no longer miss common inheritance patterns.

Closes #261.

## Changes

- `ArmeriaSpringMvcRouteCollector` discovers mappings via `visibleSignatures` plus a single TYPE_HIERARCHY type walk (`typesInHierarchy` + `findMethodBySignature`) for both class-level prefixes and method mappings
- Controllers are concrete types that declare `@Controller` / `@RestController` directly; abstract/interface stereotype types are skipped (Spring does not instantiate them). Unannotated concrete subtypes are not discovered — `@Controller` is not `@Inherited`, matching default component scanning
- Route `target` and tree/module attribution use the stereotype-annotated concrete controller; navigation `element` remains the method that owns the mapping annotation
- `SpringMvcRoute.moduleName()` owns controller-based module attribution for delegated mount filtering and route creation
- `ArmeriaRoute.create` accepts optional `moduleName` so delegated routes attribute the module without a post-hoc `copy`
- Spring MVC / Tomcat fixture stubs live in `testFixtures` (`ArmeriaFixtureSpringMvcStubs`) and are shared by delegated + inheritance collector tests
- Inheritance fixtures live in `ArmeriaSpringMvcInheritanceRouteCollectorTest` (base class, interface override, type-level prefix, Kotlin-over-Java, child override wins, dual-stereotype dedupe, mount filter by controller module, multi-level unannotated override, interface-vs-superclass prefix/method preference, concrete parent + abstract mid, dual concrete distinct prefixes, unannotated inheritor/implementor not discovered)
- Inheritance test `setUp` registers only servlet + Spring Web MVC stubs required by the fixtures

## Test plan

- [x] `ArmeriaSpringMvcInheritanceRouteCollectorTest` — inheritance + override + module attribution + stereotype filtering regressions
- [x] `ArmeriaDelegatedRouteCollectorTest` — mount / delegation baseline (module filter uses controller)
- [x] Gradle MCP: both test classes (`BUILD SUCCESSFUL`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f74e2-d110-7073-beaf-3e4f6ac0a8a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f74e2-d110-7073-beaf-3e4f6ac0a8a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

