### PR TITLE
fix: avoid Cartesian fan-out for multi-mount delegated Spring MVC

### DIFF
--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollector.kt
@@ -68,10 +68,12 @@ internal object ArmeriaDelegatedRouteCollector {
             .groupBy { it.moduleName to it.virtualHostName }
             .values
             .map { group ->
-                group.minBy { route ->
-                    val normalized = ArmeriaRouteSupport.normalizePath(route.path)
-                    normalized.length to normalized
-                }
+                group.minWith(
+                    compareBy(
+                        { ArmeriaRouteSupport.normalizePath(it.path).length },
+                        { ArmeriaRouteSupport.normalizePath(it.path) },
+                    ),
+                )
             }
 
     internal fun springMvcRoutesForMount(

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollector.kt
@@ -32,8 +32,9 @@ internal object ArmeriaDelegatedRouteCollector {
             val scopedSpringMvcRoutes = springMvcRoutesForMount(mountRoute, springMvcRoutes, unassignedModule)
             for (springMvcRoute in scopedSpringMvcRoutes) {
                 val combinedPath = ArmeriaRouteSupport.combinePaths(mountRoute.path, springMvcRoute.path)
+                // One preferred mount per (module, vhost); dedupe only within that expansion.
                 val dedupeKey =
-                    "${mountRoute.moduleName}:${mountRoute.virtualHostName}:${mountRoute.path}:$combinedPath:" +
+                    "${mountRoute.moduleName}:${mountRoute.virtualHostName}:$combinedPath:" +
                         "${springMvcRoute.httpMethod}:${springMvcRoute.target}"
                 if (!seenDelegatedKeys.add(dedupeKey)) {
                     continue
@@ -67,12 +68,10 @@ internal object ArmeriaDelegatedRouteCollector {
             .groupBy { it.moduleName to it.virtualHostName }
             .values
             .map { group ->
-                group.minWith(
-                    compareBy(
-                        { ArmeriaRouteSupport.normalizePath(it.path).length },
-                        { ArmeriaRouteSupport.normalizePath(it.path) },
-                    ),
-                )
+                group.minBy { route ->
+                    val normalized = ArmeriaRouteSupport.normalizePath(route.path)
+                    normalized.length to normalized
+                }
             }
 
     internal fun springMvcRoutesForMount(

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollector.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollector.kt
@@ -21,15 +21,17 @@ internal object ArmeriaDelegatedRouteCollector {
             return
         }
 
+        // Same-module multi-mount has no ownership signal; expand under one preferred mount
+        // per (module, virtualHost) to avoid Cartesian fan-out across every Spring-capable prefix.
+        val preferredMounts = preferredSpringMvcMounts(springCapableMounts)
         val unassignedModule = message("route.explorer.module.unassigned")
         val seenDelegatedKeys = mutableSetOf<String>()
         val delegatedRoutes = mutableListOf<ArmeriaRoute>()
 
-        for (mountRoute in springCapableMounts) {
+        for (mountRoute in preferredMounts) {
             val scopedSpringMvcRoutes = springMvcRoutesForMount(mountRoute, springMvcRoutes, unassignedModule)
             for (springMvcRoute in scopedSpringMvcRoutes) {
                 val combinedPath = ArmeriaRouteSupport.combinePaths(mountRoute.path, springMvcRoute.path)
-                // Include mount path so distinct mounts that combine to the same path keep separate children.
                 val dedupeKey =
                     "${mountRoute.moduleName}:${mountRoute.virtualHostName}:${mountRoute.path}:$combinedPath:" +
                         "${springMvcRoute.httpMethod}:${springMvcRoute.target}"
@@ -55,6 +57,23 @@ internal object ArmeriaDelegatedRouteCollector {
 
         routes += delegatedRoutes
     }
+
+    /**
+     * Picks one expandable Spring MVC mount per `(moduleName, virtualHostName)` group.
+     * Prefers the shortest path (broadest prefix); ties break lexicographically.
+     */
+    internal fun preferredSpringMvcMounts(mounts: List<ArmeriaRoute>): List<ArmeriaRoute> =
+        mounts
+            .groupBy { it.moduleName to it.virtualHostName }
+            .values
+            .map { group ->
+                group.minWith(
+                    compareBy(
+                        { ArmeriaRouteSupport.normalizePath(it.path).length },
+                        { ArmeriaRouteSupport.normalizePath(it.path) },
+                    ),
+                )
+            }
 
     internal fun springMvcRoutesForMount(
         mountRoute: ArmeriaRoute,

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
@@ -626,6 +626,7 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
 
     fun testPreferredSpringMvcMountsPicksShortestPathPerModuleAndVirtualHost() {
         val probe = myFixture.addClass("public class PreferredMountProbe {}")
+
         fun mount(
             path: String,
             moduleName: String = "app",

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
@@ -659,13 +659,14 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
             ArmeriaDelegatedRouteCollector.preferredSpringMvcMounts(listOf(beta, alpha)),
         )
 
-        val hostA = mount("/spring/", virtualHostName = "a.example.com")
-        val hostB = mount("/spring/", virtualHostName = "b.example.com")
+        val hostARoot = mount("/", virtualHostName = "a.example.com")
         val hostAApi = mount("/api", virtualHostName = "a.example.com")
+        val hostBRoot = mount("/", virtualHostName = "b.example.com")
+        val hostBApi = mount("/api", virtualHostName = "b.example.com")
         assertEquals(
-            setOf(hostA, hostB),
+            setOf(hostARoot, hostBRoot),
             ArmeriaDelegatedRouteCollector
-                .preferredSpringMvcMounts(listOf(hostAApi, hostA, hostB))
+                .preferredSpringMvcMounts(listOf(hostAApi, hostARoot, hostBApi, hostBRoot))
                 .toSet(),
         )
     }

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
@@ -652,8 +652,8 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
             ArmeriaDelegatedRouteCollector.preferredSpringMvcMounts(listOf(api, root)),
         )
 
-        val alpha = mount("/alpha")
-        val beta = mount("/beta")
+        val alpha = mount("/aaa")
+        val beta = mount("/bbb")
         assertEquals(
             listOf(alpha),
             ArmeriaDelegatedRouteCollector.preferredSpringMvcMounts(listOf(beta, alpha)),

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
@@ -496,7 +496,7 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
         assertNotNull(routes.singleOrNull { it.path == "/spring/hello" && it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC })
     }
 
-    fun testDistinctMountsKeepSeparateChildrenForSameCombinedPath() {
+    fun testAmbiguousSameModuleMountsExpandOnlyUnderShortestPath() {
         myFixture.configureByText(
             "ArmeriaConfig.java",
             """
@@ -540,14 +540,27 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
         )
 
         val routes = ArmeriaRouteCollector.collect(project)
-        val delegatedAtApi =
-            routes.filter {
-                it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC && it.path == "/api"
-            }
-        assertEquals(
-            setOf("/", "/api"),
-            delegatedAtApi.map { it.delegationMountPath }.toSet(),
+        val delegated = routes.filter { it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC }
+        assertTrue(delegated.isNotEmpty())
+        assertEquals(setOf("/"), delegated.map { it.delegationMountPath }.toSet())
+        assertNotNull(
+            delegated.singleOrNull {
+                it.path == "/api" &&
+                    it.httpMethod == "GET" &&
+                    it.target.contains("fromRootMount") &&
+                    it.delegationMountPath == "/"
+            },
         )
+        // Root mapping "" under preferred "/" becomes "/".
+        assertNotNull(
+            delegated.singleOrNull {
+                it.path == "/" &&
+                    it.httpMethod == "GET" &&
+                    it.target.contains("fromApiMount") &&
+                    it.delegationMountPath == "/"
+            },
+        )
+        assertTrue(delegated.none { it.delegationMountPath == "/api" })
     }
 
     fun testKotlinCyclicPropertyAliasesDoNotCrashCollection() {
@@ -609,6 +622,52 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
         val routes = ArmeriaRouteCollector.collect(project)
 
         assertTrue(routes.none { it.routeMatch == RouteMatch.DELEGATED_SPRING_MVC })
+    }
+
+    fun testPreferredSpringMvcMountsPicksShortestPathPerModuleAndVirtualHost() {
+        val probe = myFixture.addClass("public class PreferredMountProbe {}")
+        fun mount(
+            path: String,
+            moduleName: String = "app",
+            virtualHostName: String = "",
+        ): ArmeriaRoute =
+            ArmeriaRoute.create(
+                element = probe,
+                protocol = RouteProtocol.HTTP.presentableName(),
+                httpMethod = "",
+                path = path,
+                target = "TomcatService",
+                routeMatch = RouteMatch.SERVICE_UNDER,
+                virtualHostName = virtualHostName,
+                moduleName = moduleName,
+            )
+
+        val single = mount("/spring/")
+        assertEquals(listOf(single), ArmeriaDelegatedRouteCollector.preferredSpringMvcMounts(listOf(single)))
+
+        val root = mount("/")
+        val api = mount("/api")
+        assertEquals(
+            listOf(root),
+            ArmeriaDelegatedRouteCollector.preferredSpringMvcMounts(listOf(api, root)),
+        )
+
+        val alpha = mount("/alpha")
+        val beta = mount("/beta")
+        assertEquals(
+            listOf(alpha),
+            ArmeriaDelegatedRouteCollector.preferredSpringMvcMounts(listOf(beta, alpha)),
+        )
+
+        val hostA = mount("/spring/", virtualHostName = "a.example.com")
+        val hostB = mount("/spring/", virtualHostName = "b.example.com")
+        val hostAApi = mount("/api", virtualHostName = "a.example.com")
+        assertEquals(
+            setOf(hostA, hostB),
+            ArmeriaDelegatedRouteCollector
+                .preferredSpringMvcMounts(listOf(hostAApi, hostA, hostB))
+                .toSet(),
+        )
     }
 
     fun testSpringMvcRoutesForMountFiltersControllersByModule() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a module has multiple Spring-capable Tomcat `serviceUnder` mounts, Route Explorer no longer attaches every Spring MVC controller under every mount. Ambiguous same-module multi-mount cases expand children under a single preferred mount so delegated trees stay useful without noisy duplicate prefixes.

Closes #262

## Changes

- Prefer the shortest mount path per `(moduleName, virtualHostName)` when expanding delegated Spring MVC children
- Lexicographic path tie-break for equal-length mounts
- Distinct virtual hosts still expand independently
- Dedupe within a preferred-mount expansion using module, virtual host, combined path, method, and target
- Regression coverage for two same-module Tomcat mounts and unit coverage for preferred-mount selection

## Test plan

- [x] `ArmeriaDelegatedRouteCollectorTest` (Gradle MCP) — BUILD SUCCESSFUL
- [x] Two Tomcat mounts (`/` and `/api`) in one module expand controllers only under `/`
- [x] Different virtual hosts still expand independently (per-vhost preferred mount)
- [x] Preferred-mount helper: shortest path, lexicographic tie-break, per-vhost independence
- [x] `:plugin-route-analysis:ktlintCheck` — BUILD SUCCESSFUL
- [x] Thermos follow-up: compile + `testAmbiguousSameModuleMountsExpandOnlyUnderShortestPath` / `testPreferredSpringMvcMountsPicksShortestPathPerModuleAndVirtualHost` — BUILD SUCCESSFUL

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f77dc-f757-73a9-847f-07df5e26564f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f77dc-f757-73a9-847f-07df5e26564f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

