### PR TITLE
fix: declare supportsKotlinPluginMode as Kotlin extension

### DIFF
--- a/plugin/src/main/resources/META-INF/kotlin-integration.xml
+++ b/plugin/src/main/resources/META-INF/kotlin-integration.xml
@@ -1,5 +1,7 @@
 <idea-plugin>
-    <supportsKotlinPluginMode supportsK2="true"/>
+    <extensions defaultExtensionNs="org.jetbrains.kotlin">
+        <supportsKotlinPluginMode supportsK2="true"/>
+    </extensions>
     <extensions defaultExtensionNs="com.intellij">
         <localInspection language="kotlin"
                          bundle="messages.ArmeriaBundle"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes plugin load error `Unknown element: supportsKotlinPluginMode` by declaring K2 compatibility through the correct Kotlin extension point instead of as a root-level `idea-plugin` child.

## Changes

- Move `<supportsKotlinPluginMode supportsK2="true"/>` into `<extensions defaultExtensionNs="org.jetbrains.kotlin">` in `kotlin-integration.xml`
- Keeps existing Kotlin inspections, line markers, and live templates unchanged

## Test plan

- [x] `:plugin:compileKotlin` and `:plugin:processResources` succeed
- [ ] Load the plugin in IntelliJ IDEA and confirm the `Unknown element: supportsKotlinPluginMode` error no longer appears in the log

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf7d07b9-3192-4639-9830-14d4c63a5594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf7d07b9-3192-4639-9830-14d4c63a5594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

