### PR TITLE
fix: compose plugin-shared into main plugin jar

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Fixed
 
+- Bundle `plugin-shared` (including `ArmeriaBundle`) into the main plugin JAR so installing only `plugin-*.jar` no longer fails inspection-profile saves with `ClassNotFoundException: ArmeriaBundleKt`.
 - Route Explorer deduplicates GraphQL and Thrift IDL routes per module when the same operation appears in multiple schema or `.thrift` files.
 - DocService runtime route sync activates the Armeria Services tool window when needed so routes apply even if it was closed before the fetch completed.
 - Route Explorer Refresh no longer clears DocService-synced runtime routes; synced routes stay until the next sync replaces them.

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -10,10 +10,10 @@ group = "com.linecorp.intellij"
 version = providers.gradleProperty("pluginVersion").get()
 
 dependencies {
-    implementation(project(":plugin-shared"))
     implementation(project(":plugin-route-analysis"))
     implementation(project(":plugin-wizard"))
     intellijPlatform {
+        pluginComposedModule(implementation(project(":plugin-shared")))
         intellijIdeaUltimate(
             libs.versions.idea.platform
                 .get(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Installing only `plugin-*.jar` (instead of the full distribution ZIP) caused inspection profile saves to fail with `ClassNotFoundException: ArmeriaBundleKt`. `ArmeriaMethodEntryPoint.getDisplayName()` calls `message()` from `plugin-shared`, but that module was packaged as a separate `lib/plugin-shared.jar` and was not on the classpath for single-JAR installs.

## Changes

- Declare `plugin-shared` with `pluginComposedModule` in `plugin/build.gradle.kts` so `ArmeriaBundle` and related classes are merged into the main plugin JAR
- Remove the redundant `plugin-shared.jar` from the distribution `lib/` folder
- Document the fix in `plugin/CHANGELOG.md`

## Test plan

- [x] `:plugin:buildPlugin` — main JAR contains `ArmeriaBundleKt` and `messages/ArmeriaBundle.properties`
- [x] Distribution ZIP no longer includes a separate `plugin-shared.jar`
- [x] `:plugin:test` passes
- [ ] Manual: install rebuilt plugin (ZIP or single JAR) and confirm Settings / inspection profile save no longer errors
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd030aa3-1ccd-43c3-bee8-8476f60ef1ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd030aa3-1ccd-43c3-bee8-8476f60ef1ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

