### PR TITLE
fix: prevent inspection profile save crash when ArmeriaBundle is missing

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Fixed
 
 - Bundle `plugin-shared` (including `ArmeriaBundle`) into the main plugin JAR so installing only `plugin-*.jar` no longer fails inspection-profile saves with `ClassNotFoundException: ArmeriaBundleKt`.
+- `ArmeriaMethodEntryPoint` falls back to a default display name when the bundle class is unavailable, so inspection-profile saves do not crash on older single-JAR installs.
 - Route Explorer deduplicates GraphQL and Thrift IDL routes per module when the same operation appears in multiple schema or `.thrift` files.
 - DocService runtime route sync activates the Armeria Services tool window when needed so routes apply even if it was closed before the fetch completed.
 - Route Explorer Refresh no longer clears DocService-synced runtime routes; synced routes stay until the next sync replaces them.

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -1,6 +1,8 @@
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.date
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import java.util.jar.JarInputStream
+import java.util.zip.ZipFile
 
 plugins {
     id("com.linecorp.intellij.platform-plugin")
@@ -38,6 +40,53 @@ testing {
                 implementation(testFixtures(project(":plugin-route-collectors")))
                 implementation(libs.velocity.engine.core)
                 implementation(libs.junit4)
+            }
+        }
+    }
+}
+
+tasks.named("buildPlugin") {
+    val distributionZip =
+        layout.buildDirectory.file(
+            providers.gradleProperty("pluginVersion").map { "distributions/plugin-$it.zip" },
+        )
+    doLast {
+        val distributionFile = distributionZip.get().asFile
+        require(distributionFile.exists()) { "Missing plugin distribution: $distributionFile" }
+
+        ZipFile(distributionFile).use { zip ->
+            val mainJarEntry =
+                zip
+                    .entries()
+                    .asSequence()
+                    .map { it.name }
+                    .firstOrNull { name ->
+                        name.startsWith("plugin/lib/plugin-") &&
+                            name.endsWith(".jar") &&
+                            !name.contains("route") &&
+                            !name.contains("wizard") &&
+                            !name.contains("shared")
+                    }
+                    ?: error("Main plugin JAR not found in $distributionFile")
+
+            zip.getInputStream(zip.getEntry(mainJarEntry)).use { input ->
+                JarInputStream(input).use { jar ->
+                    val hasBundle =
+                        generateSequence { jar.nextJarEntry }
+                            .any { it.name == "com/linecorp/intellij/plugins/armeria/ArmeriaBundleKt.class" }
+                    check(hasBundle) {
+                        "Main plugin JAR ($mainJarEntry) must include ArmeriaBundleKt from plugin-shared; use pluginComposedModule"
+                    }
+                }
+            }
+
+            val hasSeparateSharedJar =
+                zip
+                    .entries()
+                    .asSequence()
+                    .any { it.name == "plugin/lib/plugin-shared.jar" }
+            check(!hasSeparateSharedJar) {
+                "plugin-shared must be composed into the main JAR, not packaged as plugin/lib/plugin-shared.jar"
             }
         }
     }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaMethodEntryPoint.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaMethodEntryPoint.kt
@@ -13,7 +13,9 @@ import org.jdom.Element
 class ArmeriaMethodEntryPoint(
     @JvmField var wasSelected: Boolean = true,
 ) : EntryPoint() {
-    override fun getDisplayName() = message("inspection.entrypoint.armeria")
+    override fun getDisplayName(): String =
+        runCatching { message("inspection.entrypoint.armeria") }
+            .getOrDefault(ENTRY_POINT_DISPLAY_NAME)
 
     override fun isEntryPoint(
         refElement: RefElement,
@@ -42,5 +44,9 @@ class ArmeriaMethodEntryPoint(
         if (!wasSelected) {
             XmlSerializer.serializeInto(this, element)
         }
+    }
+
+    private companion object {
+        private const val ENTRY_POINT_DISPLAY_NAME = "Armeria Methods"
     }
 }

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaMethodEntryPointTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaMethodEntryPointTest.kt
@@ -1,0 +1,12 @@
+package com.linecorp.intellij.plugins.armeria.inspection
+
+import com.linecorp.intellij.plugins.armeria.message
+import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import junit.framework.TestCase
+
+class ArmeriaMethodEntryPointTest : ArmeriaFixtureTestBase() {
+    fun testDisplayNameUsesBundleWhenAvailable() {
+        val entryPoint = ArmeriaMethodEntryPoint()
+        TestCase.assertEquals(message("inspection.entrypoint.armeria"), entryPoint.displayName)
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Installing only `plugin-0.2.1-SNAPSHOT.jar` (without the full plugin ZIP or `plugin-shared.jar`) caused inspection profile saves to fail with `ClassNotFoundException: ArmeriaBundleKt`. The failure happened when `ArmeriaMethodEntryPoint.getDisplayName()` resolved a bundle string from `plugin-shared` during unused-declaration settings serialization.

PR #295 already addressed packaging by composing `plugin-shared` into the main JAR via `pluginComposedModule`. This follow-up hardens runtime behavior and adds a build-time guard so the regression cannot return silently.

## Changes

- `ArmeriaMethodEntryPoint.getDisplayName()` falls back to `"Armeria Methods"` when the bundle helper is unavailable, so settings save no longer crashes on older single-JAR installs
- `buildPlugin` verifies the distribution main JAR contains `ArmeriaBundleKt` and that `plugin-shared` is not shipped as a separate `lib/plugin-shared.jar`
- Added `ArmeriaMethodEntryPointTest` for the entry point display name

## Test plan

- [x] `:plugin:test` — `ArmeriaMethodEntryPointTest`
- [x] `:plugin:ktlintCheck`
- [x] `:plugin:buildPlugin` — packaging verification passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ffb41768-eed5-48d3-9462-eef12acabd82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ffb41768-eed5-48d3-9462-eef12acabd82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

