### PR TITLE
fix: discover Spring MVC mappings on generic base signatures

### DIFF
--- a/plugin-route-spring/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/spring/ArmeriaSpringMvcRouteCollector.kt
+++ b/plugin-route-spring/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/spring/ArmeriaSpringMvcRouteCollector.kt
@@ -1,7 +1,7 @@
 package com.linecorp.intellij.plugins.armeria.explorer.spring
 import com.intellij.openapi.project.Project
-import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.HierarchicalMethodSignature
+import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiAnnotationMemberValue
 import com.intellij.psi.PsiArrayInitializerMemberValue

--- a/plugin-route-spring/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/spring/ArmeriaSpringMvcRouteCollector.kt
+++ b/plugin-route-spring/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/spring/ArmeriaSpringMvcRouteCollector.kt
@@ -1,6 +1,7 @@
 package com.linecorp.intellij.plugins.armeria.explorer.spring
 import com.intellij.openapi.project.Project
 import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.HierarchicalMethodSignature
 import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiAnnotationMemberValue
 import com.intellij.psi.PsiArrayInitializerMemberValue
@@ -105,7 +106,7 @@ internal object ArmeriaSpringMvcRouteCollector {
             if (method.containingClass?.qualifiedName == JAVA_LANG_OBJECT) {
                 continue
             }
-            val mappedMethod = resolveMappedMethod(hierarchy, method) ?: continue
+            val mappedMethod = resolveMappedMethod(hierarchy, signature) ?: continue
             for (annotation in mappedMethod.annotations) {
                 val fqn = annotation.qualifiedName ?: continue
                 val defaultMethod = MAPPING_ANNOTATIONS[fqn] ?: continue
@@ -126,15 +127,17 @@ internal object ArmeriaSpringMvcRouteCollector {
      * override chain that declares a Spring MVC mapping. Unannotated intermediate overrides
      * do not stop the search.
      *
-     * Indexes [method] and its supers via [methodsByContainingClass] so generic type-parameter
-     * substitution (e.g. `handle(T)` vs `handle(String)`) still resolves across the hierarchy
-     * (see #289), including multi-level unannotated intermediates.
+     * Indexes [signature] and its [HierarchicalMethodSignature.superSignatures] so:
+     * - generic type-parameter substitution (e.g. `handle(T)` vs `handle(String)`) still
+     *   resolves across the hierarchy (see #289), including multi-level unannotated intermediates
+     * - interface mappings stay visible when a superclass supplies the implementation without
+     *   declaring the interface itself (controller `extends Base implements Api`)
      */
     private fun resolveMappedMethod(
         hierarchy: List<PsiClass>,
-        method: PsiMethod,
+        signature: HierarchicalMethodSignature,
     ): PsiMethod? {
-        val byContainingClass = methodsByContainingClass(method)
+        val byContainingClass = methodsByContainingClass(signature)
         for (type in hierarchy) {
             val candidate = byContainingClass[type] ?: continue
             if (hasMappingAnnotation(candidate)) {
@@ -145,20 +148,23 @@ internal object ArmeriaSpringMvcRouteCollector {
     }
 
     /**
-     * Maps each declaring type to the method on that type in [method]'s override chain.
-     * Walks [PsiMethod.findSuperMethods] transitively because each call returns only immediate
-     * supers (a super that itself overrides another does not expose the grandparent).
+     * Maps each declaring type to the method on that type in [signature]'s override chain.
+     * Walks [HierarchicalMethodSignature.superSignatures] transitively (each node exposes only
+     * immediate supers) from the controller's [PsiClass.visibleSignatures] entry so the index
+     * includes every interface/superclass reachable from that controller, not only
+     * [PsiMethod.findSuperMethods] of the declaring class.
      */
-    private fun methodsByContainingClass(method: PsiMethod): Map<PsiClass, PsiMethod> {
-        val result = linkedMapOf<PsiClass, PsiMethod>()
-        val queue = ArrayDeque<PsiMethod>().apply { add(method) }
+    private fun methodsByContainingClass(signature: HierarchicalMethodSignature): Map<PsiClass, PsiMethod> {
+        val result = HashMap<PsiClass, PsiMethod>()
+        val queue = ArrayDeque<HierarchicalMethodSignature>().apply { add(signature) }
         while (queue.isNotEmpty()) {
             val current = queue.removeFirst()
-            val containingClass = current.containingClass ?: continue
-            if (result.putIfAbsent(containingClass, current) != null) {
+            val method = current.method
+            val containingClass = method.containingClass ?: continue
+            if (result.putIfAbsent(containingClass, method) != null) {
                 continue
             }
-            queue.addAll(current.findSuperMethods())
+            queue.addAll(current.superSignatures)
         }
         return result
     }

--- a/plugin-route-spring/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/spring/ArmeriaSpringMvcRouteCollector.kt
+++ b/plugin-route-spring/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/spring/ArmeriaSpringMvcRouteCollector.kt
@@ -122,15 +122,26 @@ internal object ArmeriaSpringMvcRouteCollector {
     }
 
     /**
-     * Walks [hierarchy] (Spring TYPE_HIERARCHY order) and returns the first same-signature method
-     * that declares a Spring MVC mapping. Unannotated intermediate overrides do not stop the search.
+     * Walks [hierarchy] (Spring TYPE_HIERARCHY order) and returns the first matching method that
+     * declares a Spring MVC mapping. Unannotated intermediate overrides do not stop the search.
+     *
+     * Prefers [PsiClass.findMethodBySignature]; when that fails across generic type-parameter
+     * substitution (e.g. `handle(T)` vs concrete `handle(String)`), falls back to a method
+     * declared on that type that appears in [PsiMethod.findSuperMethods] (see #289).
      */
     private fun resolveMappedMethod(
         hierarchy: List<PsiClass>,
         method: PsiMethod,
     ): PsiMethod? {
+        val superByContainingClass =
+            method
+                .findSuperMethods(/* checkBases = */ false)
+                .associateBy { it.containingClass }
         for (type in hierarchy) {
-            val candidate = type.findMethodBySignature(method, false) ?: continue
+            val candidate =
+                type.findMethodBySignature(method, false)
+                    ?: superByContainingClass[type]
+                    ?: continue
             if (hasMappingAnnotation(candidate)) {
                 return candidate
             }

--- a/plugin-route-spring/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/spring/ArmeriaSpringMvcRouteCollector.kt
+++ b/plugin-route-spring/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/spring/ArmeriaSpringMvcRouteCollector.kt
@@ -122,31 +122,45 @@ internal object ArmeriaSpringMvcRouteCollector {
     }
 
     /**
-     * Walks [hierarchy] (Spring TYPE_HIERARCHY order) and returns the first matching method that
-     * declares a Spring MVC mapping. Unannotated intermediate overrides do not stop the search.
+     * Walks [hierarchy] (Spring TYPE_HIERARCHY order) and returns the first method in the
+     * override chain that declares a Spring MVC mapping. Unannotated intermediate overrides
+     * do not stop the search.
      *
-     * Prefers [PsiClass.findMethodBySignature]; when that fails across generic type-parameter
-     * substitution (e.g. `handle(T)` vs concrete `handle(String)`), falls back to a method
-     * declared on that type that appears in [PsiMethod.findSuperMethods] (see #289).
+     * Indexes [method] and its supers via [methodsByContainingClass] so generic type-parameter
+     * substitution (e.g. `handle(T)` vs `handle(String)`) still resolves across the hierarchy
+     * (see #289), including multi-level unannotated intermediates.
      */
     private fun resolveMappedMethod(
         hierarchy: List<PsiClass>,
         method: PsiMethod,
     ): PsiMethod? {
-        val superByContainingClass =
-            method
-                .findSuperMethods(/* checkBases = */ false)
-                .associateBy { it.containingClass }
+        val byContainingClass = methodsByContainingClass(method)
         for (type in hierarchy) {
-            val candidate =
-                type.findMethodBySignature(method, false)
-                    ?: superByContainingClass[type]
-                    ?: continue
+            val candidate = byContainingClass[type] ?: continue
             if (hasMappingAnnotation(candidate)) {
                 return candidate
             }
         }
         return null
+    }
+
+    /**
+     * Maps each declaring type to the method on that type in [method]'s override chain.
+     * Walks [PsiMethod.findSuperMethods] transitively because each call returns only immediate
+     * supers (a super that itself overrides another does not expose the grandparent).
+     */
+    private fun methodsByContainingClass(method: PsiMethod): Map<PsiClass, PsiMethod> {
+        val result = linkedMapOf<PsiClass, PsiMethod>()
+        val queue = ArrayDeque<PsiMethod>().apply { add(method) }
+        while (queue.isNotEmpty()) {
+            val current = queue.removeFirst()
+            val containingClass = current.containingClass ?: continue
+            if (result.putIfAbsent(containingClass, current) != null) {
+                continue
+            }
+            queue.addAll(current.findSuperMethods())
+        }
+        return result
     }
 
     private fun addRoutesFromMethod(

--- a/plugin-route-spring/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcInheritanceRouteCollectorTest.kt
+++ b/plugin-route-spring/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcInheritanceRouteCollectorTest.kt
@@ -137,6 +137,45 @@ class ArmeriaSpringMvcInheritanceRouteCollectorTest : ArmeriaFixtureTestBase() {
         )
     }
 
+    fun testGenericInterfaceMappingIsDiscoveredUnderConcreteController() {
+        myFixture.addClass(
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.GetMapping;
+
+            public interface Handler<T> {
+                @GetMapping("/handle")
+                T handle(T t);
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "StringHandler.java",
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.RestController;
+
+            @RestController
+            public class StringHandler implements Handler<String> {
+                @Override
+                public String handle(String t) {
+                    return t;
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.projectScope(project))
+        val springMvcRoute = springMvcRoutes.single()
+        assertEquals("GET", springMvcRoute.httpMethod)
+        assertEquals("/handle", springMvcRoute.path)
+        assertEquals("example.StringHandler#handle()", springMvcRoute.target)
+        assertEquals("example.StringHandler", springMvcRoute.controller.qualifiedName)
+        assertEquals("example.Handler", springMvcRoute.element.containingClass?.qualifiedName)
+    }
+
     fun testBaseClassRequestMappingPrefixAppliesToInheritedMethod() {
         configureTomcatMount("/spring/")
         myFixture.addClass(

--- a/plugin-route-spring/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcInheritanceRouteCollectorTest.kt
+++ b/plugin-route-spring/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcInheritanceRouteCollectorTest.kt
@@ -266,6 +266,52 @@ class ArmeriaSpringMvcInheritanceRouteCollectorTest : ArmeriaFixtureTestBase() {
         assertEquals("example.BaseHandler", springMvcRoute.element.containingClass?.qualifiedName)
     }
 
+    fun testInheritedBaseMethodSatisfyingInterfaceMappingIsDiscovered() {
+        myFixture.addClass(
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.GetMapping;
+
+            public interface GreetingApi {
+                @GetMapping("/api")
+                String hello();
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public abstract class BaseController {
+                public String hello() {
+                    return "base";
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "HelloController.java",
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.RestController;
+
+            @RestController
+            public class HelloController extends BaseController implements GreetingApi {
+            }
+            """.trimIndent(),
+        )
+
+        val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.projectScope(project))
+        val springMvcRoute = springMvcRoutes.single()
+        assertEquals("GET", springMvcRoute.httpMethod)
+        assertEquals("/api", springMvcRoute.path)
+        assertEquals("example.HelloController#hello()", springMvcRoute.target)
+        assertEquals("example.HelloController", springMvcRoute.controller.qualifiedName)
+        assertEquals("example.GreetingApi", springMvcRoute.element.containingClass?.qualifiedName)
+    }
+
     fun testBaseClassRequestMappingPrefixAppliesToInheritedMethod() {
         configureTomcatMount("/spring/")
         myFixture.addClass(

--- a/plugin-route-spring/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcInheritanceRouteCollectorTest.kt
+++ b/plugin-route-spring/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcInheritanceRouteCollectorTest.kt
@@ -176,6 +176,96 @@ class ArmeriaSpringMvcInheritanceRouteCollectorTest : ArmeriaFixtureTestBase() {
         assertEquals("example.Handler", springMvcRoute.element.containingClass?.qualifiedName)
     }
 
+    fun testGenericMultiLevelUnannotatedOverrideResolvesGrandparentMapping() {
+        myFixture.addClass(
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.GetMapping;
+
+            public interface Handler<T> {
+                @GetMapping("/handle")
+                T handle(T t);
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public abstract class MidHandler<T> implements Handler<T> {
+                @Override
+                public T handle(T t) {
+                    return t;
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "StringHandler.java",
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.RestController;
+
+            @RestController
+            public class StringHandler extends MidHandler<String> {
+                @Override
+                public String handle(String t) {
+                    return t;
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.projectScope(project))
+        val springMvcRoute = springMvcRoutes.single()
+        assertEquals("GET", springMvcRoute.httpMethod)
+        assertEquals("/handle", springMvcRoute.path)
+        assertEquals("example.StringHandler#handle()", springMvcRoute.target)
+        assertEquals("example.StringHandler", springMvcRoute.controller.qualifiedName)
+        assertEquals("example.Handler", springMvcRoute.element.containingClass?.qualifiedName)
+    }
+
+    fun testGenericAbstractBaseMappingIsDiscoveredUnderConcreteController() {
+        myFixture.addClass(
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.GetMapping;
+
+            public abstract class BaseHandler<T> {
+                @GetMapping("/handle")
+                public abstract T handle(T t);
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "StringHandler.java",
+            """
+            package example;
+
+            import org.springframework.web.bind.annotation.RestController;
+
+            @RestController
+            public class StringHandler extends BaseHandler<String> {
+                @Override
+                public String handle(String t) {
+                    return t;
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val springMvcRoutes = ArmeriaSpringMvcRouteCollector.collect(project, GlobalSearchScope.projectScope(project))
+        val springMvcRoute = springMvcRoutes.single()
+        assertEquals("GET", springMvcRoute.httpMethod)
+        assertEquals("/handle", springMvcRoute.path)
+        assertEquals("example.StringHandler#handle()", springMvcRoute.target)
+        assertEquals("example.StringHandler", springMvcRoute.controller.qualifiedName)
+        assertEquals("example.BaseHandler", springMvcRoute.element.containingClass?.qualifiedName)
+    }
+
     fun testBaseClassRequestMappingPrefixAppliesToInheritedMethod() {
         configureTomcatMount("/spring/")
         myFixture.addClass(

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Fixed
 
+- Spring MVC Route Explorer discovery finds mappings declared on generic base types/interfaces when the concrete controller substitutes type parameters (e.g. `Handler<T>` → `StringHandler`).
 - Bundle `plugin-shared` (including `ArmeriaBundle`) into the main plugin JAR so installing only `plugin-*.jar` no longer fails inspection-profile saves with `ClassNotFoundException: ArmeriaBundleKt`.
 - Route Explorer deduplicates GraphQL and Thrift IDL routes per module when the same operation appears in multiple schema or `.thrift` files.
 - DocService runtime route sync activates the Armeria Services tool window when needed so routes apply even if it was closed before the fetch completed.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### Fixed
 
-- Spring MVC Route Explorer discovery finds mappings declared on generic base types/interfaces when the concrete controller substitutes type parameters (e.g. `Handler<T>` → `StringHandler`).
+- Spring MVC Route Explorer discovery finds mappings declared on generic base types/interfaces when the concrete controller substitutes type parameters (e.g. `Handler<T>` → `StringHandler`), including multi-level unannotated overrides.
 - Bundle `plugin-shared` (including `ArmeriaBundle`) into the main plugin JAR so installing only `plugin-*.jar` no longer fails inspection-profile saves with `ClassNotFoundException: ArmeriaBundleKt`.
 - Route Explorer deduplicates GraphQL and Thrift IDL routes per module when the same operation appears in multiple schema or `.thrift` files.
 - DocService runtime route sync activates the Armeria Services tool window when needed so routes apply even if it was closed before the fetch completed.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### Fixed
 
-- Spring MVC Route Explorer discovery finds mappings declared on generic base types/interfaces when the concrete controller substitutes type parameters (e.g. `Handler<T>` → `StringHandler`), including multi-level unannotated overrides.
+- Spring MVC Route Explorer discovery finds mappings declared on generic base types/interfaces when the concrete controller substitutes type parameters (e.g. `Handler<T>` → `StringHandler`), including multi-level unannotated overrides and interface mappings satisfied by an inherited superclass method.
 - Bundle `plugin-shared` (including `ArmeriaBundle`) into the main plugin JAR so installing only `plugin-*.jar` no longer fails inspection-profile saves with `ClassNotFoundException: ArmeriaBundleKt`.
 - Route Explorer deduplicates GraphQL and Thrift IDL routes per module when the same operation appears in multiple schema or `.thrift` files.
 - DocService runtime route sync activates the Armeria Services tool window when needed so routes apply even if it was closed before the fetch completed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Spring MVC Route Explorer now discovers mappings declared on generic base types/interfaces when the concrete controller substitutes type parameters (for example `Handler<T>` → `StringHandler`). Override resolution indexes each controller `visibleSignatures` entry through transitive `HierarchicalMethodSignature.superSignatures`, then selects the first annotated method in Spring TYPE_HIERARCHY order (“first annotated wins”). That also covers interface mappings satisfied by an inherited superclass method (`extends Base implements Api` with no child override).

Closes #289.

## Changes

- `ArmeriaSpringMvcRouteCollector.resolveMappedMethod` indexes the override chain from the controller’s `HierarchicalMethodSignature` (transitive `superSignatures`), covering generic type-parameter substitution, multi-level unannotated intermediates, and interface mappings implemented by an inherited superclass method
- Regression fixtures for direct generic interfaces, generic abstract bases, multi-level generic unannotated overrides, and inherited-base-implements-interface mappings
- CHANGELOG Unreleased Fixed entry

## Test plan

- [x] `:plugin-route-spring:test` — `ArmeriaSpringMvcInheritanceRouteCollectorTest` (generic interface / abstract base / multi-level / inherited-implements-interface cases)
- [x] `:plugin-route-spring:ktlintMainSourceSetCheck` — import order for `HierarchicalMethodSignature`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f872c-086f-7a80-82f4-fb5b1e470e08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f872c-086f-7a80-82f4-fb5b1e470e08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

