### PR TITLE
feat: use Proto Editor PSI for gRPC route discovery

### DIFF
--- a/plugin-route-protocol/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/protocol/ArmeriaGrpcRouteCollector.kt
+++ b/plugin-route-protocol/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/protocol/ArmeriaGrpcRouteCollector.kt
@@ -1,8 +1,10 @@
 package com.linecorp.intellij.plugins.armeria.explorer.protocol
+
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.registry.Registry
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import com.intellij.psi.search.FilenameIndex
 import com.intellij.psi.search.GlobalSearchScope
@@ -31,9 +33,29 @@ object ArmeriaGrpcRouteCollector {
         for (virtualFile in FilenameIndex.getAllFilesByExt(project, "proto", scope)) {
             ArmeriaRouteCollectionMetrics.current()?.filesScanned?.incrementAndGet()
             val psiFile = PsiManager.getInstance(project).findFile(virtualFile) ?: continue
-            collectFromProtoText(psiFile.text, psiFile, routes, seenProtoRoutes)
+            collectFromProtoFile(psiFile, routes, seenProtoRoutes)
         }
     }
+
+    private fun collectFromProtoFile(
+        psiFile: PsiFile,
+        routes: MutableList<ArmeriaRoute>,
+        seenProtoRoutes: MutableSet<String>,
+    ) {
+        for (collector in protoRouteCollectors()) {
+            if (collector.collectFromFile(psiFile, routes, seenProtoRoutes)) {
+                return
+            }
+        }
+        collectFromProtoText(psiFile.text, psiFile, routes, seenProtoRoutes)
+    }
+
+    private fun protoRouteCollectors(): List<ArmeriaProtoRouteCollector> =
+        try {
+            ArmeriaProtoRouteCollector.EP.extensionList
+        } catch (_: IllegalArgumentException) {
+            emptyList()
+        }
 
     internal fun collectFromProtoText(
         text: String,
@@ -52,22 +74,32 @@ object ArmeriaGrpcRouteCollector {
             val fqService = if (packageName.isBlank()) serviceName else "$packageName.$serviceName"
             for (rpc in RPC_PATTERN.findAll(body)) {
                 val methodName = rpc.groupValues[1]
-                val path = "/$fqService/$methodName"
-                val dedupeKey = "${ArmeriaRouteMetadata.moduleName(element)}:$path"
-                if (!seenProtoRoutes.add(dedupeKey)) {
-                    continue
-                }
-                routes +=
-                    ArmeriaRoute.create(
-                        element = element,
-                        protocol = message("route.explorer.protocol.grpc"),
-                        httpMethod = "",
-                        path = path,
-                        target = "$fqService.$methodName",
-                        routeMatch = RouteMatch.NON_HTTP,
-                    )
+                addProtoRoute(element, fqService, methodName, routes, seenProtoRoutes)
             }
         }
+    }
+
+    internal fun addProtoRoute(
+        element: PsiElement,
+        fqService: String,
+        methodName: String,
+        routes: MutableList<ArmeriaRoute>,
+        seenProtoRoutes: MutableSet<String>,
+    ) {
+        val path = "/$fqService/$methodName"
+        val dedupeKey = "${ArmeriaRouteMetadata.moduleName(element)}:$path"
+        if (!seenProtoRoutes.add(dedupeKey)) {
+            return
+        }
+        routes +=
+            ArmeriaRoute.create(
+                element = element,
+                protocol = message("route.explorer.protocol.grpc"),
+                httpMethod = "",
+                path = path,
+                target = "$fqService.$methodName",
+                routeMatch = RouteMatch.NON_HTTP,
+            )
     }
 
     fun isProtoRouteDiscoveryEnabled(): Boolean =
@@ -100,4 +132,14 @@ object ArmeriaGrpcRouteCollector {
         }
         return results
     }
+}
+
+fun registerArmeriaGrpcProtoRoute(
+    element: PsiElement,
+    fqService: String,
+    methodName: String,
+    routes: MutableList<ArmeriaRoute>,
+    seenProtoRoutes: MutableSet<String>,
+) {
+    ArmeriaGrpcRouteCollector.addProtoRoute(element, fqService, methodName, routes, seenProtoRoutes)
 }

--- a/plugin-route-protocol/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/protocol/ArmeriaGrpcRouteCollector.kt
+++ b/plugin-route-protocol/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/protocol/ArmeriaGrpcRouteCollector.kt
@@ -1,5 +1,6 @@
 package com.linecorp.intellij.plugins.armeria.explorer.protocol
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.registry.Registry
 import com.intellij.psi.JavaPsiFacade
@@ -50,12 +51,13 @@ object ArmeriaGrpcRouteCollector {
         collectFromProtoText(psiFile.text, psiFile, routes, seenProtoRoutes)
     }
 
-    private fun protoRouteCollectors(): List<ArmeriaProtoRouteCollector> =
-        try {
-            ArmeriaProtoRouteCollector.EP.extensionList
-        } catch (_: IllegalArgumentException) {
-            emptyList()
+    private fun protoRouteCollectors(): List<ArmeriaProtoRouteCollector> {
+        val area = ApplicationManager.getApplication().extensionArea
+        if (!area.hasExtensionPoint(ArmeriaProtoRouteCollector.EP.name)) {
+            return emptyList()
         }
+        return ArmeriaProtoRouteCollector.EP.extensionList
+    }
 
     internal fun collectFromProtoText(
         text: String,
@@ -79,7 +81,7 @@ object ArmeriaGrpcRouteCollector {
         }
     }
 
-    internal fun addProtoRoute(
+    fun addProtoRoute(
         element: PsiElement,
         fqService: String,
         methodName: String,
@@ -132,14 +134,4 @@ object ArmeriaGrpcRouteCollector {
         }
         return results
     }
-}
-
-fun registerArmeriaGrpcProtoRoute(
-    element: PsiElement,
-    fqService: String,
-    methodName: String,
-    routes: MutableList<ArmeriaRoute>,
-    seenProtoRoutes: MutableSet<String>,
-) {
-    ArmeriaGrpcRouteCollector.addProtoRoute(element, fqService, methodName, routes, seenProtoRoutes)
 }

--- a/plugin-route-protocol/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/protocol/ArmeriaProtoRouteCollector.kt
+++ b/plugin-route-protocol/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/protocol/ArmeriaProtoRouteCollector.kt
@@ -1,0 +1,25 @@
+package com.linecorp.intellij.plugins.armeria.explorer.protocol
+
+import com.intellij.openapi.extensions.ExtensionPointName
+import com.intellij.psi.PsiFile
+import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
+
+/**
+ * Optional `.proto` route extractor. Implementations that depend on Proto Editor PSI
+ * register via `proto-integration.xml` when `idea.plugin.protoeditor` is present.
+ *
+ * Returning `true` means the file was handled (routes may still be empty after dedupe).
+ * Returning `false` lets [ArmeriaGrpcRouteCollector] fall back to text parsing.
+ */
+interface ArmeriaProtoRouteCollector {
+    fun collectFromFile(
+        file: PsiFile,
+        routes: MutableList<ArmeriaRoute>,
+        seenProtoRoutes: MutableSet<String>,
+    ): Boolean
+
+    companion object {
+        val EP: ExtensionPointName<ArmeriaProtoRouteCollector> =
+            ExtensionPointName.create("com.linecorp.intellij.armeria.protoRouteCollector")
+    }
+}

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - ktlint via `com.linecorp.intellij.ktlint` convention (`ktlint_official` style); `ktlintCheck` runs as part of `check` / `build`.
+- gRPC Route Explorer discovery uses Proto Editor PSI when `idea.plugin.protoeditor` is available (RPC-level navigation), with fallback to the existing `.proto` text parser.
 
 ### Changed
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
         bundledPlugin("org.jetbrains.plugins.gradle")
         bundledPlugin("org.jetbrains.kotlin")
         bundledPlugin("org.jetbrains.plugins.yaml")
+        bundledPlugin("idea.plugin.protoeditor")
         testFramework(TestFrameworkType.Plugin.Java)
         testFramework(TestFrameworkType.Plugin.Java, configurationName = "testFixturesImplementation")
     }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaProtoPsiRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaProtoPsiRouteCollector.kt
@@ -5,8 +5,8 @@ import com.intellij.protobuf.lang.psi.PbServiceDefinition
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.PsiTreeUtil
 import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
+import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaGrpcRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaProtoRouteCollector
-import com.linecorp.intellij.plugins.armeria.explorer.protocol.registerArmeriaGrpcProtoRoute
 
 /**
  * Proto Editor PSI-backed gRPC route collector. Loaded only when
@@ -23,19 +23,14 @@ class ArmeriaProtoPsiRouteCollector : ArmeriaProtoRouteCollector {
         if (services.isEmpty()) {
             return false
         }
-        var collected = false
         for (service in services) {
-            val fqService = service.qualifiedName?.toString().orEmpty()
-            if (fqService.isBlank()) {
-                return false
-            }
-            val methods = service.body?.serviceMethodList.orEmpty()
-            for (method in methods) {
+            val fqService = service.qualifiedName?.toString()?.takeIf { it.isNotBlank() } ?: continue
+            for (method in service.body?.serviceMethodList.orEmpty()) {
                 val methodName = method.name ?: continue
-                registerArmeriaGrpcProtoRoute(method, fqService, methodName, routes, seenProtoRoutes)
-                collected = true
+                ArmeriaGrpcRouteCollector.addProtoRoute(method, fqService, methodName, routes, seenProtoRoutes)
             }
         }
-        return collected
+        // Services were present: PSI owns this file even when every method was skipped/deduped.
+        return true
     }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaProtoPsiRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaProtoPsiRouteCollector.kt
@@ -1,0 +1,41 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.intellij.protobuf.lang.psi.PbFile
+import com.intellij.protobuf.lang.psi.PbServiceDefinition
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
+import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaProtoRouteCollector
+import com.linecorp.intellij.plugins.armeria.explorer.protocol.registerArmeriaGrpcProtoRoute
+
+/**
+ * Proto Editor PSI-backed gRPC route collector. Loaded only when
+ * `idea.plugin.protoeditor` is present (see `proto-integration.xml`).
+ */
+class ArmeriaProtoPsiRouteCollector : ArmeriaProtoRouteCollector {
+    override fun collectFromFile(
+        file: PsiFile,
+        routes: MutableList<ArmeriaRoute>,
+        seenProtoRoutes: MutableSet<String>,
+    ): Boolean {
+        val pbFile = file as? PbFile ?: return false
+        val services = PsiTreeUtil.findChildrenOfType(pbFile, PbServiceDefinition::class.java)
+        if (services.isEmpty()) {
+            return false
+        }
+        var collected = false
+        for (service in services) {
+            val fqService = service.qualifiedName?.toString().orEmpty()
+            if (fqService.isBlank()) {
+                return false
+            }
+            val methods = service.body?.serviceMethodList.orEmpty()
+            for (method in methods) {
+                val methodName = method.name ?: continue
+                registerArmeriaGrpcProtoRoute(method, fqService, methodName, routes, seenProtoRoutes)
+                collected = true
+            }
+        }
+        return collected
+    }
+}

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -3,6 +3,12 @@
     <name>Armeria</name>
     <vendor email="nise.nabe@gmail.com" url="https://github.com/nise-nabe/armeria-intellij-plugin">nise_nabe</vendor>
 
+    <extensionPoints>
+        <extensionPoint qualifiedName="com.linecorp.intellij.armeria.protoRouteCollector"
+                        interface="com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaProtoRouteCollector"
+                        dynamic="true"/>
+    </extensionPoints>
+
     <depends>com.intellij.java</depends>
     <depends>org.jetbrains.plugins.gradle</depends>
     <depends optional="true" config-file="kotlin-integration.xml">org.jetbrains.kotlin</depends>

--- a/plugin/src/main/resources/META-INF/proto-integration.xml
+++ b/plugin/src/main/resources/META-INF/proto-integration.xml
@@ -1,2 +1,5 @@
 <idea-plugin>
+    <extensions defaultExtensionNs="com.linecorp.intellij.armeria">
+        <protoRouteCollector implementation="com.linecorp.intellij.plugins.armeria.explorer.ArmeriaProtoPsiRouteCollector"/>
+    </extensions>
 </idea-plugin>

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaProtoPsiRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaProtoPsiRouteCollectorTest.kt
@@ -1,0 +1,196 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.extensions.ExtensionPoint
+import com.intellij.protobuf.lang.psi.PbFile
+import com.intellij.protobuf.lang.psi.PbServiceMethod
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteAnalysisCollector
+import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
+import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
+import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaProtoRouteCollector
+
+class ArmeriaProtoPsiRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
+    override fun setUp() {
+        super.setUp()
+        registerArmeriaStubs()
+        registerProtoRouteCollectorExtensionPoint()
+    }
+
+    fun testCollectGrpcRoutesFromProtoPsi() {
+        val file =
+            myFixture.configureByText(
+                "greeter.proto",
+                """
+                syntax = "proto3";
+                package com.example;
+
+                service Greeter {
+                  rpc SayHello(HelloRequest) returns (HelloResponse);
+                  rpc SayGoodbye(HelloRequest) returns (HelloResponse);
+                }
+                """.trimIndent(),
+            )
+        assertTrue("Expected Proto Editor PSI for .proto fixture", file is PbFile)
+
+        val routes = mutableListOf<ArmeriaRoute>()
+        assertTrue(ArmeriaProtoPsiRouteCollector().collectFromFile(file, routes, mutableSetOf()))
+
+        assertEquals(
+            listOf("/com.example.Greeter/SayGoodbye", "/com.example.Greeter/SayHello"),
+            routes.map { it.path }.sorted(),
+        )
+        assertTrue(routes.all { it.routeMatch == RouteMatch.NON_HTTP })
+    }
+
+    fun testCollectGrpcRoutesFromProtoPsiWithoutPackage() {
+        val file =
+            myFixture.configureByText(
+                "greeter.proto",
+                """
+                syntax = "proto3";
+
+                service Greeter {
+                  rpc Ping(PingRequest) returns (PingResponse);
+                }
+                """.trimIndent(),
+            )
+        assertTrue(file is PbFile)
+
+        val routes = mutableListOf<ArmeriaRoute>()
+        assertTrue(ArmeriaProtoPsiRouteCollector().collectFromFile(file, routes, mutableSetOf()))
+
+        val route = routes.single()
+        assertEquals("/Greeter/Ping", route.path)
+        assertEquals("Greeter.Ping", route.target)
+    }
+
+    fun testCollectGrpcRoutesFromProtoPsiAnchorsRpcMethod() {
+        val file =
+            myFixture.configureByText(
+                "greeter.proto",
+                """
+                syntax = "proto3";
+                package com.example;
+
+                service Greeter {
+                  rpc SayHello(HelloRequest) returns (HelloResponse);
+                }
+                """.trimIndent(),
+            ) as PbFile
+
+        val routes = mutableListOf<ArmeriaRoute>()
+        ArmeriaProtoPsiRouteCollector().collectFromFile(file, routes, mutableSetOf())
+
+        val route = routes.single()
+        assertTrue(route.pointer.element is PbServiceMethod)
+        assertEquals("SayHello", (route.pointer.element as PbServiceMethod).name)
+    }
+
+    fun testCommentedRpcIsIgnoredByProtoPsi() {
+        val file =
+            myFixture.configureByText(
+                "greeter.proto",
+                """
+                syntax = "proto3";
+                package com.example;
+
+                service Greeter {
+                  // rpc Deprecated(HelloRequest) returns (HelloResponse);
+                  rpc SayHello(HelloRequest) returns (HelloResponse);
+                }
+                """.trimIndent(),
+            )
+        assertTrue(file is PbFile)
+
+        val routes = mutableListOf<ArmeriaRoute>()
+        ArmeriaProtoPsiRouteCollector().collectFromFile(file, routes, mutableSetOf())
+
+        assertEquals(listOf("/com.example.Greeter/SayHello"), routes.map { it.path })
+    }
+
+    fun testProtoPsiReturnsFalseWhenNoServicesToAllowTextFallback() {
+        val file =
+            myFixture.configureByText(
+                "empty.proto",
+                """
+                syntax = "proto3";
+                package com.example;
+                """.trimIndent(),
+            )
+        assertTrue(file is PbFile)
+
+        val routes = mutableListOf<ArmeriaRoute>()
+        assertFalse(ArmeriaProtoPsiRouteCollector().collectFromFile(file, routes, mutableSetOf()))
+        assertTrue(routes.isEmpty())
+    }
+
+    fun testCollectFromProtoFilePrefersPsiCollectorOverTextParsing() {
+        myFixture.configureByText(
+            "greeter.proto",
+            """
+            syntax = "proto3";
+            package com.example;
+
+            service Greeter {
+              // rpc Deprecated(HelloRequest) returns (HelloResponse);
+              rpc SayHello(HelloRequest) returns (HelloResponse);
+            }
+            """.trimIndent(),
+        )
+        registerProtoRouteCollectorExtension()
+
+        val routes = ArmeriaRouteAnalysisCollector.collect(project, includeProtoRoutes = true)
+
+        assertEquals(listOf("/com.example.Greeter/SayHello"), routes.map { it.path })
+        assertTrue(routes.single().pointer.element is PbServiceMethod)
+    }
+
+    private fun registerProtoRouteCollectorExtensionPoint() {
+        try {
+            ArmeriaProtoRouteCollector.EP.extensionList
+            return
+        } catch (_: IllegalArgumentException) {
+            // Extension point is not registered in this test container yet.
+        }
+        val extensionArea = ApplicationManager.getApplication().extensionArea
+        extensionArea.registerExtensionPoint(
+            "com.linecorp.intellij.armeria.protoRouteCollector",
+            ArmeriaProtoRouteCollector::class.java.name,
+            ExtensionPoint.Kind.INTERFACE,
+            true,
+        )
+    }
+
+    private fun registerProtoRouteCollectorExtension() {
+        ArmeriaProtoRouteCollector.EP.point.registerExtension(
+            ArmeriaProtoPsiRouteCollector(),
+            testRootDisposable,
+        )
+    }
+
+    private fun registerArmeriaStubs() {
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.server.grpc;
+
+            public final class GrpcService {
+                public static GrpcServiceBuilder builder(Object bindableService) {
+                    return null;
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.server.grpc;
+
+            public final class GrpcServiceBuilder {
+                public com.linecorp.armeria.server.grpc.GrpcService build() {
+                    return null;
+                }
+            }
+            """.trimIndent(),
+        )
+    }
+}

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaProtoPsiRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaProtoPsiRouteCollectorTest.kt
@@ -126,6 +126,77 @@ class ArmeriaProtoPsiRouteCollectorTest : ArmeriaLightJavaCodeInsightFixtureTest
         assertTrue(routes.isEmpty())
     }
 
+    fun testEmptyServiceBodyIsHandledWithoutTextFallback() {
+        val file =
+            myFixture.configureByText(
+                "empty-service.proto",
+                """
+                syntax = "proto3";
+                package com.example;
+
+                service Greeter {
+                }
+                """.trimIndent(),
+            )
+        assertTrue(file is PbFile)
+
+        val routes = mutableListOf<ArmeriaRoute>()
+        assertTrue(ArmeriaProtoPsiRouteCollector().collectFromFile(file, routes, mutableSetOf()))
+        assertTrue(routes.isEmpty())
+    }
+
+    fun testCollectGrpcRoutesFromMultipleServicesInOneProto() {
+        val file =
+            myFixture.configureByText(
+                "multi.proto",
+                """
+                syntax = "proto3";
+                package com.example;
+
+                service Greeter {
+                  rpc SayHello(HelloRequest) returns (HelloResponse);
+                }
+
+                service Echo {
+                  rpc Ping(PingRequest) returns (PingResponse);
+                }
+                """.trimIndent(),
+            )
+        assertTrue(file is PbFile)
+
+        val routes = mutableListOf<ArmeriaRoute>()
+        assertTrue(ArmeriaProtoPsiRouteCollector().collectFromFile(file, routes, mutableSetOf()))
+
+        assertEquals(
+            listOf("/com.example.Echo/Ping", "/com.example.Greeter/SayHello"),
+            routes.map { it.path }.sorted(),
+        )
+    }
+
+    fun testJavaPackageOptionDoesNotChangeGrpcPath() {
+        val file =
+            myFixture.configureByText(
+                "greeter.proto",
+                """
+                syntax = "proto3";
+                package com.example;
+                option java_package = "com.example.java";
+
+                service Greeter {
+                  rpc SayHello(HelloRequest) returns (HelloResponse);
+                }
+                """.trimIndent(),
+            )
+        assertTrue(file is PbFile)
+
+        val routes = mutableListOf<ArmeriaRoute>()
+        assertTrue(ArmeriaProtoPsiRouteCollector().collectFromFile(file, routes, mutableSetOf()))
+
+        val route = routes.single()
+        assertEquals("/com.example.Greeter/SayHello", route.path)
+        assertEquals("com.example.Greeter.SayHello", route.target)
+    }
+
     fun testCollectFromProtoFilePrefersPsiCollectorOverTextParsing() {
         myFixture.configureByText(
             "greeter.proto",
@@ -153,15 +224,12 @@ class ArmeriaProtoPsiRouteCollectorTest : ArmeriaLightJavaCodeInsightFixtureTest
     }
 
     private fun registerProtoRouteCollectorExtensionPoint() {
-        try {
-            ArmeriaProtoRouteCollector.EP.extensionList
+        val area = ApplicationManager.getApplication().extensionArea
+        if (area.hasExtensionPoint(ArmeriaProtoRouteCollector.EP.name)) {
             return
-        } catch (_: IllegalArgumentException) {
-            // Extension point is not registered in this test container yet.
         }
-        val extensionArea = ApplicationManager.getApplication().extensionArea
-        extensionArea.registerExtensionPoint(
-            "com.linecorp.intellij.armeria.protoRouteCollector",
+        area.registerExtensionPoint(
+            ArmeriaProtoRouteCollector.EP.name,
             ArmeriaProtoRouteCollector::class.java.name,
             ExtensionPoint.Kind.INTERFACE,
             true,

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaProtoPsiRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaProtoPsiRouteCollectorTest.kt
@@ -4,13 +4,14 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.extensions.ExtensionPoint
 import com.intellij.protobuf.lang.psi.PbFile
 import com.intellij.protobuf.lang.psi.PbServiceMethod
-import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
-import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteAnalysisCollector
+import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaProtoRouteCollector
+import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaProtocolRouteContributor
+import com.linecorp.intellij.plugins.armeria.test.ArmeriaLightJavaCodeInsightFixtureTestCase
 
-class ArmeriaProtoPsiRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() {
+class ArmeriaProtoPsiRouteCollectorTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {
     override fun setUp() {
         super.setUp()
         registerArmeriaStubs()
@@ -140,7 +141,12 @@ class ArmeriaProtoPsiRouteCollectorTest : LightJavaCodeInsightFixtureTestCase() 
         )
         registerProtoRouteCollectorExtension()
 
-        val routes = ArmeriaRouteAnalysisCollector.collect(project, includeProtoRoutes = true)
+        val routes =
+            ArmeriaRouteCollector.collect(
+                project,
+                includeProtoRoutes = true,
+                contributors = listOf(ArmeriaProtocolRouteContributor),
+            )
 
         assertEquals(listOf("/com.example.Greeter/SayHello"), routes.map { it.path })
         assertTrue(routes.single().pointer.element is PbServiceMethod)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Uses the IntelliJ Proto Editor PSI for gRPC route discovery when available, with fallback to the existing `.proto` text parser. Resumes the parked design from #216 / issue #265 against the current multi-module layout.

Fixes #265

## Changes

- Add `ArmeriaProtoRouteCollector` extension point in `plugin-route-protocol`
- Prefer PSI-based `.proto` service/RPC detection in `ArmeriaGrpcRouteCollector`, falling back to text parsing when Proto Editor is absent or cannot resolve services
- Add `ArmeriaProtoPsiRouteCollector` (Proto Editor classpath) registered via `proto-integration.xml`
- Anchor routes on RPC method elements for navigation
- Once Proto Editor finds services in a file, treat the file as handled (skip blank FQNs without aborting after partial mutation; empty service bodies do not re-enter text parsing)
- Probe the extension point with `hasExtensionPoint` instead of catching `IllegalArgumentException`
- Expose `ArmeriaGrpcRouteCollector.addProtoRoute` for the optional PSI collector
- Bundle `idea.plugin.protoeditor` for plugin compile/test; regression tests for PSI and fallback paths (multi-service, empty service body, `java_package` path parity)

## Test plan

- [x] `:plugin:test` — `ArmeriaProtoPsiRouteCollectorTest`
- [x] `:plugin:ktlintCheck` + `:plugin-route-protocol:ktlintCheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8758-4b23-71ac-8d1d-aae54ab8ef6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8758-4b23-71ac-8d1d-aae54ab8ef6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

