### PR TITLE
feat: add Scala support for Route Explorer and Clients Explorer

### DIFF
--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/navigation/ArmeriaRouteNavigation.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/navigation/ArmeriaRouteNavigation.kt
@@ -22,15 +22,7 @@ object ArmeriaRouteNavigation {
     fun navigateToPointer(
         project: Project,
         pointer: SmartPsiElementPointer<PsiElement>,
-        parentDisposable: Disposable? = null,
-    ) {
-        navigateToPointer(project, pointer, sourceOffset = null, parentDisposable)
-    }
-
-    fun navigateToPointer(
-        project: Project,
-        pointer: SmartPsiElementPointer<PsiElement>,
-        sourceOffset: Int?,
+        sourceOffset: Int? = null,
         parentDisposable: Disposable? = null,
     ) {
         ReadAction
@@ -45,7 +37,7 @@ object ArmeriaRouteNavigation {
             }.submit(AppExecutorUtil.getAppExecutorService())
     }
 
-    fun resolveNavigatable(
+    private fun resolveNavigatable(
         pointer: SmartPsiElementPointer<PsiElement>,
         sourceOffset: Int?,
     ): Navigatable? {

--- a/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/navigation/ArmeriaRouteNavigation.kt
+++ b/plugin-route-analysis/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/navigation/ArmeriaRouteNavigation.kt
@@ -2,23 +2,40 @@ package com.linecorp.intellij.plugins.armeria.explorer.navigation
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
 import com.intellij.openapi.project.Project
 import com.intellij.pom.Navigatable
 import com.intellij.psi.PsiElement
 import com.intellij.psi.SmartPsiElementPointer
 import com.intellij.util.concurrency.AppExecutorUtil
+import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
 
 object ArmeriaRouteNavigation {
+    fun navigateToRoute(
+        project: Project,
+        route: ArmeriaRoute,
+        parentDisposable: Disposable? = null,
+    ) {
+        navigateToPointer(project, route.pointer, route.sourceOffset, parentDisposable)
+    }
+
     fun navigateToPointer(
         project: Project,
         pointer: SmartPsiElementPointer<PsiElement>,
         parentDisposable: Disposable? = null,
     ) {
+        navigateToPointer(project, pointer, sourceOffset = null, parentDisposable)
+    }
+
+    fun navigateToPointer(
+        project: Project,
+        pointer: SmartPsiElementPointer<PsiElement>,
+        sourceOffset: Int?,
+        parentDisposable: Disposable? = null,
+    ) {
         ReadAction
             .nonBlocking<Navigatable?> {
-                val element = pointer.element
-                (element as? Navigatable)?.takeIf { it.canNavigate() }
-                    ?: (element?.navigationElement as? Navigatable)?.takeIf { it.canNavigate() }
+                resolveNavigatable(pointer, sourceOffset)
             }.inSmartMode(project)
             .expireWith(project)
             .let { coordinator ->
@@ -26,5 +43,20 @@ object ArmeriaRouteNavigation {
             }.finishOnUiThread(ModalityState.any()) { navigatable ->
                 navigatable?.navigate(true)
             }.submit(AppExecutorUtil.getAppExecutorService())
+    }
+
+    fun resolveNavigatable(
+        pointer: SmartPsiElementPointer<PsiElement>,
+        sourceOffset: Int?,
+    ): Navigatable? {
+        val element = pointer.element ?: return null
+        if (sourceOffset != null) {
+            val virtualFile = element.containingFile?.virtualFile
+            if (virtualFile != null) {
+                return OpenFileDescriptor(element.project, virtualFile, sourceOffset)
+            }
+        }
+        return (element as? Navigatable)?.takeIf { it.canNavigate() }
+            ?: (element.navigationElement as? Navigatable)?.takeIf { it.canNavigate() }
     }
 }

--- a/plugin-route-collectors/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaScalaTextSupportTest.kt
+++ b/plugin-route-collectors/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaScalaTextSupportTest.kt
@@ -2,6 +2,8 @@ package com.linecorp.intellij.plugins.armeria.explorer
 
 import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaScalaTextSupport
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ArmeriaScalaTextSupportTest {
@@ -25,7 +27,14 @@ class ArmeriaScalaTextSupportTest {
         assertEquals("service", match.methodName)
         assertEquals("/api", match.path)
         assertEquals("new HelloService()", match.targetText)
+        assertEquals(2, match.argumentCount)
         assertEquals("HelloService", ArmeriaScalaTextSupport.renderScalaTarget(match.targetText))
+        assertFalse(
+            ArmeriaScalaTextSupport.isUnresolvedScalaTarget(
+                match.targetText,
+                ArmeriaScalaTextSupport.renderScalaTarget(match.targetText),
+            ),
+        )
     }
 
     @Test
@@ -45,6 +54,7 @@ class ArmeriaScalaTextSupportTest {
         val match = matches.single()
         assertEquals("annotatedService", match.methodName)
         assertEquals("/prefix", match.path)
+        assertEquals(2, match.argumentCount)
         assertEquals("AnnotatedService", ArmeriaScalaTextSupport.renderScalaTarget(match.targetText))
     }
 
@@ -65,6 +75,27 @@ class ArmeriaScalaTextSupportTest {
         val match = matches.single()
         assertEquals("annotatedService", match.methodName)
         assertEquals("/", match.path)
+        assertEquals(1, match.argumentCount)
+    }
+
+    @Test
+    fun findAnnotatedServiceWithRootPathPrefixKeepsTwoArguments() {
+        val matches =
+            ArmeriaScalaTextSupport.findServiceRegistrations(
+                """
+                import com.linecorp.armeria.server.Server
+
+                Server.builder()
+                  .annotatedService("/", new AnnotatedService())
+                  .build()
+                """.trimIndent(),
+            )
+
+        assertEquals(1, matches.size)
+        val match = matches.single()
+        assertEquals("annotatedService", match.methodName)
+        assertEquals("/", match.path)
+        assertEquals(2, match.argumentCount)
     }
 
     @Test
@@ -108,21 +139,47 @@ class ArmeriaScalaTextSupportTest {
     }
 
     @Test
-    fun findWebClientEndpoint() {
-        val endpoints =
-            ArmeriaScalaTextSupport.findClientEndpoints(
+    fun findServiceUnderWithNamedArgumentsServiceFirst() {
+        val matches =
+            ArmeriaScalaTextSupport.findServiceRegistrations(
                 """
-                import com.linecorp.armeria.client.WebClient
+                import com.linecorp.armeria.server.Server
+
+                Server.builder()
+                  .serviceUnder(service = new HelloService(), pathPrefix = "/v1")
+                  .build()
+                """.trimIndent(),
+            )
+
+        assertEquals(1, matches.size)
+        val match = matches.single()
+        assertEquals("serviceUnder", match.methodName)
+        assertEquals("/v1", match.path)
+        assertEquals("HelloService", ArmeriaScalaTextSupport.renderScalaTarget(match.targetText))
+    }
+
+    @Test
+    fun ignoresRegistrationsInsideLineComments() {
+        val matches =
+            ArmeriaScalaTextSupport.findServiceRegistrations(
+                """
+                import com.linecorp.armeria.server.Server
 
                 object Main {
-                  val client = WebClient.of("https://example.com")
+                  Server.builder()
+                    // .service("/api", new HelloService())
+                    .build()
                 }
                 """.trimIndent(),
             )
 
-        assertEquals(1, endpoints.size)
-        val endpoint = endpoints.single()
-        assertEquals("WebClient", endpoint.clientSimpleName)
-        assertEquals("https://example.com", endpoint.uri)
+        assertTrue(matches.isEmpty())
+    }
+
+    @Test
+    fun bareIdentifierTargetIsUnresolved() {
+        assertTrue(ArmeriaScalaTextSupport.isUnresolvedScalaTarget("handler", "handler"))
+        assertFalse(ArmeriaScalaTextSupport.isUnresolvedScalaTarget("new HelloService()", "HelloService"))
+        assertFalse(ArmeriaScalaTextSupport.isUnresolvedScalaTarget("HelloService()", "HelloService"))
     }
 }

--- a/plugin-route-collectors/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaScalaTextSupportTest.kt
+++ b/plugin-route-collectors/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaScalaTextSupportTest.kt
@@ -1,0 +1,128 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaScalaTextSupport
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ArmeriaScalaTextSupportTest {
+    @Test
+    fun findServiceRegistrationFromBuilderChain() {
+        val matches =
+            ArmeriaScalaTextSupport.findServiceRegistrations(
+                """
+                import com.linecorp.armeria.server.Server
+
+                object Main {
+                  Server.builder()
+                    .service("/api", new HelloService())
+                    .build()
+                }
+                """.trimIndent(),
+            )
+
+        assertEquals(1, matches.size)
+        val match = matches.single()
+        assertEquals("service", match.methodName)
+        assertEquals("/api", match.path)
+        assertEquals("new HelloService()", match.targetText)
+        assertEquals("HelloService", ArmeriaScalaTextSupport.renderScalaTarget(match.targetText))
+    }
+
+    @Test
+    fun findAnnotatedServiceWithPathPrefix() {
+        val matches =
+            ArmeriaScalaTextSupport.findServiceRegistrations(
+                """
+                import com.linecorp.armeria.server.Server
+
+                Server.builder()
+                  .annotatedService("/prefix", new AnnotatedService())
+                  .build()
+                """.trimIndent(),
+            )
+
+        assertEquals(1, matches.size)
+        val match = matches.single()
+        assertEquals("annotatedService", match.methodName)
+        assertEquals("/prefix", match.path)
+        assertEquals("AnnotatedService", ArmeriaScalaTextSupport.renderScalaTarget(match.targetText))
+    }
+
+    @Test
+    fun findAnnotatedServiceWithoutPathPrefix() {
+        val matches =
+            ArmeriaScalaTextSupport.findServiceRegistrations(
+                """
+                import com.linecorp.armeria.server.Server
+
+                Server.builder()
+                  .annotatedService(new AnnotatedService())
+                  .build()
+                """.trimIndent(),
+            )
+
+        assertEquals(1, matches.size)
+        val match = matches.single()
+        assertEquals("annotatedService", match.methodName)
+        assertEquals("/", match.path)
+    }
+
+    @Test
+    fun findServiceUnderWithPositionalArguments() {
+        val matches =
+            ArmeriaScalaTextSupport.findServiceRegistrations(
+                """
+                import com.linecorp.armeria.server.Server
+
+                Server.builder()
+                  .serviceUnder("/api", new ApiService())
+                  .build()
+                """.trimIndent(),
+            )
+
+        assertEquals(1, matches.size)
+        val match = matches.single()
+        assertEquals("serviceUnder", match.methodName)
+        assertEquals("/api", match.path)
+        assertEquals("ApiService", ArmeriaScalaTextSupport.renderScalaTarget(match.targetText))
+    }
+
+    @Test
+    fun findServiceUnderWithNamedArguments() {
+        val matches =
+            ArmeriaScalaTextSupport.findServiceRegistrations(
+                """
+                import com.linecorp.armeria.server.Server
+
+                Server.builder()
+                  .serviceUnder(pathPrefix = "/v1", service = new HelloService())
+                  .build()
+                """.trimIndent(),
+            )
+
+        assertEquals(1, matches.size)
+        val match = matches.single()
+        assertEquals("serviceUnder", match.methodName)
+        assertEquals("/v1", match.path)
+        assertEquals("HelloService", ArmeriaScalaTextSupport.renderScalaTarget(match.targetText))
+    }
+
+    @Test
+    fun findWebClientEndpoint() {
+        val endpoints =
+            ArmeriaScalaTextSupport.findClientEndpoints(
+                """
+                import com.linecorp.armeria.client.WebClient
+
+                object Main {
+                  val client = WebClient.of("https://example.com")
+                }
+                """.trimIndent(),
+            )
+
+        assertEquals(1, endpoints.size)
+        val endpoint = endpoints.single()
+        assertEquals("WebClient", endpoint.clientSimpleName)
+        assertEquals("https://example.com", endpoint.uri)
+    }
+}

--- a/plugin-route-collectors/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaScalaTextSupportTest.kt
+++ b/plugin-route-collectors/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaScalaTextSupportTest.kt
@@ -177,6 +177,50 @@ class ArmeriaScalaTextSupportTest {
     }
 
     @Test
+    fun keepsRegistrationWhenCommentMarkersAppearInsideStrings() {
+        val matches =
+            ArmeriaScalaTextSupport.findServiceRegistrations(
+                """
+                import com.linecorp.armeria.server.Server
+
+                object Main {
+                  val marker = "/*"
+                  Server.builder()
+                    .service("/api", new HelloService())
+                    .build()
+                  val end = "*/"
+                }
+                """.trimIndent(),
+            )
+
+        assertEquals(1, matches.size)
+        assertEquals("/api", matches.single().path)
+    }
+
+    @Test
+    fun keepsRegistrationWhenCommentMarkersAppearInsideTripleQuotedStrings() {
+        val matches =
+            ArmeriaScalaTextSupport.findServiceRegistrations(
+                """
+                import com.linecorp.armeria.server.Server
+
+                object Main {
+                  val docs = ${"\"\"\""}
+                    // not a real comment
+                    /* also not */
+                  ${"\"\"\""}
+                  Server.builder()
+                    .service("/api", new HelloService())
+                    .build()
+                }
+                """.trimIndent(),
+            )
+
+        assertEquals(1, matches.size)
+        assertEquals("/api", matches.single().path)
+    }
+
+    @Test
     fun bareIdentifierTargetIsUnresolved() {
         assertTrue(ArmeriaScalaTextSupport.isUnresolvedScalaTarget("handler", "handler"))
         assertFalse(ArmeriaScalaTextSupport.isUnresolvedScalaTarget("new HelloService()", "HelloService"))

--- a/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/collector/ArmeriaRouteCollector.kt
+++ b/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/collector/ArmeriaRouteCollector.kt
@@ -124,6 +124,14 @@ object ArmeriaRouteCollector {
             )
         }
 
+        ArmeriaScalaRouteCollector.collectServiceRegistrationsFallback(
+            project,
+            scope,
+            routes,
+            fallbackScannedFiles,
+            seenServiceRegistrations,
+        )
+
         collectExtendedRegistrations(project, scope, routes, seenServiceRegistrations, fallbackScannedFiles)
 
         for (contributor in contributors) {

--- a/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/collector/ArmeriaRouteCollectorServiceRegistration.kt
+++ b/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/collector/ArmeriaRouteCollectorServiceRegistration.kt
@@ -151,6 +151,7 @@ object ArmeriaRouteCollectorServiceRegistration {
         routes: MutableList<ArmeriaRoute>,
         seenServiceRegistrations: MutableSet<String>,
         decorators: List<String>? = null,
+        sourceOffset: Int? = null,
     ): Boolean {
         if (!seenServiceRegistrations.add(registrationKey)) {
             return false
@@ -183,6 +184,7 @@ object ArmeriaRouteCollectorServiceRegistration {
                 decorators = programmaticDecorators,
                 timeoutHints = timeoutHints,
                 delegationKind = delegationKind,
+                sourceOffset = sourceOffset,
             )
         return true
     }

--- a/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/collector/ArmeriaScalaRouteCollector.kt
+++ b/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/collector/ArmeriaScalaRouteCollector.kt
@@ -8,6 +8,7 @@ import com.intellij.psi.search.FilenameIndex
 import com.intellij.psi.search.GlobalSearchScope
 import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
 import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaRouteCollectionMetrics
+import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaRouteSupport
 import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaScalaTextSupport
 
 internal object ArmeriaScalaRouteCollector {
@@ -25,7 +26,7 @@ internal object ArmeriaScalaRouteCollector {
             ArmeriaRouteCollectionMetrics.current()?.filesScanned?.incrementAndGet()
             val psiFile = PsiManager.getInstance(project).findFile(virtualFile) ?: continue
             val contents = psiFile.text
-            if (!ArmeriaScalaTextSupport.referencesArmeriaScalaContent(contents)) {
+            if (!ArmeriaRouteSupport.referencesArmeriaSourceContent(contents)) {
                 continue
             }
             fallbackScannedFiles += virtualFile
@@ -55,6 +56,7 @@ internal object ArmeriaScalaRouteCollector {
                 argumentCount = match.argumentCount,
                 routes = routes,
                 seenServiceRegistrations = seenServiceRegistrations,
+                sourceOffset = match.startOffset,
             )
         }
     }

--- a/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/collector/ArmeriaScalaRouteCollector.kt
+++ b/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/collector/ArmeriaScalaRouteCollector.kt
@@ -52,7 +52,7 @@ internal object ArmeriaScalaRouteCollector {
                 target = target,
                 targetUnresolved = targetUnresolved,
                 implementationText = match.targetText,
-                argumentCount = if (match.methodName == "annotatedService" && match.path == "/") 1 else 2,
+                argumentCount = match.argumentCount,
                 routes = routes,
                 seenServiceRegistrations = seenServiceRegistrations,
             )

--- a/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/collector/ArmeriaScalaRouteCollector.kt
+++ b/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/collector/ArmeriaScalaRouteCollector.kt
@@ -1,0 +1,61 @@
+package com.linecorp.intellij.plugins.armeria.explorer.collector
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
+import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaRouteCollectionMetrics
+import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaScalaTextSupport
+
+internal object ArmeriaScalaRouteCollector {
+    fun collectServiceRegistrationsFallback(
+        project: Project,
+        scope: GlobalSearchScope,
+        routes: MutableList<ArmeriaRoute>,
+        fallbackScannedFiles: MutableSet<VirtualFile>,
+        seenServiceRegistrations: MutableSet<String>,
+    ) {
+        for (virtualFile in FilenameIndex.getAllFilesByExt(project, "scala", scope)) {
+            if (virtualFile in fallbackScannedFiles) {
+                continue
+            }
+            ArmeriaRouteCollectionMetrics.current()?.filesScanned?.incrementAndGet()
+            val psiFile = PsiManager.getInstance(project).findFile(virtualFile) ?: continue
+            val contents = psiFile.text
+            if (!ArmeriaScalaTextSupport.referencesArmeriaScalaContent(contents)) {
+                continue
+            }
+            fallbackScannedFiles += virtualFile
+            ArmeriaRouteCollectionMetrics.current()?.armeriaFiles?.incrementAndGet()
+            collectServiceRegistrationsFromFile(psiFile, contents, routes, seenServiceRegistrations)
+        }
+    }
+
+    private fun collectServiceRegistrationsFromFile(
+        file: PsiFile,
+        contents: String,
+        routes: MutableList<ArmeriaRoute>,
+        seenServiceRegistrations: MutableSet<String>,
+    ) {
+        for (match in ArmeriaScalaTextSupport.findServiceRegistrations(contents)) {
+            val element = file.findElementAt(match.startOffset) ?: file
+            val target = ArmeriaScalaTextSupport.renderScalaTarget(match.targetText)
+            val targetUnresolved = ArmeriaScalaTextSupport.isUnresolvedScalaTarget(match.targetText, target)
+            ArmeriaRouteCollectorServiceRegistration.addServiceRegistrationRoute(
+                element = element,
+                registrationKey = "${file.virtualFile?.path}:${match.startOffset}",
+                methodName = match.methodName,
+                path = match.path,
+                target = target,
+                targetUnresolved = targetUnresolved,
+                implementationText = match.targetText,
+                argumentCount = if (match.methodName == "annotatedService" && match.path == "/") 1 else 2,
+                routes = routes,
+                seenServiceRegistrations = seenServiceRegistrations,
+            )
+        }
+    }
+}

--- a/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaRouteContentScan.kt
+++ b/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaRouteContentScan.kt
@@ -31,8 +31,6 @@ internal object ArmeriaRouteContentScan {
         return referencesArmeriaInText(contents)
     }
 
-    fun referencesArmeriaKotlinContentInText(contents: CharSequence): Boolean = referencesArmeriaSourceContent(contents)
-
     fun mayReferenceSpringBootArmeriaInText(contents: CharSequence): Boolean {
         if (referencesArmeriaSourceContent(contents)) {
             return true

--- a/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaRouteContentScan.kt
+++ b/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaRouteContentScan.kt
@@ -23,7 +23,7 @@ internal object ArmeriaRouteContentScan {
         return ARMERIA_REFERENCE_PATTERN.containsMatchIn(searchWindow)
     }
 
-    fun referencesArmeriaKotlinContentInText(contents: CharSequence): Boolean {
+    fun referencesArmeriaSourceContent(contents: CharSequence): Boolean {
         val header = contents.subSequence(0, minOf(contents.length, ArmeriaRouteSupport.ARMERIA_HEADER_SCAN_LIMIT))
         if (header.contains("import ${ArmeriaRouteSupport.ARMERIA_PACKAGE_PREFIX}")) {
             return true
@@ -31,8 +31,10 @@ internal object ArmeriaRouteContentScan {
         return referencesArmeriaInText(contents)
     }
 
+    fun referencesArmeriaKotlinContentInText(contents: CharSequence): Boolean = referencesArmeriaSourceContent(contents)
+
     fun mayReferenceSpringBootArmeriaInText(contents: CharSequence): Boolean {
-        if (referencesArmeriaKotlinContentInText(contents)) {
+        if (referencesArmeriaSourceContent(contents)) {
             return true
         }
         val header = contents.subSequence(0, minOf(contents.length, ArmeriaRouteSupport.ARMERIA_HEADER_SCAN_LIMIT))

--- a/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaRouteSupport.kt
+++ b/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaRouteSupport.kt
@@ -213,8 +213,10 @@ object ArmeriaRouteSupport {
         return referencesArmeriaInText(file.viewProvider.contents)
     }
 
-    fun referencesArmeriaKotlinContentInText(contents: CharSequence): Boolean =
-        ArmeriaRouteContentScan.referencesArmeriaKotlinContentInText(contents)
+    fun referencesArmeriaSourceContent(contents: CharSequence): Boolean =
+        ArmeriaRouteContentScan.referencesArmeriaSourceContent(contents)
+
+    fun referencesArmeriaKotlinContentInText(contents: CharSequence): Boolean = referencesArmeriaSourceContent(contents)
 
     fun mayReferenceSpringBootArmeriaInText(contents: CharSequence): Boolean =
         ArmeriaRouteContentScan.mayReferenceSpringBootArmeriaInText(contents)

--- a/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaRouteSupport.kt
+++ b/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaRouteSupport.kt
@@ -215,8 +215,6 @@ object ArmeriaRouteSupport {
 
     fun referencesArmeriaSourceContent(contents: CharSequence): Boolean = ArmeriaRouteContentScan.referencesArmeriaSourceContent(contents)
 
-    fun referencesArmeriaKotlinContentInText(contents: CharSequence): Boolean = referencesArmeriaSourceContent(contents)
-
     fun mayReferenceSpringBootArmeriaInText(contents: CharSequence): Boolean =
         ArmeriaRouteContentScan.mayReferenceSpringBootArmeriaInText(contents)
 

--- a/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaRouteSupport.kt
+++ b/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaRouteSupport.kt
@@ -213,8 +213,7 @@ object ArmeriaRouteSupport {
         return referencesArmeriaInText(file.viewProvider.contents)
     }
 
-    fun referencesArmeriaSourceContent(contents: CharSequence): Boolean =
-        ArmeriaRouteContentScan.referencesArmeriaSourceContent(contents)
+    fun referencesArmeriaSourceContent(contents: CharSequence): Boolean = ArmeriaRouteContentScan.referencesArmeriaSourceContent(contents)
 
     fun referencesArmeriaKotlinContentInText(contents: CharSequence): Boolean = referencesArmeriaSourceContent(contents)
 

--- a/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaScalaTextSupport.kt
+++ b/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaScalaTextSupport.kt
@@ -30,8 +30,7 @@ object ArmeriaScalaTextSupport {
         val argumentCount: Int,
     )
 
-    private fun pathFirst(method: String): Regex =
-        Regex("""\.$method\s*\(\s*"([^"]+)"\s*,\s*($TARGET)\s*\)""")
+    private fun pathFirst(method: String): Regex = Regex("""\.$method\s*\(\s*"([^"]+)"\s*,\s*($TARGET)\s*\)""")
 
     private val RULES =
         listOf(
@@ -85,8 +84,7 @@ object ArmeriaScalaTextSupport {
             ),
         )
 
-    fun referencesArmeriaScalaContent(contents: CharSequence): Boolean =
-        ArmeriaRouteSupport.referencesArmeriaSourceContent(contents)
+    fun referencesArmeriaScalaContent(contents: CharSequence): Boolean = ArmeriaRouteSupport.referencesArmeriaSourceContent(contents)
 
     fun findServiceRegistrations(text: String): List<ScalaServiceRegistrationMatch> {
         val scanText = stripScalaComments(text)

--- a/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaScalaTextSupport.kt
+++ b/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaScalaTextSupport.kt
@@ -5,127 +5,107 @@ data class ScalaServiceRegistrationMatch(
     val path: String,
     val targetText: String,
     val startOffset: Int,
+    val argumentCount: Int,
 )
 
-data class ScalaClientEndpointMatch(
-    val clientSimpleName: String,
-    val uri: String,
-    val startOffset: Int,
-)
-
+/**
+ * Text-based Scala route scanning uses regex over source text (no Scala PSI).
+ *
+ * Supported shapes:
+ * - `.service("/path", new Handler())` / `.service("/path", Handler())`
+ * - `.serviceUnder("/prefix", …)` and named `pathPrefix` / `service` argument orders
+ * - `.annotatedService(…)` with optional path prefix
+ *
+ * Non-literal path expressions and dynamic prefixes are not matched.
+ * Line/block comments are blanked before matching to avoid phantom routes.
+ */
 object ArmeriaScalaTextSupport {
-    /**
-     * Text-based Scala route scanning uses regex over source text (no Scala PSI).
-     *
-     * Supported `serviceUnder` shapes:
-     * - `.serviceUnder("/prefix", new Handler())` and `.serviceUnder("/prefix", Handler())`
-     * - `.serviceUnder(pathPrefix = "/prefix", service = new Handler())`
-     *
-     * Non-literal path expressions, multiline argument lists, and dynamic prefixes are not matched.
-     */
-    private val SERVICE_PATTERN =
-        Regex("""\.service\s*\(\s*"([^"]+)"\s*,\s*((?:new\s+)?[\w.]+(?:\([^)]*\))?)\s*\)""")
-    private val SERVICE_UNDER_PATTERN =
-        Regex("""\.serviceUnder\s*\(\s*"([^"]+)"\s*,\s*((?:new\s+)?[\w.]+(?:\([^)]*\))?)\s*\)""")
-    private val SERVICE_UNDER_NAMED_PREFIX_FIRST_PATTERN =
-        Regex(
-            """\.serviceUnder\s*\(\s*pathPrefix\s*=\s*"([^"]+)"\s*,\s*service\s*=\s*((?:new\s+)?[\w.]+(?:\([^)]*\))?)\s*\)""",
-        )
-    private val SERVICE_UNDER_NAMED_SERVICE_FIRST_PATTERN =
-        Regex(
-            """\.serviceUnder\s*\(\s*service\s*=\s*((?:new\s+)?[\w.]+(?:\([^)]*\))?)\s*,\s*pathPrefix\s*=\s*"([^"]+)"\s*\)""",
-        )
-    private val ANNOTATED_SERVICE_WITH_PREFIX_PATTERN =
-        Regex("""\.annotatedService\s*\(\s*"([^"]+)"\s*,\s*((?:new\s+)?[\w.]+(?:\([^)]*\))?)\s*\)""")
-    private val ANNOTATED_SERVICE_PATTERN =
-        Regex("""\.annotatedService\s*\(\s*((?:new\s+)?[\w.]+(?:\([^)]*\))?)\s*\)""")
-    private val CLIENT_ENDPOINT_PATTERN =
-        Regex(
-            """\b(WebClient|GrpcClient|GrpcClients|ThriftClient|ThriftClients)\s*\.\s*(?:of|builder|newClient)\s*\(\s*"([^"]+)"\s*\)""",
+    private const val TARGET = """(?:new\s+)?[\w.]+(?:\([^)]*\))?"""
+
+    private data class RegistrationRule(
+        val methodName: String,
+        val pattern: Regex,
+        val path: (MatchResult) -> String,
+        val target: (MatchResult) -> String,
+        val argumentCount: Int,
+    )
+
+    private fun pathFirst(method: String): Regex =
+        Regex("""\.$method\s*\(\s*"([^"]+)"\s*,\s*($TARGET)\s*\)""")
+
+    private val RULES =
+        listOf(
+            RegistrationRule(
+                methodName = "service",
+                pattern = pathFirst("service"),
+                path = { it.groupValues[1] },
+                target = { it.groupValues[2] },
+                argumentCount = 2,
+            ),
+            RegistrationRule(
+                methodName = "serviceUnder",
+                pattern = pathFirst("serviceUnder"),
+                path = { it.groupValues[1] },
+                target = { it.groupValues[2] },
+                argumentCount = 2,
+            ),
+            RegistrationRule(
+                methodName = "serviceUnder",
+                pattern =
+                    Regex(
+                        """\.serviceUnder\s*\(\s*pathPrefix\s*=\s*"([^"]+)"\s*,\s*service\s*=\s*($TARGET)\s*\)""",
+                    ),
+                path = { it.groupValues[1] },
+                target = { it.groupValues[2] },
+                argumentCount = 2,
+            ),
+            RegistrationRule(
+                methodName = "serviceUnder",
+                pattern =
+                    Regex(
+                        """\.serviceUnder\s*\(\s*service\s*=\s*($TARGET)\s*,\s*pathPrefix\s*=\s*"([^"]+)"\s*\)""",
+                    ),
+                path = { it.groupValues[2] },
+                target = { it.groupValues[1] },
+                argumentCount = 2,
+            ),
+            RegistrationRule(
+                methodName = "annotatedService",
+                pattern = pathFirst("annotatedService"),
+                path = { it.groupValues[1] },
+                target = { it.groupValues[2] },
+                argumentCount = 2,
+            ),
+            RegistrationRule(
+                methodName = "annotatedService",
+                pattern = Regex("""\.annotatedService\s*\(\s*($TARGET)\s*\)"""),
+                path = { "/" },
+                target = { it.groupValues[1] },
+                argumentCount = 1,
+            ),
         )
 
-    fun referencesArmeriaScalaContent(contents: CharSequence): Boolean {
-        val header = contents.subSequence(0, minOf(contents.length, ArmeriaRouteSupport.ARMERIA_HEADER_SCAN_LIMIT))
-        if (header.contains("import com.linecorp.armeria")) {
-            return true
-        }
-        return ArmeriaRouteSupport.referencesArmeriaInText(contents)
-    }
-
-    fun looksLikeServerBuilderScalaFile(contents: CharSequence): Boolean {
-        val text = contents.toString()
-        return ArmeriaRouteSupport.referencesArmeriaApplicationInSource(contents) ||
-            ArmeriaRouteSupport.looksLikeServerBuilderReceiverText(text)
-    }
+    fun referencesArmeriaScalaContent(contents: CharSequence): Boolean =
+        ArmeriaRouteSupport.referencesArmeriaSourceContent(contents)
 
     fun findServiceRegistrations(text: String): List<ScalaServiceRegistrationMatch> {
-        if (!looksLikeServerBuilderScalaFile(text)) {
+        val scanText = stripScalaComments(text)
+        if (!looksLikeServerBuilderScalaFile(scanText)) {
             return emptyList()
         }
-        val matches = mutableListOf<ScalaServiceRegistrationMatch>()
-        collectPatternMatches(text, SERVICE_PATTERN, "service", matches) { groups ->
-            groups[1] to groups[2]
-        }
-        collectPatternMatches(text, SERVICE_UNDER_PATTERN, "serviceUnder", matches) { groups ->
-            groups[1] to groups[2]
-        }
-        collectPatternMatches(text, SERVICE_UNDER_NAMED_PREFIX_FIRST_PATTERN, "serviceUnder", matches) { groups ->
-            groups[1] to groups[2]
-        }
-        for (match in SERVICE_UNDER_NAMED_SERVICE_FIRST_PATTERN.findAll(text)) {
-            val target = match.groupValues[1].trim()
-            val path = match.groupValues[2]
-            val overlapping =
-                matches.any { existing ->
-                    existing.startOffset in match.range.first..match.range.last
+        return RULES
+            .flatMap { rule ->
+                rule.pattern.findAll(scanText).map { match ->
+                    ScalaServiceRegistrationMatch(
+                        methodName = rule.methodName,
+                        path = rule.path(match),
+                        targetText = rule.target(match).trim(),
+                        startOffset = match.range.first,
+                        argumentCount = rule.argumentCount,
+                    )
                 }
-            if (overlapping) {
-                continue
-            }
-            matches +=
-                ScalaServiceRegistrationMatch(
-                    methodName = "serviceUnder",
-                    path = path,
-                    targetText = target,
-                    startOffset = match.range.first,
-                )
-        }
-        collectPatternMatches(text, ANNOTATED_SERVICE_WITH_PREFIX_PATTERN, "annotatedService", matches) { groups ->
-            groups[1] to groups[2]
-        }
-        for (match in ANNOTATED_SERVICE_PATTERN.findAll(text)) {
-            val serviceText = match.groupValues[1].trim()
-            if (serviceText.startsWith("\"")) {
-                continue
-            }
-            val overlapping =
-                matches.any { existing ->
-                    existing.startOffset in match.range.first..match.range.last
-                }
-            if (overlapping) {
-                continue
-            }
-            matches +=
-                ScalaServiceRegistrationMatch(
-                    methodName = "annotatedService",
-                    path = "/",
-                    targetText = serviceText,
-                    startOffset = match.range.first,
-                )
-        }
-        return matches.sortedBy { it.startOffset }
+            }.sortedBy { it.startOffset }
     }
-
-    fun findClientEndpoints(text: String): List<ScalaClientEndpointMatch> =
-        CLIENT_ENDPOINT_PATTERN
-            .findAll(text)
-            .map { match ->
-                ScalaClientEndpointMatch(
-                    clientSimpleName = match.groupValues[1],
-                    uri = match.groupValues[2],
-                    startOffset = match.range.first,
-                )
-            }.toList()
 
     fun renderScalaTarget(targetText: String): String {
         val trimmed = targetText.trim()
@@ -134,31 +114,57 @@ object ArmeriaScalaTextSupport {
         return withoutParens.substringAfterLast('.').ifBlank { withoutParens }
     }
 
+    /**
+     * Without Scala PSI resolution, a target is unresolved only when rendering could not
+     * improve past the raw expression text (e.g. a bare identifier `handler`).
+     * Constructor forms like `new HelloService()` successfully yield a class simple name
+     * and are treated as resolved best-effort.
+     */
     fun isUnresolvedScalaTarget(
         targetText: String,
         renderedTarget: String,
-    ): Boolean {
-        val trimmed = targetText.trim()
-        return renderedTarget == trimmed ||
-            renderedTarget == trimmed.removePrefix("new ").substringBefore('(').trim()
-    }
+    ): Boolean = renderedTarget == targetText.trim()
 
-    private inline fun collectPatternMatches(
-        text: String,
-        pattern: Regex,
-        methodName: String,
-        matches: MutableList<ScalaServiceRegistrationMatch>,
-        pathAndTarget: (List<String>) -> Pair<String, String>,
-    ) {
-        for (match in pattern.findAll(text)) {
-            val (path, target) = pathAndTarget(match.groupValues)
-            matches +=
-                ScalaServiceRegistrationMatch(
-                    methodName = methodName,
-                    path = path,
-                    targetText = target.trim(),
-                    startOffset = match.range.first,
-                )
+    private fun looksLikeServerBuilderScalaFile(contents: CharSequence): Boolean =
+        ArmeriaRouteSupport.referencesArmeriaApplicationInSource(contents) ||
+            ArmeriaRouteSupport.looksLikeServerBuilderReceiverText(contents.toString())
+
+    /**
+     * Best-effort comment blanking for text scanning. Replaces comment text with spaces so
+     * match offsets stay aligned with the original source for PSI navigation.
+     * Strings that contain comment-like sequences may be altered; that only affects discovery
+     * accuracy, not compilation.
+     */
+    fun stripScalaComments(text: String): String {
+        val chars = text.toCharArray()
+        var i = 0
+        while (i < chars.size) {
+            if (i + 1 < chars.size && chars[i] == '/' && chars[i + 1] == '*') {
+                chars[i] = ' '
+                chars[i + 1] = ' '
+                i += 2
+                while (i + 1 < chars.size && !(chars[i] == '*' && chars[i + 1] == '/')) {
+                    if (chars[i] != '\n') {
+                        chars[i] = ' '
+                    }
+                    i++
+                }
+                if (i + 1 < chars.size) {
+                    chars[i] = ' '
+                    chars[i + 1] = ' '
+                    i += 2
+                }
+                continue
+            }
+            if (i + 1 < chars.size && chars[i] == '/' && chars[i + 1] == '/') {
+                while (i < chars.size && chars[i] != '\n') {
+                    chars[i] = ' '
+                    i++
+                }
+                continue
+            }
+            i++
         }
+        return String(chars)
     }
 }

--- a/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaScalaTextSupport.kt
+++ b/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaScalaTextSupport.kt
@@ -1,0 +1,164 @@
+package com.linecorp.intellij.plugins.armeria.explorer.support
+
+data class ScalaServiceRegistrationMatch(
+    val methodName: String,
+    val path: String,
+    val targetText: String,
+    val startOffset: Int,
+)
+
+data class ScalaClientEndpointMatch(
+    val clientSimpleName: String,
+    val uri: String,
+    val startOffset: Int,
+)
+
+object ArmeriaScalaTextSupport {
+    /**
+     * Text-based Scala route scanning uses regex over source text (no Scala PSI).
+     *
+     * Supported `serviceUnder` shapes:
+     * - `.serviceUnder("/prefix", new Handler())` and `.serviceUnder("/prefix", Handler())`
+     * - `.serviceUnder(pathPrefix = "/prefix", service = new Handler())`
+     *
+     * Non-literal path expressions, multiline argument lists, and dynamic prefixes are not matched.
+     */
+    private val SERVICE_PATTERN =
+        Regex("""\.service\s*\(\s*"([^"]+)"\s*,\s*((?:new\s+)?[\w.]+(?:\([^)]*\))?)\s*\)""")
+    private val SERVICE_UNDER_PATTERN =
+        Regex("""\.serviceUnder\s*\(\s*"([^"]+)"\s*,\s*((?:new\s+)?[\w.]+(?:\([^)]*\))?)\s*\)""")
+    private val SERVICE_UNDER_NAMED_PREFIX_FIRST_PATTERN =
+        Regex(
+            """\.serviceUnder\s*\(\s*pathPrefix\s*=\s*"([^"]+)"\s*,\s*service\s*=\s*((?:new\s+)?[\w.]+(?:\([^)]*\))?)\s*\)""",
+        )
+    private val SERVICE_UNDER_NAMED_SERVICE_FIRST_PATTERN =
+        Regex(
+            """\.serviceUnder\s*\(\s*service\s*=\s*((?:new\s+)?[\w.]+(?:\([^)]*\))?)\s*,\s*pathPrefix\s*=\s*"([^"]+)"\s*\)""",
+        )
+    private val ANNOTATED_SERVICE_WITH_PREFIX_PATTERN =
+        Regex("""\.annotatedService\s*\(\s*"([^"]+)"\s*,\s*((?:new\s+)?[\w.]+(?:\([^)]*\))?)\s*\)""")
+    private val ANNOTATED_SERVICE_PATTERN =
+        Regex("""\.annotatedService\s*\(\s*((?:new\s+)?[\w.]+(?:\([^)]*\))?)\s*\)""")
+    private val CLIENT_ENDPOINT_PATTERN =
+        Regex(
+            """\b(WebClient|GrpcClient|GrpcClients|ThriftClient|ThriftClients)\s*\.\s*(?:of|builder|newClient)\s*\(\s*"([^"]+)"\s*\)""",
+        )
+
+    fun referencesArmeriaScalaContent(contents: CharSequence): Boolean {
+        val header = contents.subSequence(0, minOf(contents.length, ArmeriaRouteSupport.ARMERIA_HEADER_SCAN_LIMIT))
+        if (header.contains("import com.linecorp.armeria")) {
+            return true
+        }
+        return ArmeriaRouteSupport.referencesArmeriaInText(contents)
+    }
+
+    fun looksLikeServerBuilderScalaFile(contents: CharSequence): Boolean {
+        val text = contents.toString()
+        return ArmeriaRouteSupport.referencesArmeriaApplicationInSource(contents) ||
+            ArmeriaRouteSupport.looksLikeServerBuilderReceiverText(text)
+    }
+
+    fun findServiceRegistrations(text: String): List<ScalaServiceRegistrationMatch> {
+        if (!looksLikeServerBuilderScalaFile(text)) {
+            return emptyList()
+        }
+        val matches = mutableListOf<ScalaServiceRegistrationMatch>()
+        collectPatternMatches(text, SERVICE_PATTERN, "service", matches) { groups ->
+            groups[1] to groups[2]
+        }
+        collectPatternMatches(text, SERVICE_UNDER_PATTERN, "serviceUnder", matches) { groups ->
+            groups[1] to groups[2]
+        }
+        collectPatternMatches(text, SERVICE_UNDER_NAMED_PREFIX_FIRST_PATTERN, "serviceUnder", matches) { groups ->
+            groups[1] to groups[2]
+        }
+        for (match in SERVICE_UNDER_NAMED_SERVICE_FIRST_PATTERN.findAll(text)) {
+            val target = match.groupValues[1].trim()
+            val path = match.groupValues[2]
+            val overlapping =
+                matches.any { existing ->
+                    existing.startOffset in match.range.first..match.range.last
+                }
+            if (overlapping) {
+                continue
+            }
+            matches +=
+                ScalaServiceRegistrationMatch(
+                    methodName = "serviceUnder",
+                    path = path,
+                    targetText = target,
+                    startOffset = match.range.first,
+                )
+        }
+        collectPatternMatches(text, ANNOTATED_SERVICE_WITH_PREFIX_PATTERN, "annotatedService", matches) { groups ->
+            groups[1] to groups[2]
+        }
+        for (match in ANNOTATED_SERVICE_PATTERN.findAll(text)) {
+            val serviceText = match.groupValues[1].trim()
+            if (serviceText.startsWith("\"")) {
+                continue
+            }
+            val overlapping =
+                matches.any { existing ->
+                    existing.startOffset in match.range.first..match.range.last
+                }
+            if (overlapping) {
+                continue
+            }
+            matches +=
+                ScalaServiceRegistrationMatch(
+                    methodName = "annotatedService",
+                    path = "/",
+                    targetText = serviceText,
+                    startOffset = match.range.first,
+                )
+        }
+        return matches.sortedBy { it.startOffset }
+    }
+
+    fun findClientEndpoints(text: String): List<ScalaClientEndpointMatch> =
+        CLIENT_ENDPOINT_PATTERN
+            .findAll(text)
+            .map { match ->
+                ScalaClientEndpointMatch(
+                    clientSimpleName = match.groupValues[1],
+                    uri = match.groupValues[2],
+                    startOffset = match.range.first,
+                )
+            }.toList()
+
+    fun renderScalaTarget(targetText: String): String {
+        val trimmed = targetText.trim()
+        val withoutNew = trimmed.removePrefix("new ").trim()
+        val withoutParens = withoutNew.substringBefore('(').trim()
+        return withoutParens.substringAfterLast('.').ifBlank { withoutParens }
+    }
+
+    fun isUnresolvedScalaTarget(
+        targetText: String,
+        renderedTarget: String,
+    ): Boolean {
+        val trimmed = targetText.trim()
+        return renderedTarget == trimmed ||
+            renderedTarget == trimmed.removePrefix("new ").substringBefore('(').trim()
+    }
+
+    private inline fun collectPatternMatches(
+        text: String,
+        pattern: Regex,
+        methodName: String,
+        matches: MutableList<ScalaServiceRegistrationMatch>,
+        pathAndTarget: (List<String>) -> Pair<String, String>,
+    ) {
+        for (match in pattern.findAll(text)) {
+            val (path, target) = pathAndTarget(match.groupValues)
+            matches +=
+                ScalaServiceRegistrationMatch(
+                    methodName = methodName,
+                    path = path,
+                    targetText = target.trim(),
+                    startOffset = match.range.first,
+                )
+        }
+    }
+}

--- a/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaScalaTextSupport.kt
+++ b/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaScalaTextSupport.kt
@@ -16,8 +16,11 @@ data class ScalaServiceRegistrationMatch(
  * - `.serviceUnder("/prefix", …)` and named `pathPrefix` / `service` argument orders
  * - `.annotatedService(…)` with optional path prefix
  *
- * Non-literal path expressions and dynamic prefixes are not matched.
- * Line/block comments are blanked before matching to avoid phantom routes.
+ * Paths must be string literals; non-literal / dynamic path expressions are not matched.
+ * Targets may be constructor forms or bare identifiers (the latter are marked unresolved).
+ * Line/block comments are blanked before matching to avoid phantom routes; string literals
+ * (including Scala triple-quoted strings) are preserved so comment markers inside them do
+ * not blank following code.
  */
 object ArmeriaScalaTextSupport {
     private const val TARGET = """(?:new\s+)?[\w.]+(?:\([^)]*\))?"""
@@ -84,8 +87,6 @@ object ArmeriaScalaTextSupport {
             ),
         )
 
-    fun referencesArmeriaScalaContent(contents: CharSequence): Boolean = ArmeriaRouteSupport.referencesArmeriaSourceContent(contents)
-
     fun findServiceRegistrations(text: String): List<ScalaServiceRegistrationMatch> {
         val scanText = stripScalaComments(text)
         if (!looksLikeServerBuilderScalaFile(scanText)) {
@@ -129,14 +130,38 @@ object ArmeriaScalaTextSupport {
 
     /**
      * Best-effort comment blanking for text scanning. Replaces comment text with spaces so
-     * match offsets stay aligned with the original source for PSI navigation.
-     * Strings that contain comment-like sequences may be altered; that only affects discovery
-     * accuracy, not compilation.
+     * match offsets stay aligned with the original source for navigation.
+     * Skips contents of `"…"` and `"""…"""` string literals (including escaped quotes in
+     * single-quoted strings). Nested block comments are not supported.
      */
     fun stripScalaComments(text: String): String {
         val chars = text.toCharArray()
         var i = 0
         while (i < chars.size) {
+            if (i + 2 < chars.size && chars[i] == '"' && chars[i + 1] == '"' && chars[i + 2] == '"') {
+                i += 3
+                while (i + 2 < chars.size && !(chars[i] == '"' && chars[i + 1] == '"' && chars[i + 2] == '"')) {
+                    i++
+                }
+                if (i + 2 < chars.size) {
+                    i += 3
+                }
+                continue
+            }
+            if (chars[i] == '"') {
+                i++
+                while (i < chars.size && chars[i] != '"') {
+                    if (chars[i] == '\\' && i + 1 < chars.size) {
+                        i += 2
+                    } else {
+                        i++
+                    }
+                }
+                if (i < chars.size) {
+                    i++
+                }
+                continue
+            }
             if (i + 1 < chars.size && chars[i] == '/' && chars[i + 1] == '*') {
                 chars[i] = ' '
                 chars[i + 1] = ' '

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaScalaRouteCollectorTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaScalaRouteCollectorTest.kt
@@ -79,7 +79,7 @@ class ArmeriaScalaRouteCollectorTest : ArmeriaFixtureTestBase() {
         val byPath = serviceRoutes.associateBy { it.path }
         assertEquals("HelloService", byPath.getValue("/api").target)
         assertEquals("AdminService", byPath.getValue("/admin").target)
-        assertNotEquals(byPath.getValue("/api").sourceOffset, byPath.getValue("/admin").sourceOffset)
+        assertFalse(byPath.getValue("/api").sourceOffset == byPath.getValue("/admin").sourceOffset)
     }
 
     fun testCollectAnnotatedServiceRegistrationFromScala() {

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaScalaRouteCollectorTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaScalaRouteCollectorTest.kt
@@ -35,6 +35,51 @@ class ArmeriaScalaRouteCollectorTest : ArmeriaFixtureTestBase() {
         assertNotNull(serviceRoute)
         assertEquals("HelloService", serviceRoute!!.target)
         assertFalse(serviceRoute.targetUnresolved)
+        assertNotNull(serviceRoute.sourceOffset)
+        assertTrue(serviceRoute.sourceOffset!! > 0)
+        assertFalse(serviceRoute.resolveSourceHint().endsWith(":1"))
+    }
+
+    fun testCollectMultipleServiceRegistrationsFromSameScalaFile() {
+        myFixture.configureByText(
+            "Main.scala",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            object Main {
+              Server.builder()
+                .service("/api", new HelloService())
+                .service("/admin", new AdminService())
+                .build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class AdminService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+        val serviceRoutes = routes.filter { it.routeMatch == RouteMatch.SERVICE }
+        assertEquals(2, serviceRoutes.size)
+        val byPath = serviceRoutes.associateBy { it.path }
+        assertEquals("HelloService", byPath.getValue("/api").target)
+        assertEquals("AdminService", byPath.getValue("/admin").target)
+        assertNotEquals(byPath.getValue("/api").sourceOffset, byPath.getValue("/admin").sourceOffset)
     }
 
     fun testCollectAnnotatedServiceRegistrationFromScala() {

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaScalaRouteCollectorTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaScalaRouteCollectorTest.kt
@@ -34,6 +34,7 @@ class ArmeriaScalaRouteCollectorTest : ArmeriaFixtureTestBase() {
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
         assertNotNull(serviceRoute)
         assertEquals("HelloService", serviceRoute!!.target)
+        assertFalse(serviceRoute.targetUnresolved)
     }
 
     fun testCollectAnnotatedServiceRegistrationFromScala() {

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaScalaRouteCollectorTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaScalaRouteCollectorTest.kt
@@ -1,0 +1,69 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
+import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
+import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+
+class ArmeriaScalaRouteCollectorTest : ArmeriaFixtureTestBase() {
+    fun testCollectServiceRegistrationFromScalaBuilderChain() {
+        myFixture.configureByText(
+            "Main.scala",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            object Main {
+              Server.builder()
+                .service("/api", new HelloService())
+                .build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class HelloService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
+        assertNotNull(serviceRoute)
+        assertEquals("HelloService", serviceRoute!!.target)
+    }
+
+    fun testCollectAnnotatedServiceRegistrationFromScala() {
+        myFixture.configureByText(
+            "Main.scala",
+            """
+            package example
+
+            import com.linecorp.armeria.server.Server
+
+            object Main {
+              Server.builder()
+                .annotatedService("/prefix", new AnnotatedService())
+                .build()
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            public class AnnotatedService {
+            }
+            """.trimIndent(),
+        )
+
+        val routes = ArmeriaRouteCollector.collect(project)
+
+        val route = routes.firstOrNull { it.path == "/prefix" && it.routeMatch == RouteMatch.ANNOTATED_SERVICE }
+        assertNotNull(route)
+        assertEquals("AnnotatedService", route!!.target)
+    }
+}

--- a/plugin-route-model/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/model/ArmeriaRoute.kt
+++ b/plugin-route-model/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/model/ArmeriaRoute.kt
@@ -25,9 +25,18 @@ data class ArmeriaRoute(
     val delegationMountPath: String = "",
     val delegationKind: DelegationKind? = null,
     val pointer: SmartPsiElementPointer<PsiElement>,
+    /**
+     * Optional text offset for language-agnostic / plain-text sources (e.g. Scala without PSI).
+     * When set, Explorer navigation and [resolveSourceHint] prefer this offset over the pointer element range.
+     */
+    val sourceOffset: Int? = null,
 ) {
     fun resolveSourceHint(): String {
         val element = pointer.element ?: return ""
+        val offset = sourceOffset
+        if (offset != null) {
+            return ArmeriaRouteMetadata.sourceHintAtOffset(element, offset)
+        }
         return ArmeriaRouteMetadata.sourceHint(element)
     }
 
@@ -102,6 +111,7 @@ data class ArmeriaRoute(
             delegationKind: DelegationKind? = null,
             /** When set, overrides module attribution derived from [element] (e.g. concrete controller). */
             moduleName: String? = null,
+            sourceOffset: Int? = null,
         ): ArmeriaRoute =
             ArmeriaRoute(
                 protocol = protocol,
@@ -123,6 +133,7 @@ data class ArmeriaRoute(
                 delegationMountPath = delegationMountPath,
                 delegationKind = delegationKind,
                 pointer = SmartPointerManager.createPointer(element),
+                sourceOffset = sourceOffset,
             )
 
         fun createRuntime(

--- a/plugin-route-model/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/model/ArmeriaRoute.kt
+++ b/plugin-route-model/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/model/ArmeriaRoute.kt
@@ -33,11 +33,7 @@ data class ArmeriaRoute(
 ) {
     fun resolveSourceHint(): String {
         val element = pointer.element ?: return ""
-        val offset = sourceOffset
-        if (offset != null) {
-            return ArmeriaRouteMetadata.sourceHintAtOffset(element, offset)
-        }
-        return ArmeriaRouteMetadata.sourceHint(element)
+        return ArmeriaRouteMetadata.sourceHintAtOffset(element, sourceOffset ?: element.textRange.startOffset)
     }
 
     fun resolveRegisteredInHint(): String {

--- a/plugin-route-model/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/model/ArmeriaRouteMetadata.kt
+++ b/plugin-route-model/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/model/ArmeriaRouteMetadata.kt
@@ -12,11 +12,17 @@ object ArmeriaRouteMetadata {
         ModuleUtilCore.findModuleForPsiElement(element)?.name
             ?: message("route.explorer.module.unassigned")
 
-    fun sourceHint(element: PsiElement): String {
+    fun sourceHint(element: PsiElement): String = sourceHintAtOffset(element, element.textRange.startOffset)
+
+    fun sourceHintAtOffset(
+        element: PsiElement,
+        offset: Int,
+    ): String {
         val containingFile = element.containingFile ?: return ""
         val virtualFile = containingFile.virtualFile ?: return ""
         val document = PsiDocumentManager.getInstance(element.project).getDocument(containingFile) ?: return virtualFile.presentableUrl
-        val line = document.getLineNumber(element.textRange.startOffset) + 1
+        val safeOffset = offset.coerceIn(0, document.textLength)
+        val line = document.getLineNumber(safeOffset) + 1
         return "${virtualFile.presentableUrl}:$line"
     }
 

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaClientCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaClientCollector.kt
@@ -261,10 +261,12 @@ object ArmeriaClientCollector {
         decorators: List<String> = emptyList(),
         endpointGroup: String? = null,
         transport: String? = null,
+        dedupeKey: String? = null,
+        sourceOffset: Int? = null,
     ) {
         val virtualFile = element.containingFile?.virtualFile ?: return
-        val dedupeKey = "${virtualFile.path}:${element.textRange.startOffset}"
-        if (!seenEndpoints.add(dedupeKey)) {
+        val key = dedupeKey ?: "${virtualFile.path}:${element.textRange.startOffset}"
+        if (!seenEndpoints.add(key)) {
             return
         }
         endpoints +=
@@ -276,6 +278,7 @@ object ArmeriaClientCollector {
                 decorators = decorators,
                 endpointGroup = endpointGroup,
                 transport = transport,
+                sourceOffset = sourceOffset,
             )
     }
 

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaClientCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaClientCollector.kt
@@ -40,6 +40,7 @@ object ArmeriaClientCollector {
         if (isKotlinPluginAvailable()) {
             ArmeriaKotlinClientCollector.collect(project, scope, endpoints, seenEndpoints)
         }
+        ArmeriaScalaClientCollector.collect(project, scope, endpoints, seenEndpoints)
         val sorted = endpoints.sortedWith(compareBy({ it.clientType }, { it.uri }, { it.target }))
         return CachedValueProvider.Result.create(
             sorted,

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaClientEndpoint.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaClientEndpoint.kt
@@ -14,6 +14,8 @@ data class ArmeriaClientEndpoint(
     val decorators: List<String> = emptyList(),
     val endpointGroup: String? = null,
     val transport: String? = null,
+    /** Text offset for plain-text sources (e.g. Scala); preferred for Explorer navigation. */
+    val sourceOffset: Int? = null,
 ) {
     companion object {
         fun create(
@@ -24,6 +26,7 @@ data class ArmeriaClientEndpoint(
             decorators: List<String> = emptyList(),
             endpointGroup: String? = null,
             transport: String? = null,
+            sourceOffset: Int? = null,
         ): ArmeriaClientEndpoint =
             ArmeriaClientEndpoint(
                 clientType = clientType,
@@ -34,6 +37,7 @@ data class ArmeriaClientEndpoint(
                 decorators = decorators,
                 endpointGroup = endpointGroup,
                 transport = transport,
+                sourceOffset = sourceOffset,
             )
     }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaClientExplorerPanel.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaClientExplorerPanel.kt
@@ -16,6 +16,7 @@ import com.intellij.ui.components.JBList
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.util.concurrency.AppExecutorUtil
 import com.intellij.util.ui.JBUI
+import com.linecorp.intellij.plugins.armeria.explorer.navigation.ArmeriaRouteNavigation
 import com.linecorp.intellij.plugins.armeria.message
 import java.awt.BorderLayout
 import java.awt.Component
@@ -180,8 +181,7 @@ class ArmeriaClientExplorerPanel(
         val endpoint = endpointList.selectedValue ?: return
         ReadAction
             .nonBlocking<Navigatable?> {
-                val element = endpoint.pointer.element as? Navigatable
-                element?.takeIf { it.canNavigate() }
+                ArmeriaRouteNavigation.resolveNavigatable(endpoint.pointer, endpoint.sourceOffset)
             }.inSmartMode(project)
             .expireWith(this)
             .finishOnUiThread(ModalityState.any()) { navigatable ->

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaClientExplorerPanel.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaClientExplorerPanel.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.SimpleToolWindowPanel
-import com.intellij.pom.Navigatable
 import com.intellij.ui.OnePixelSplitter
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBList
@@ -179,14 +178,12 @@ class ArmeriaClientExplorerPanel(
 
     private fun navigateToSelection() {
         val endpoint = endpointList.selectedValue ?: return
-        ReadAction
-            .nonBlocking<Navigatable?> {
-                ArmeriaRouteNavigation.resolveNavigatable(endpoint.pointer, endpoint.sourceOffset)
-            }.inSmartMode(project)
-            .expireWith(this)
-            .finishOnUiThread(ModalityState.any()) { navigatable ->
-                navigatable?.navigate(true)
-            }.submit(AppExecutorUtil.getAppExecutorService())
+        ArmeriaRouteNavigation.navigateToPointer(
+            project,
+            endpoint.pointer,
+            endpoint.sourceOffset,
+            parentDisposable = this,
+        )
     }
 
     private fun formatListLabel(endpoint: ArmeriaClientEndpoint): String {

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaClientSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaClientSupport.kt
@@ -37,6 +37,14 @@ internal object ArmeriaClientSupport {
 
     fun protocolForClass(qualifiedName: String?): ClientProtocol? = qualifiedName?.let { CLIENT_CLASS_PROTOCOLS[it] }
 
+    fun protocolForSimpleName(simpleName: String): ClientProtocol? =
+        CLIENT_CLASS_PROTOCOLS.entries
+            .firstOrNull { (fqcn, _) -> fqcn.substringAfterLast('.') == simpleName }
+            ?.value
+
+    /** Simple class names used by text-based Scala client scanning. */
+    fun clientSimpleNames(): Set<String> = CLIENT_CLASS_PROTOCOLS.keys.mapTo(linkedSetOf()) { it.substringAfterLast('.') }
+
     fun isWebClientClass(qualifiedName: String?): Boolean =
         qualifiedName != null &&
             (qualifiedName in WEB_CLIENT_CLASS_NAMES || qualifiedName.endsWith(".WebClient"))

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaClientSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaClientSupport.kt
@@ -27,6 +27,9 @@ internal object ArmeriaClientSupport {
             "com.linecorp.armeria.client.retrofit2.ArmeriaRetrofit" to ClientProtocol.RETROFIT,
         )
 
+    private val CLIENT_SIMPLE_NAME_PROTOCOLS =
+        CLIENT_CLASS_PROTOCOLS.mapKeys { (fqcn, _) -> fqcn.substringAfterLast('.') }
+
     val FACTORY_METHOD_NAMES = setOf("builder", "of", "newClient")
 
     private val WEB_CLIENT_CLASS_NAMES =
@@ -37,13 +40,10 @@ internal object ArmeriaClientSupport {
 
     fun protocolForClass(qualifiedName: String?): ClientProtocol? = qualifiedName?.let { CLIENT_CLASS_PROTOCOLS[it] }
 
-    fun protocolForSimpleName(simpleName: String): ClientProtocol? =
-        CLIENT_CLASS_PROTOCOLS.entries
-            .firstOrNull { (fqcn, _) -> fqcn.substringAfterLast('.') == simpleName }
-            ?.value
+    fun protocolForSimpleName(simpleName: String): ClientProtocol? = CLIENT_SIMPLE_NAME_PROTOCOLS[simpleName]
 
     /** Simple class names used by text-based Scala client scanning. */
-    fun clientSimpleNames(): Set<String> = CLIENT_CLASS_PROTOCOLS.keys.mapTo(linkedSetOf()) { it.substringAfterLast('.') }
+    fun clientSimpleNames(): Set<String> = CLIENT_SIMPLE_NAME_PROTOCOLS.keys
 
     fun isWebClientClass(qualifiedName: String?): Boolean =
         qualifiedName != null &&

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaScalaClientCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaScalaClientCollector.kt
@@ -1,0 +1,55 @@
+package com.linecorp.intellij.plugins.armeria.client
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaScalaTextSupport
+
+internal object ArmeriaScalaClientCollector {
+    private val CLIENT_CLASS_PROTOCOLS =
+        mapOf(
+            "WebClient" to ClientProtocol.HTTP,
+            "GrpcClient" to ClientProtocol.GRPC,
+            "GrpcClients" to ClientProtocol.GRPC,
+            "ThriftClient" to ClientProtocol.THRIFT,
+            "ThriftClients" to ClientProtocol.THRIFT,
+        )
+
+    fun collect(
+        project: Project,
+        scope: GlobalSearchScope,
+        endpoints: MutableList<ArmeriaClientEndpoint>,
+        seenEndpoints: MutableSet<String>,
+    ) {
+        for (virtualFile in FilenameIndex.getAllFilesByExt(project, "scala", scope)) {
+            val psiFile = PsiManager.getInstance(project).findFile(virtualFile) ?: continue
+            val contents = psiFile.text
+            if (!ArmeriaScalaTextSupport.referencesArmeriaScalaContent(contents)) {
+                continue
+            }
+            collectFromFile(psiFile, contents, endpoints, seenEndpoints)
+        }
+    }
+
+    private fun collectFromFile(
+        file: PsiFile,
+        contents: String,
+        endpoints: MutableList<ArmeriaClientEndpoint>,
+        seenEndpoints: MutableSet<String>,
+    ) {
+        for (match in ArmeriaScalaTextSupport.findClientEndpoints(contents)) {
+            val protocol = CLIENT_CLASS_PROTOCOLS[match.clientSimpleName] ?: continue
+            val element = file.findElementAt(match.startOffset) ?: file
+            ArmeriaClientCollector.addEndpoint(
+                element,
+                protocol,
+                match.clientSimpleName,
+                match.uri,
+                endpoints,
+                seenEndpoints,
+            )
+        }
+    }
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaScalaClientCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaScalaClientCollector.kt
@@ -39,17 +39,21 @@ internal object ArmeriaScalaClientCollector {
         seenEndpoints: MutableSet<String>,
     ) {
         val scanText = ArmeriaScalaTextSupport.stripScalaComments(contents)
+        val filePath = file.virtualFile?.path ?: return
         for (match in CLIENT_ENDPOINT_PATTERN.findAll(scanText)) {
             val clientSimpleName = match.groupValues[1]
             val protocol = ArmeriaClientSupport.protocolForSimpleName(clientSimpleName) ?: continue
-            val element = file.findElementAt(match.range.first) ?: file
+            val offset = match.range.first
+            val element = file.findElementAt(offset) ?: file
             ArmeriaClientCollector.addEndpoint(
-                element,
-                protocol,
-                clientSimpleName,
-                match.groupValues[2],
-                endpoints,
-                seenEndpoints,
+                element = element,
+                protocol = protocol,
+                target = clientSimpleName,
+                uri = match.groupValues[2],
+                endpoints = endpoints,
+                seenEndpoints = seenEndpoints,
+                dedupeKey = "$filePath:$offset",
+                sourceOffset = offset,
             )
         }
     }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaScalaClientCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaScalaClientCollector.kt
@@ -5,16 +5,15 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import com.intellij.psi.search.FilenameIndex
 import com.intellij.psi.search.GlobalSearchScope
+import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaRouteSupport
 import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaScalaTextSupport
 
 internal object ArmeriaScalaClientCollector {
-    private val CLIENT_CLASS_PROTOCOLS =
-        mapOf(
-            "WebClient" to ClientProtocol.HTTP,
-            "GrpcClient" to ClientProtocol.GRPC,
-            "GrpcClients" to ClientProtocol.GRPC,
-            "ThriftClient" to ClientProtocol.THRIFT,
-            "ThriftClients" to ClientProtocol.THRIFT,
+    private val CLIENT_ENDPOINT_PATTERN =
+        Regex(
+            """\b(${ArmeriaClientSupport.clientSimpleNames().joinToString("|")})\s*\.\s*(?:${
+                ArmeriaClientSupport.FACTORY_METHOD_NAMES.joinToString("|")
+            })\s*\(\s*"([^"]+)"\s*\)""",
         )
 
     fun collect(
@@ -26,7 +25,7 @@ internal object ArmeriaScalaClientCollector {
         for (virtualFile in FilenameIndex.getAllFilesByExt(project, "scala", scope)) {
             val psiFile = PsiManager.getInstance(project).findFile(virtualFile) ?: continue
             val contents = psiFile.text
-            if (!ArmeriaScalaTextSupport.referencesArmeriaScalaContent(contents)) {
+            if (!ArmeriaRouteSupport.referencesArmeriaSourceContent(contents)) {
                 continue
             }
             collectFromFile(psiFile, contents, endpoints, seenEndpoints)
@@ -39,14 +38,16 @@ internal object ArmeriaScalaClientCollector {
         endpoints: MutableList<ArmeriaClientEndpoint>,
         seenEndpoints: MutableSet<String>,
     ) {
-        for (match in ArmeriaScalaTextSupport.findClientEndpoints(contents)) {
-            val protocol = CLIENT_CLASS_PROTOCOLS[match.clientSimpleName] ?: continue
-            val element = file.findElementAt(match.startOffset) ?: file
+        val scanText = ArmeriaScalaTextSupport.stripScalaComments(contents)
+        for (match in CLIENT_ENDPOINT_PATTERN.findAll(scanText)) {
+            val clientSimpleName = match.groupValues[1]
+            val protocol = ArmeriaClientSupport.protocolForSimpleName(clientSimpleName) ?: continue
+            val element = file.findElementAt(match.range.first) ?: file
             ArmeriaClientCollector.addEndpoint(
                 element,
                 protocol,
-                match.clientSimpleName,
-                match.uri,
+                clientSimpleName,
+                match.groupValues[2],
                 endpoints,
                 seenEndpoints,
             )

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerPanel.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerPanel.kt
@@ -259,7 +259,7 @@ class ArmeriaRouteExplorerPanel(
 
     private fun navigateToSelection() {
         val route = selectedRouteFromTree() ?: return
-        ArmeriaRouteNavigation.navigateToPointer(project, route.pointer, parentDisposable = this)
+        ArmeriaRouteNavigation.navigateToRoute(project, route, parentDisposable = this)
     }
 
     private fun selectedRouteFromTree(): ArmeriaRoute? = ArmeriaRouteTreeBuilder.selectedRoute(routeTree.lastSelectedPathComponent)

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaScalaClientCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaScalaClientCollectorTest.kt
@@ -74,9 +74,9 @@ class ArmeriaScalaClientCollectorTest : ArmeriaLightJavaCodeInsightFixtureTestCa
         val byUri = endpoints.associateBy { it.uri }
         assertEquals("WebClient", byUri.getValue("https://example.com").target)
         assertEquals("GrpcClients", byUri.getValue("https://grpc.example.com").target)
-        assertNotEquals(
-            byUri.getValue("https://example.com").sourceOffset,
-            byUri.getValue("https://grpc.example.com").sourceOffset,
+        assertFalse(
+            byUri.getValue("https://example.com").sourceOffset ==
+                byUri.getValue("https://grpc.example.com").sourceOffset,
         )
     }
 }

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaScalaClientCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaScalaClientCollectorTest.kt
@@ -32,5 +32,51 @@ class ArmeriaScalaClientCollectorTest : ArmeriaLightJavaCodeInsightFixtureTestCa
         assertEquals("HTTP", endpoint.clientType)
         assertEquals("https://example.com", endpoint.uri)
         assertEquals("WebClient", endpoint.target)
+        assertNotNull(endpoint.sourceOffset)
+        assertTrue(endpoint.sourceOffset!! > 0)
+    }
+
+    fun testCollectMultipleClientsFromSameScalaFile() {
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.client;
+
+            public final class WebClient {
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.client.grpc;
+
+            public final class GrpcClients {
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "Main.scala",
+            """
+            package example
+
+            import com.linecorp.armeria.client.WebClient
+            import com.linecorp.armeria.client.grpc.GrpcClients
+
+            object Main {
+              val web = WebClient.of("https://example.com")
+              val grpc = GrpcClients.of("https://grpc.example.com")
+            }
+            """.trimIndent(),
+        )
+
+        val endpoints = ArmeriaClientCollector.collect(project)
+
+        assertEquals(2, endpoints.size)
+        val byUri = endpoints.associateBy { it.uri }
+        assertEquals("WebClient", byUri.getValue("https://example.com").target)
+        assertEquals("GrpcClients", byUri.getValue("https://grpc.example.com").target)
+        assertNotEquals(
+            byUri.getValue("https://example.com").sourceOffset,
+            byUri.getValue("https://grpc.example.com").sourceOffset,
+        )
     }
 }

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaScalaClientCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaScalaClientCollectorTest.kt
@@ -1,0 +1,36 @@
+package com.linecorp.intellij.plugins.armeria.client
+
+import com.linecorp.intellij.plugins.armeria.test.ArmeriaLightJavaCodeInsightFixtureTestCase
+
+class ArmeriaScalaClientCollectorTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {
+    fun testCollectWebClientOfFromScala() {
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.client;
+
+            public final class WebClient {
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "Main.scala",
+            """
+            package example
+
+            import com.linecorp.armeria.client.WebClient
+
+            object Main {
+              val client = WebClient.of("https://example.com")
+            }
+            """.trimIndent(),
+        )
+
+        val endpoints = ArmeriaClientCollector.collect(project)
+
+        assertEquals(1, endpoints.size)
+        val endpoint = endpoints.single()
+        assertEquals("HTTP", endpoint.clientType)
+        assertEquals("https://example.com", endpoint.uri)
+        assertEquals("WebClient", endpoint.target)
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Scala source support to Route Explorer and Clients Explorer by porting the text-based collectors from parked PR #217 into the current `plugin-route-*` module layout. Scanning uses regex over `.scala` source text (no Scala PSI / JetBrains Scala plugin dependency).

Fixes #266.

## Changes

- `ArmeriaScalaTextSupport` in `plugin-route-collectors` for service registration matching via a declarative regex rule table
- Comment blanking that preserves string literals (including triple-quoted) so comment-only registrations are ignored without blanking code after string-embedded `//` / `/*`
- Best-effort `targetUnresolved` for constructor forms (`new Foo()` resolved; bare identifiers unresolved)
- `argumentCount` carried on each match so `.annotatedService("/…", …)` keeps path-prefix semantics
- `ArmeriaScalaRouteCollector` hooked into `ArmeriaRouteCollector` after the Kotlin fallback
- `ArmeriaScalaClientCollector` driven by `ArmeriaClientSupport` simple-name/protocol helpers
- Match offsets threaded into `ArmeriaRoute` / `ArmeriaClientEndpoint` (`sourceOffset`) so multi-registration Scala files keep distinct entries; Explorer navigation prefers `OpenFileDescriptor` at that offset via shared `ArmeriaRouteNavigation`
- Shared `referencesArmeriaSourceContent` for text-based Armeria content detection
- `fastTest` coverage for text matching; fixture tests for route and client discovery (including multi-match cases)

## Test plan

- [x] `:plugin-route-collectors:fastTest` — `ArmeriaScalaTextSupportTest`
- [x] `:plugin-route-collectors:test` — `ArmeriaScalaRouteCollectorTest`
- [x] `:plugin:test` — `ArmeriaScalaClientCollectorTest`
- [x] `ktlintCheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8775-873b-7f7d-a745-2a8d4ce5da49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8775-873b-7f7d-a745-2a8d4ce5da49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

