### PR TITLE
refactor: move runtime route pointer to model package

### DIFF
--- a/.cursor/skills/intellij-armeria-plugin/SKILL.md
+++ b/.cursor/skills/intellij-armeria-plugin/SKILL.md
@@ -22,11 +22,11 @@ in this repository. Apply it **during implementation**, not only before opening 
 
 | Module | Owns |
 |--------|------|
-| `plugin-route-model/` | Leaf domain types (`ArmeriaRoute`, `RouteMatch`, `RouteProtocol`, `PathType`, `DelegationKind`, `CoreServiceRegistrationMethod`, `ArmeriaRouteMetadata`) |
+| `plugin-route-model/` | Leaf domain types (`ArmeriaRoute`, `RouteMatch`, `RouteProtocol`, `PathType`, `DelegationKind`, `CoreServiceRegistrationMethod`, `ArmeriaRouteMetadata`) and runtime route helpers (`ArmeriaRuntimeRoutePointer`, `ArmeriaRuntimeRouteFactory` in `explorer.model.runtime`) |
 | `plugin-route-collectors/` | Annotated/service-registration collectors, decorator/timeout/annotation helpers, `ArmeriaKotlinRouteCollector`, `psi` traversal, `ArmeriaRouteSupport`, `RouteContributor`/`RouteCollectContext` SPI, shared test fixtures (`ArmeriaFixtureTestBase`, stubs) |
 | `plugin-route-spring/` | `ArmeriaSpringBootRouteCollector`, `ArmeriaKotlinSpringBootRouteCollector`, `ArmeriaSpringMvcRouteCollector`, `ArmeriaSpringConfigRouteCollector`, `ArmeriaYamlSpringConfigReader`, `SpringArmeriaConfig*`, `ArmeriaDelegatedRouteCollector` |
 | `plugin-route-protocol/` | `ArmeriaGraphqlRouteCollector`, `ArmeriaGrpcRouteCollector`, `ArmeriaThriftRouteCollector`, `ArmeriaIdlRouteSupport`, `ArmeriaProtoTextSupport` |
-| `plugin-route-analysis/` | Route Explorer UI helpers (`ui/`), DocService support (`docservice/`), navigation (`navigation/`), duplicate index (`duplicate/`), and `ArmeriaRouteAnalysisCollector` (production façade that always supplies Spring/protocol contributors) |
+| `plugin-route-analysis/` | Route Explorer UI helpers (`ui/`), DocService support (`docservice/`), jump-to-source navigation (`navigation/ArmeriaRouteNavigation` only), duplicate index (`duplicate/`), and `ArmeriaRouteAnalysisCollector` (production façade that always supplies Spring/protocol contributors) |
 | `plugin-shared/` | Shared bundle helpers, cross-cutting PSI utilities, test fixtures |
 | `plugin-wizard/` | New-project/module wizard, file templates, starter resources |
 | `plugin/` | `plugin.xml` wiring, UI panels/actions, run configs, inspection registration |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,11 +82,11 @@ Kotlin style is enforced by ktlint (`com.linecorp.intellij.ktlint` convention, `
 | Path | Role |
 |------|------|
 | `plugin-shared/` | Shared bundle, icons, and starters used by other modules |
-| `plugin-route-model/` | Leaf module with `ArmeriaRoute`, `RouteMatch`, `RouteProtocol`, `DelegationKind`, etc. (no collector code) |
+| `plugin-route-model/` | Leaf module with `ArmeriaRoute`, `RouteMatch`, `RouteProtocol`, `DelegationKind`, etc., plus runtime route helpers (`ArmeriaRuntimeRoutePointer`, `ArmeriaRuntimeRouteFactory` in `explorer.model.runtime`; no collector code) |
 | `plugin-route-collectors/` | Core annotated + service-registration collectors, decorator/timeout/annotation helpers, support utilities, PSI traversal, `RouteContributor`/`RouteCollectContext` SPI, `ArmeriaKotlinRouteCollector`, and shared test fixtures |
 | `plugin-route-spring/` | Spring MVC / Spring Boot / Spring config collectors and `ArmeriaDelegatedRouteCollector` |
 | `plugin-route-protocol/` | GraphQL / gRPC / Thrift / IDL / proto-text collectors |
-| `plugin-route-analysis/` | Route Explorer UI helpers, DocService support, navigation, duplicate index, and `ArmeriaRouteAnalysisCollector` (production façade that always supplies Spring/protocol contributors) |
+| `plugin-route-analysis/` | Route Explorer UI helpers, DocService support, jump-to-source navigation (`navigation/ArmeriaRouteNavigation` only), duplicate index, and `ArmeriaRouteAnalysisCollector` (production façade that always supplies Spring/protocol contributors) |
 | `plugin-wizard/` | New Project Wizard templates and verification |
 | `plugin/` | Aggregating plugin module, run config, Clients explorer, resources, `CHANGELOG.md` |
 | `build-logic/` | Shared IntelliJ Platform Gradle conventions |

--- a/plugin-route-model/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/model/runtime/ArmeriaRuntimeRouteFactory.kt
+++ b/plugin-route-model/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/model/runtime/ArmeriaRuntimeRouteFactory.kt
@@ -1,4 +1,4 @@
-package com.linecorp.intellij.plugins.armeria.explorer.navigation
+package com.linecorp.intellij.plugins.armeria.explorer.model.runtime
 
 import com.intellij.openapi.project.Project
 import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute

--- a/plugin-route-model/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/model/runtime/ArmeriaRuntimeRoutePointer.kt
+++ b/plugin-route-model/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/model/runtime/ArmeriaRuntimeRoutePointer.kt
@@ -1,4 +1,5 @@
-package com.linecorp.intellij.plugins.armeria.explorer.navigation
+package com.linecorp.intellij.plugins.armeria.explorer.model.runtime
+
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.TextRange

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Route Explorer reads Spring Boot `application.yml` / `.yaml` via IntelliJ YAML PSI (key-level navigation); `.properties` parsing is unchanged. YAML config is skipped when the YAML plugin is unavailable.
 - Split `plugin-route-analysis` `explorer` sources into focused packages (`model`, `collector`, `spring`, `protocol`, `docservice`, `support`, `duplicate`, `navigation`, `ui`).
 - Split the route-analysis codebase into five acyclic Gradle modules: `plugin-route-model` (leaf domain types), `plugin-route-collectors` (annotated / service-registration collectors, decorator/timeout support, `RouteContributor` SPI, public `ArmeriaRouteCollector`, shared test fixtures), `plugin-route-spring` (Spring MVC / Boot / config collectors), `plugin-route-protocol` (GraphQL / gRPC / Thrift), and `plugin-route-analysis` (UI helpers, DocService, navigation, duplicate index, `ArmeriaRouteAnalysisCollector`). `plugin` depends only on `plugin-route-analysis` (transitively `api`-exported to the rest); test fixtures are consumed from `plugin-route-collectors`.
+- Move DocService runtime route pointer/factory from `explorer.navigation` to `explorer.model.runtime` in `plugin-route-model` so `navigation` is jump-to-source only.
 
 ### Deprecated
 

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRuntimeRouteFetcher.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRuntimeRouteFetcher.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.project.Project
 import com.linecorp.intellij.plugins.armeria.explorer.docservice.ArmeriaDocServiceEndpointValidator
 import com.linecorp.intellij.plugins.armeria.explorer.docservice.ArmeriaDocServiceSpecificationParser
 import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
-import com.linecorp.intellij.plugins.armeria.explorer.navigation.ArmeriaRuntimeRouteFactory
+import com.linecorp.intellij.plugins.armeria.explorer.model.runtime.ArmeriaRuntimeRouteFactory
 import com.linecorp.intellij.plugins.armeria.message
 import java.io.ByteArrayOutputStream
 import java.io.IOException


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the cheap tier of #292 (explorer package layering follow-up from #291). The `model → ui` dependency was already removed earlier; this PR relocates DocService runtime route helpers so `explorer.navigation` is jump-to-source only.

## Changes

- Move `ArmeriaRuntimeRoutePointer` and `ArmeriaRuntimeRouteFactory` from `plugin-route-analysis` `explorer.navigation` to `plugin-route-model` `explorer.model.runtime`
- Update `ArmeriaRuntimeRouteFetcher` import to the new package
- Document runtime helpers under `plugin-route-model` in the IntelliJ plugin skill and `AGENTS.md`
- Note the move in `CHANGELOG.md`

## Depends on

None.

## Test plan

- [x] `ktlintCheck`
- [x] `:plugin-route-model:compileKotlin`, `:plugin:compileKotlin`
- [x] `:plugin:test` (includes `ArmeriaRuntimeRouteFetcherTest`)
- [x] `:plugin-route-analysis:fastTest`

Closes #292 (cheap tier). Structural items in that issue (support facade clarity, collector mesh DAG, test package mirroring) remain for follow-up.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8fdd-7685-7068-bead-8aff814599e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8fdd-7685-7068-bead-8aff814599e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

