### PR TITLE
test: add duplicate route/registration inspection fixtures

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- PSI fixture regression tests for duplicate annotated route and duplicate route registration inspections (Java duplicate route highlighting and registration inspection scenarios).
 - ktlint via `com.linecorp.intellij.ktlint` convention (`ktlint_official` style); `ktlintCheck` runs as part of `check` / `build`.
 - gRPC Route Explorer discovery uses Proto Editor PSI when `idea.plugin.protoeditor` is available (RPC-level navigation), with fallback to the existing `.proto` text parser.
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- PSI fixture regression tests for duplicate annotated route and duplicate route registration inspections (Java duplicate route highlighting and registration inspection scenarios).
+- PSI fixture regression tests for duplicate annotated route and duplicate route registration inspections (Java route highlighting, Java/Kotlin registration inspection scenarios).
 - ktlint via `com.linecorp.intellij.ktlint` convention (`ktlint_official` style); `ktlintCheck` runs as part of `check` / `build`.
 - gRPC Route Explorer discovery uses Proto Editor PSI when `idea.plugin.protoeditor` is available (RPC-level navigation), with fallback to the existing `.proto` text parser.
 

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspectionTest.kt
@@ -2,6 +2,7 @@ package com.linecorp.intellij.plugins.armeria.inspection
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.psi.PsiJavaFile
 import com.intellij.testFramework.PlatformTestUtil
 import com.linecorp.intellij.plugins.armeria.message
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
@@ -16,6 +17,29 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
             it.description?.let(::matchesRegistrationDuplicateProblem) == true
         }
 
+    private fun assertRegistrationDuplicateHighlightOnMethod(
+        className: String,
+        methodName: String,
+        expectedDescription: String,
+    ) {
+        val duplicateHighlights =
+            myFixture.doHighlighting().filter {
+                it.description == expectedDescription
+            }
+        assertEquals(1, duplicateHighlights.size)
+
+        val file = myFixture.file as PsiJavaFile
+        val clazz =
+            file.classes.singleOrNull { it.name == className }
+                ?: error("Class $className not found in ${file.name}")
+        val method = clazz.findMethodsByName(methodName, false).single()
+        val methodOffset = method.nameIdentifier!!.textRange.startOffset
+        assertTrue(
+            "Expected registration duplicate highlight on $className.$methodName",
+            methodOffset in duplicateHighlights.map { it.startOffset }.toSet(),
+        )
+    }
+
     private fun matchesRegistrationDuplicateProblem(description: String): Boolean {
         val labelPlaceholder = "\uE000"
         val countPlaceholder = "\uE001"
@@ -26,7 +50,8 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
                 countPlaceholder,
             )
         val pattern =
-            Regex.escape(template)
+            Regex
+                .escape(template)
                 .replace(Regex.escape(labelPlaceholder), "(.+?)")
                 .replace(Regex.escape(countPlaceholder), "(\\p{N}+)")
         return Regex("^$pattern$").matches(description)
@@ -107,16 +132,10 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
         myFixture.enableInspections(ArmeriaDuplicateRegistrationInspection())
         val expectedDescription = message("inspection.duplicate.registration.problem", "GET /shared", 2)
 
-        assertEquals(
-            1,
-            myFixture.doHighlighting().count { it.description == expectedDescription },
-        )
+        assertRegistrationDuplicateHighlightOnMethod("First", "first", expectedDescription)
 
         myFixture.openFileInEditor(secondClass.containingFile.virtualFile)
-        assertEquals(
-            1,
-            myFixture.doHighlighting().count { it.description == expectedDescription },
-        )
+        assertRegistrationDuplicateHighlightOnMethod("Second", "second", expectedDescription)
     }
 
     fun testInClassJavaAnnotatedDuplicatesAreNotRegistrationProblems() {

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspectionTest.kt
@@ -18,16 +18,17 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
 
     private fun matchesRegistrationDuplicateProblem(description: String): Boolean {
         val labelPlaceholder = "\uE000"
+        val countPlaceholder = "\uE001"
         val template =
             message(
                 "inspection.duplicate.registration.problem",
                 labelPlaceholder,
-                0,
+                countPlaceholder,
             )
         val pattern =
             Regex.escape(template)
                 .replace(Regex.escape(labelPlaceholder), "(.+?)")
-                .replace(Regex.escape("0"), "(\\d+)")
+                .replace(Regex.escape(countPlaceholder), "(\\d+)")
         return Regex("^$pattern$").matches(description)
     }
 

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspectionTest.kt
@@ -11,6 +11,26 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
         registerRouteDuplicateIndexStubs()
     }
 
+    private fun registrationDuplicateHighlights() =
+        myFixture.doHighlighting().filter {
+            it.description?.let(::matchesRegistrationDuplicateProblem) == true
+        }
+
+    private fun matchesRegistrationDuplicateProblem(description: String): Boolean {
+        val labelPlaceholder = "\uE000"
+        val template =
+            message(
+                "inspection.duplicate.registration.problem",
+                labelPlaceholder,
+                0,
+            )
+        val pattern =
+            Regex.escape(template)
+                .replace(Regex.escape(labelPlaceholder), "(.+?)")
+                .replace(Regex.escape("0"), "(\\d+)")
+        return Regex("^$pattern$").matches(description)
+    }
+
     fun testInspectionHighlightsDuplicateAndOffersNavigateQuickFix() {
         configureDuplicateServiceRegistrationFixture()
 
@@ -116,12 +136,7 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
         )
 
         myFixture.enableInspections(ArmeriaDuplicateRegistrationInspection())
-        val registrationHighlights =
-            myFixture.doHighlighting().filter {
-                it.description?.contains("conflicting registrations in this module") == true
-            }
-
-        assertTrue(registrationHighlights.isEmpty())
+        assertTrue(registrationDuplicateHighlights().isEmpty())
     }
 
     fun testKotlinInClassAnnotatedDuplicatesAreNotRegistrationProblems() {
@@ -143,12 +158,7 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
         )
 
         myFixture.enableInspections(ArmeriaDuplicateRegistrationKotlinInspection())
-        val registrationHighlights =
-            myFixture.doHighlighting().filter {
-                it.description?.contains("conflicting registrations in this module") == true
-            }
-
-        assertTrue(registrationHighlights.isEmpty())
+        assertTrue(registrationDuplicateHighlights().isEmpty())
     }
 
     fun testKotlinDistinctPathsAreNotRegistrationProblems() {
@@ -170,12 +180,7 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
         )
 
         myFixture.enableInspections(ArmeriaDuplicateRegistrationKotlinInspection())
-        val registrationHighlights =
-            myFixture.doHighlighting().filter {
-                it.description?.contains("conflicting registrations in this module") == true
-            }
-
-        assertTrue(registrationHighlights.isEmpty())
+        assertTrue(registrationDuplicateHighlights().isEmpty())
     }
 
     fun testKotlinInspectionHighlightsDuplicateAndOffersNavigateQuickFix() {

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspectionTest.kt
@@ -28,7 +28,7 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
         val pattern =
             Regex.escape(template)
                 .replace(Regex.escape(labelPlaceholder), "(.+?)")
-                .replace(Regex.escape(countPlaceholder), "(\\d+)")
+                .replace(Regex.escape(countPlaceholder), "(\\p{N}+)")
         return Regex("^$pattern$").matches(description)
     }
 
@@ -74,8 +74,7 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
     }
 
     fun testJavaCrossFileAnnotatedRoutesAreHighlighted() {
-        myFixture.configureByText(
-            "First.java",
+        val firstContent =
             """
             package example;
 
@@ -87,9 +86,8 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
                     return "first";
                 }
             }
-            """.trimIndent(),
-        )
-        myFixture.addClass(
+            """.trimIndent()
+        val secondContent =
             """
             package example;
 
@@ -101,17 +99,24 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
                     return "second";
                 }
             }
-            """.trimIndent(),
-        )
+            """.trimIndent()
+
+        myFixture.configureByText("First.java", firstContent)
+        val secondClass = myFixture.addClass(secondContent)
 
         myFixture.enableInspections(ArmeriaDuplicateRegistrationInspection())
         val expectedDescription = message("inspection.duplicate.registration.problem", "GET /shared", 2)
-        val duplicateHighlights =
-            myFixture.doHighlighting().filter {
-                it.description == expectedDescription
-            }
 
-        assertEquals(1, duplicateHighlights.size)
+        assertEquals(
+            1,
+            myFixture.doHighlighting().count { it.description == expectedDescription },
+        )
+
+        myFixture.openFileInEditor(secondClass.containingFile.virtualFile)
+        assertEquals(
+            1,
+            myFixture.doHighlighting().count { it.description == expectedDescription },
+        )
     }
 
     fun testInClassJavaAnnotatedDuplicatesAreNotRegistrationProblems() {

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspectionTest.kt
@@ -52,6 +52,132 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
         assertTrue("Expected Extra.java among open files but found $openFileNames", "Extra.java" in openFileNames)
     }
 
+    fun testJavaCrossFileAnnotatedRoutesAreHighlighted() {
+        myFixture.configureByText(
+            "First.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Get;
+
+            public class First {
+                @Get("/shared")
+                public String first() {
+                    return "first";
+                }
+            }
+            """.trimIndent(),
+        )
+        myFixture.addClass(
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Get;
+
+            public class Second {
+                @Get("/shared")
+                public String second() {
+                    return "second";
+                }
+            }
+            """.trimIndent(),
+        )
+
+        myFixture.enableInspections(ArmeriaDuplicateRegistrationInspection())
+        val expectedDescription = message("inspection.duplicate.registration.problem", "GET /shared", 2)
+        val duplicateHighlights =
+            myFixture.doHighlighting().filter {
+                it.description == expectedDescription
+            }
+
+        assertEquals(1, duplicateHighlights.size)
+    }
+
+    fun testInClassJavaAnnotatedDuplicatesAreNotRegistrationProblems() {
+        myFixture.configureByText(
+            "BadService.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Get;
+
+            public class BadService {
+                @Get("/dup")
+                public String first() {
+                    return "first";
+                }
+
+                @Get("/dup")
+                public String second() {
+                    return "second";
+                }
+            }
+            """.trimIndent(),
+        )
+
+        myFixture.enableInspections(ArmeriaDuplicateRegistrationInspection())
+        val registrationHighlights =
+            myFixture.doHighlighting().filter {
+                it.description.startsWith("This Armeria route")
+            }
+
+        assertTrue(registrationHighlights.isEmpty())
+    }
+
+    fun testKotlinInClassAnnotatedDuplicatesAreNotRegistrationProblems() {
+        myFixture.configureByText(
+            "BadService.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.annotation.Get
+
+            class BadService {
+                @Get("/dup")
+                fun first(): String = "first"
+
+                @Get("/dup")
+                fun second(): String = "second"
+            }
+            """.trimIndent(),
+        )
+
+        myFixture.enableInspections(ArmeriaDuplicateRegistrationKotlinInspection())
+        val registrationHighlights =
+            myFixture.doHighlighting().filter {
+                it.description.startsWith("This Armeria route")
+            }
+
+        assertTrue(registrationHighlights.isEmpty())
+    }
+
+    fun testKotlinDistinctPathsAreNotRegistrationProblems() {
+        myFixture.configureByText(
+            "HelloService.kt",
+            """
+            package example
+
+            import com.linecorp.armeria.server.annotation.Get
+
+            class HelloService {
+                @Get("/hello")
+                fun hello(): String = "hello"
+
+                @Get("/goodbye")
+                fun goodbye(): String = "goodbye"
+            }
+            """.trimIndent(),
+        )
+
+        myFixture.enableInspections(ArmeriaDuplicateRegistrationKotlinInspection())
+        val registrationHighlights =
+            myFixture.doHighlighting().filter {
+                it.description.startsWith("This Armeria route")
+            }
+
+        assertTrue(registrationHighlights.isEmpty())
+    }
+
     fun testKotlinInspectionHighlightsDuplicateAndOffersNavigateQuickFix() {
         myFixture.configureByText(
             "First.kt",

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspectionTest.kt
@@ -118,7 +118,7 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
         myFixture.enableInspections(ArmeriaDuplicateRegistrationInspection())
         val registrationHighlights =
             myFixture.doHighlighting().filter {
-                it.description.startsWith("This Armeria route")
+                it.description?.contains("conflicting registrations in this module") == true
             }
 
         assertTrue(registrationHighlights.isEmpty())
@@ -145,7 +145,7 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
         myFixture.enableInspections(ArmeriaDuplicateRegistrationKotlinInspection())
         val registrationHighlights =
             myFixture.doHighlighting().filter {
-                it.description.startsWith("This Armeria route")
+                it.description?.contains("conflicting registrations in this module") == true
             }
 
         assertTrue(registrationHighlights.isEmpty())
@@ -172,7 +172,7 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
         myFixture.enableInspections(ArmeriaDuplicateRegistrationKotlinInspection())
         val registrationHighlights =
             myFixture.doHighlighting().filter {
-                it.description.startsWith("This Armeria route")
+                it.description?.contains("conflicting registrations in this module") == true
             }
 
         assertTrue(registrationHighlights.isEmpty())

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspectionTest.kt
@@ -293,11 +293,15 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
 
         myFixture.openFileInEditor(firstFile.virtualFile)
         assertRegistrationDuplicateHighlightOnKotlinMethod("First", "first", expectedDescription)
+        assertRegistrationNavigateQuickFixAvailable("GET /shared")
 
         myFixture.openFileInEditor(secondFile.virtualFile)
         assertRegistrationDuplicateHighlightOnKotlinMethod("Second", "second", expectedDescription)
+        assertRegistrationNavigateQuickFixAvailable("GET /shared")
+    }
 
-        val expectedQuickFixName = message("inspection.duplicate.registration.quickfix.navigate", "GET /shared")
+    private fun assertRegistrationNavigateQuickFixAvailable(label: String) {
+        val expectedQuickFixName = message("inspection.duplicate.registration.quickfix.navigate", label)
         val quickFixes =
             myFixture.getAvailableQuickFixes().filter {
                 it.text == expectedQuickFixName

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspectionTest.kt
@@ -6,6 +6,9 @@ import com.intellij.psi.PsiJavaFile
 import com.intellij.testFramework.PlatformTestUtil
 import com.linecorp.intellij.plugins.armeria.message
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtNamedFunction
 
 class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {
@@ -16,6 +19,30 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
         myFixture.doHighlighting().filter {
             it.description?.let(::matchesRegistrationDuplicateProblem) == true
         }
+
+    private fun assertRegistrationDuplicateHighlightOnKotlinMethod(
+        className: String,
+        functionName: String,
+        expectedDescription: String,
+    ) {
+        val duplicateHighlights =
+            myFixture.doHighlighting().filter {
+                it.description == expectedDescription
+            }
+        assertEquals(1, duplicateHighlights.size)
+
+        val file = myFixture.file as KtFile
+        val clazz =
+            file.declarations.filterIsInstance<KtClassOrObject>().singleOrNull { it.name == className }
+                ?: error("Class $className not found in ${file.name}")
+        val function =
+            clazz.declarations.filterIsInstance<KtNamedFunction>().single { it.name == functionName }
+        val functionOffset = function.nameIdentifier!!.textRange.startOffset
+        assertTrue(
+            "Expected registration duplicate highlight on $className.$functionName",
+            functionOffset in duplicateHighlights.map { it.startOffset }.toSet(),
+        )
+    }
 
     private fun assertRegistrationDuplicateHighlightOnMethod(
         className: String,
@@ -186,6 +213,32 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
         assertTrue(registrationDuplicateHighlights().isEmpty())
     }
 
+    fun testJavaDistinctPathsAreNotRegistrationProblems() {
+        myFixture.configureByText(
+            "HelloService.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Get;
+
+            public class HelloService {
+                @Get("/hello")
+                public String hello() {
+                    return "hello";
+                }
+
+                @Get("/goodbye")
+                public String goodbye() {
+                    return "goodbye";
+                }
+            }
+            """.trimIndent(),
+        )
+
+        myFixture.enableInspections(ArmeriaDuplicateRegistrationInspection())
+        assertTrue(registrationDuplicateHighlights().isEmpty())
+    }
+
     fun testKotlinDistinctPathsAreNotRegistrationProblems() {
         myFixture.configureByText(
             "HelloService.kt",
@@ -209,8 +262,7 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
     }
 
     fun testKotlinInspectionHighlightsDuplicateAndOffersNavigateQuickFix() {
-        myFixture.configureByText(
-            "First.kt",
+        val firstContent =
             """
             package example
 
@@ -220,10 +272,8 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
                 @Get("/shared")
                 fun first(): String = "first"
             }
-            """.trimIndent(),
-        )
-        myFixture.configureByText(
-            "Second.kt",
+            """.trimIndent()
+        val secondContent =
             """
             package example
 
@@ -233,17 +283,20 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
                 @Get("/shared")
                 fun second(): String = "second"
             }
-            """.trimIndent(),
-        )
+            """.trimIndent()
+
+        val firstFile = myFixture.configureByText("First.kt", firstContent)
+        val secondFile = myFixture.configureByText("Second.kt", secondContent)
 
         myFixture.enableInspections(ArmeriaDuplicateRegistrationKotlinInspection())
         val expectedDescription = message("inspection.duplicate.registration.problem", "GET /shared", 2)
-        val duplicateHighlights =
-            myFixture.doHighlighting().filter {
-                it.description == expectedDescription
-            }
 
-        assertEquals(1, duplicateHighlights.size)
+        myFixture.openFileInEditor(firstFile.virtualFile)
+        assertRegistrationDuplicateHighlightOnKotlinMethod("First", "first", expectedDescription)
+
+        myFixture.openFileInEditor(secondFile.virtualFile)
+        assertRegistrationDuplicateHighlightOnKotlinMethod("Second", "second", expectedDescription)
+
         val expectedQuickFixName = message("inspection.duplicate.registration.quickfix.navigate", "GET /shared")
         val quickFixes =
             myFixture.getAvailableQuickFixes().filter {

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRouteInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRouteInspectionTest.kt
@@ -1,5 +1,6 @@
 package com.linecorp.intellij.plugins.armeria.inspection
 
+import com.linecorp.intellij.plugins.armeria.message
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
 
 class ArmeriaDuplicateRouteInspectionTest : ArmeriaFixtureTestBase() {
@@ -22,19 +23,25 @@ class ArmeriaDuplicateRouteInspectionTest : ArmeriaFixtureTestBase() {
 
             public class BadService {
                 @Get("/dup")
-                public String <warning descr="This annotated Armeria route duplicates another HTTP method/path combination in the same service class.">first</warning>() {
+                public String first() {
                     return "first";
                 }
 
                 @Get("/dup")
-                public String <warning descr="This annotated Armeria route duplicates another HTTP method/path combination in the same service class.">second</warning>() {
+                public String second() {
                     return "second";
                 }
             }
             """.trimIndent(),
         )
 
-        myFixture.testHighlighting(true, false, true)
+        val expectedDescription = message("inspection.duplicate.route.problem")
+        val duplicateHighlights =
+            myFixture.doHighlighting().filter {
+                it.description == expectedDescription
+            }
+
+        assertEquals(2, duplicateHighlights.size)
     }
 
     fun testAllowsDistinctPaths() {
@@ -59,7 +66,12 @@ class ArmeriaDuplicateRouteInspectionTest : ArmeriaFixtureTestBase() {
             """.trimIndent(),
         )
 
-        myFixture.testHighlighting(true, false, true)
+        val routeDuplicateHighlights =
+            myFixture.doHighlighting().filter {
+                it.description == message("inspection.duplicate.route.problem")
+            }
+
+        assertTrue(routeDuplicateHighlights.isEmpty())
     }
 
     fun testAllowsDifferentHttpMethodsOnSamePath() {
@@ -85,6 +97,11 @@ class ArmeriaDuplicateRouteInspectionTest : ArmeriaFixtureTestBase() {
             """.trimIndent(),
         )
 
-        myFixture.testHighlighting(true, false, true)
+        val routeDuplicateHighlights =
+            myFixture.doHighlighting().filter {
+                it.description == message("inspection.duplicate.route.problem")
+            }
+
+        assertTrue(routeDuplicateHighlights.isEmpty())
     }
 }

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRouteInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRouteInspectionTest.kt
@@ -1,0 +1,90 @@
+package com.linecorp.intellij.plugins.armeria.inspection
+
+import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+
+class ArmeriaDuplicateRouteInspectionTest : ArmeriaFixtureTestBase() {
+    override fun registerArmeriaStubs() {
+        registerRouteDuplicateIndexStubs()
+    }
+
+    override fun setUp() {
+        super.setUp()
+        myFixture.enableInspections(ArmeriaDuplicateRouteInspection())
+    }
+
+    fun testHighlightsDuplicateJavaRoutes() {
+        myFixture.configureByText(
+            "BadService.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Get;
+
+            public class BadService {
+                @Get("/dup")
+                public String <warning descr="This annotated Armeria route duplicates another HTTP method/path combination in the same service class.">first</warning>() {
+                    return "first";
+                }
+
+                @Get("/dup")
+                public String <warning descr="This annotated Armeria route duplicates another HTTP method/path combination in the same service class.">second</warning>() {
+                    return "second";
+                }
+            }
+            """.trimIndent(),
+        )
+
+        myFixture.testHighlighting(true, false, true)
+    }
+
+    fun testAllowsDistinctPaths() {
+        myFixture.configureByText(
+            "HelloService.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Get;
+
+            public class HelloService {
+                @Get("/hello")
+                public String hello() {
+                    return "hello";
+                }
+
+                @Get("/goodbye")
+                public String goodbye() {
+                    return "goodbye";
+                }
+            }
+            """.trimIndent(),
+        )
+
+        myFixture.testHighlighting(true, false, true)
+    }
+
+    fun testAllowsDifferentHttpMethodsOnSamePath() {
+        myFixture.configureByText(
+            "Routes.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Get;
+            import com.linecorp.armeria.server.annotation.Post;
+
+            public class Routes {
+                @Get("/resource")
+                public String read() {
+                    return "read";
+                }
+
+                @Post("/resource")
+                public String write() {
+                    return "write";
+                }
+            }
+            """.trimIndent(),
+        )
+
+        myFixture.testHighlighting(true, false, true)
+    }
+}

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRouteInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRouteInspectionTest.kt
@@ -1,5 +1,6 @@
 package com.linecorp.intellij.plugins.armeria.inspection
 
+import com.intellij.psi.PsiJavaFile
 import com.linecorp.intellij.plugins.armeria.message
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
 
@@ -35,13 +36,7 @@ class ArmeriaDuplicateRouteInspectionTest : ArmeriaFixtureTestBase() {
             """.trimIndent(),
         )
 
-        val expectedDescription = message("inspection.duplicate.route.problem")
-        val duplicateHighlights =
-            myFixture.doHighlighting().filter {
-                it.description == expectedDescription
-            }
-
-        assertEquals(2, duplicateHighlights.size)
+        assertDuplicateRouteHighlightsOnMethods("BadService", "first", "BadService", "second")
     }
 
     fun testAllowsDistinctPaths() {
@@ -66,12 +61,7 @@ class ArmeriaDuplicateRouteInspectionTest : ArmeriaFixtureTestBase() {
             """.trimIndent(),
         )
 
-        val routeDuplicateHighlights =
-            myFixture.doHighlighting().filter {
-                it.description == message("inspection.duplicate.route.problem")
-            }
-
-        assertTrue(routeDuplicateHighlights.isEmpty())
+        assertNoDuplicateRouteHighlights()
     }
 
     fun testAllowsDifferentHttpMethodsOnSamePath() {
@@ -97,11 +87,41 @@ class ArmeriaDuplicateRouteInspectionTest : ArmeriaFixtureTestBase() {
             """.trimIndent(),
         )
 
+        assertNoDuplicateRouteHighlights()
+    }
+
+    private fun assertNoDuplicateRouteHighlights() {
         val routeDuplicateHighlights =
             myFixture.doHighlighting().filter {
                 it.description == message("inspection.duplicate.route.problem")
             }
 
         assertTrue(routeDuplicateHighlights.isEmpty())
+    }
+
+    private fun assertDuplicateRouteHighlightsOnMethods(vararg classAndMethodNames: String) {
+        require(classAndMethodNames.size % 2 == 0) { "Expected class/method pairs" }
+
+        val expectedDescription = message("inspection.duplicate.route.problem")
+        val duplicateHighlights =
+            myFixture.doHighlighting().filter {
+                it.description == expectedDescription
+            }
+
+        assertEquals(classAndMethodNames.size / 2, duplicateHighlights.size)
+
+        val file = myFixture.file as PsiJavaFile
+        val highlightedOffsets = duplicateHighlights.map { it.startOffset }.toSet()
+        classAndMethodNames.toList().chunked(2).forEach { (className, methodName) ->
+            val clazz =
+                file.classes.singleOrNull { it.name == className }
+                    ?: error("Class $className not found in ${file.name}")
+            val method = clazz.findMethodsByName(methodName, false).single()
+            val methodOffset = method.nameIdentifier!!.textRange.startOffset
+            assertTrue(
+                "Expected duplicate route highlight on $className.$methodName",
+                methodOffset in highlightedOffsets,
+            )
+        }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds PSI fixture regression tests for Armeria duplicate route and duplicate registration inspections. These inspections previously had limited automated coverage at the highlighting level beyond duplicate index unit tests.

Closes #275.

## Changes

- Add `ArmeriaDuplicateRouteInspectionTest` for Java annotated route duplicates: same-class duplicate `@Get`, distinct paths, and different HTTP methods on the same path; positive cases assert highlights land on method `nameIdentifier` offsets, not only description text
- Extend `ArmeriaDuplicateRegistrationInspectionTest` with Java cross-file annotated route highlighting (active file `First.java` and `Second.java`) with `nameIdentifier` offset assertions, in-class annotated duplicate exclusion from registration inspection, Java/Kotlin distinct-path negative cases, and Kotlin cross-file highlighting with per-file `nameIdentifier` and navigate quick-fix assertions
- Add `matchesRegistrationDuplicateProblem()` helper that builds a regex from localized bundle messages (private-use placeholders for label and Unicode digit count) instead of hardcoded English substrings
- Document the new fixture coverage in `CHANGELOG.md` Unreleased

## Test plan

- [x] Gradle MCP `:plugin:ktlintTestSourceSetCheck`
- [x] Gradle MCP `:plugin:test` — `ArmeriaDuplicateRouteInspectionTest` (3 methods)
- [x] Gradle MCP `:plugin:test` — `ArmeriaDuplicateRegistrationInspectionTest` (8 methods)
- [x] Thermo-nuclear review — zero P0–P2 findings
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9150-6941-71c6-99c3-b69ec0979827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9150-6941-71c6-99c3-b69ec0979827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

