### PR TITLE
Add gRPC gutter icons for proto rpc definitions

### DIFF
--- a/plugin-route-model/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/model/GrpcRoutePath.kt
+++ b/plugin-route-model/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/model/GrpcRoutePath.kt
@@ -1,0 +1,8 @@
+package com.linecorp.intellij.plugins.armeria.explorer.model
+
+object GrpcRoutePath {
+    fun path(
+        fqService: String,
+        methodName: String,
+    ): String = "/$fqService/$methodName"
+}

--- a/plugin-route-protocol/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/protocol/ArmeriaGrpcRouteCollector.kt
+++ b/plugin-route-protocol/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/protocol/ArmeriaGrpcRouteCollector.kt
@@ -81,6 +81,11 @@ object ArmeriaGrpcRouteCollector {
         }
     }
 
+    fun grpcPath(
+        fqService: String,
+        methodName: String,
+    ): String = "/$fqService/$methodName"
+
     fun addProtoRoute(
         element: PsiElement,
         fqService: String,
@@ -88,7 +93,7 @@ object ArmeriaGrpcRouteCollector {
         routes: MutableList<ArmeriaRoute>,
         seenProtoRoutes: MutableSet<String>,
     ) {
-        val path = "/$fqService/$methodName"
+        val path = grpcPath(fqService, methodName)
         val dedupeKey = "${ArmeriaRouteMetadata.moduleName(element)}:$path"
         if (!seenProtoRoutes.add(dedupeKey)) {
             return

--- a/plugin-route-protocol/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/protocol/ArmeriaGrpcRouteCollector.kt
+++ b/plugin-route-protocol/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/protocol/ArmeriaGrpcRouteCollector.kt
@@ -11,6 +11,7 @@ import com.intellij.psi.search.FilenameIndex
 import com.intellij.psi.search.GlobalSearchScope
 import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
 import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRouteMetadata
+import com.linecorp.intellij.plugins.armeria.explorer.model.GrpcRoutePath
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaRouteCollectionMetrics
 import com.linecorp.intellij.plugins.armeria.message
@@ -81,11 +82,6 @@ object ArmeriaGrpcRouteCollector {
         }
     }
 
-    fun grpcPath(
-        fqService: String,
-        methodName: String,
-    ): String = "/$fqService/$methodName"
-
     fun addProtoRoute(
         element: PsiElement,
         fqService: String,
@@ -93,7 +89,7 @@ object ArmeriaGrpcRouteCollector {
         routes: MutableList<ArmeriaRoute>,
         seenProtoRoutes: MutableSet<String>,
     ) {
-        val path = grpcPath(fqService, methodName)
+        val path = GrpcRoutePath.path(fqService, methodName)
         val dedupeKey = "${ArmeriaRouteMetadata.moduleName(element)}:$path"
         if (!seenProtoRoutes.add(dedupeKey)) {
             return

--- a/plugin-shared/src/main/resources/messages/ArmeriaBundle.properties
+++ b/plugin-shared/src/main/resources/messages/ArmeriaBundle.properties
@@ -135,6 +135,8 @@ armeria.services.name=Armeria Services
 marker.route.title=Armeria route
 marker.route.annotated={0} {1}
 marker.route.registration={0}("{1}")
+marker.grpc.title=Armeria gRPC route
+marker.grpc.rpc={0}
 
 editor.route.gotoRelated.handler={0} {1}
 editor.route.gotoRelated.handlers=Annotated handlers

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,7 @@
 - ktlint via `com.linecorp.intellij.ktlint` convention (`ktlint_official` style); `ktlintCheck` runs as part of `check` / `build`.
 - gRPC Route Explorer discovery uses Proto Editor PSI when `idea.plugin.protoeditor` is available (RPC-level navigation), with fallback to the existing `.proto` text parser.
 - IDE support for Armeria JUnit 5 integration tests: `@RegisterExtension` `ServerExtension` gutter markers, blocking-route inspection in tests, and Generate Test Method from Route Explorer.
+- gRPC gutter icons on `rpc` keywords in `.proto` files (when Proto Editor is installed), showing the resolved gRPC path in the tooltip.
 
 ### Changed
 

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaProtoPsiRouteCollector.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaProtoPsiRouteCollector.kt
@@ -24,10 +24,15 @@ class ArmeriaProtoPsiRouteCollector : ArmeriaProtoRouteCollector {
             return false
         }
         for (service in services) {
-            val fqService = service.qualifiedName?.toString()?.takeIf { it.isNotBlank() } ?: continue
             for (method in service.body?.serviceMethodList.orEmpty()) {
-                val methodName = method.name ?: continue
-                ArmeriaGrpcRouteCollector.addProtoRoute(method, fqService, methodName, routes, seenProtoRoutes)
+                val resolved = resolveProtoGrpcMethod(method) ?: continue
+                ArmeriaGrpcRouteCollector.addProtoRoute(
+                    method,
+                    resolved.fqService,
+                    resolved.methodName,
+                    routes,
+                    seenProtoRoutes,
+                )
             }
         }
         // Services were present: PSI owns this file even when every method was skipped/deduped.

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ResolvedProtoGrpcMethod.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ResolvedProtoGrpcMethod.kt
@@ -1,0 +1,21 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.intellij.protobuf.lang.psi.PbServiceDefinition
+import com.intellij.protobuf.lang.psi.PbServiceMethod
+import com.intellij.psi.util.PsiTreeUtil
+import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaGrpcRouteCollector
+
+internal data class ResolvedProtoGrpcMethod(
+    val fqService: String,
+    val methodName: String,
+) {
+    val path: String
+        get() = ArmeriaGrpcRouteCollector.grpcPath(fqService, methodName)
+}
+
+internal fun resolveProtoGrpcMethod(method: PbServiceMethod): ResolvedProtoGrpcMethod? {
+    val methodName = method.name ?: return null
+    val service = PsiTreeUtil.getParentOfType(method, PbServiceDefinition::class.java) ?: return null
+    val fqService = service.qualifiedName?.toString()?.takeIf { it.isNotBlank() } ?: return null
+    return ResolvedProtoGrpcMethod(fqService, methodName)
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ResolvedProtoGrpcMethod.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ResolvedProtoGrpcMethod.kt
@@ -3,14 +3,14 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.intellij.protobuf.lang.psi.PbServiceDefinition
 import com.intellij.protobuf.lang.psi.PbServiceMethod
 import com.intellij.psi.util.PsiTreeUtil
-import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaGrpcRouteCollector
+import com.linecorp.intellij.plugins.armeria.explorer.model.GrpcRoutePath
 
 internal data class ResolvedProtoGrpcMethod(
     val fqService: String,
     val methodName: String,
 ) {
     val path: String
-        get() = ArmeriaGrpcRouteCollector.grpcPath(fqService, methodName)
+        get() = GrpcRoutePath.path(fqService, methodName)
 }
 
 internal fun resolveProtoGrpcMethod(method: PbServiceMethod): ResolvedProtoGrpcMethod? {

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaProtoRpcLineMarkerProvider.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaProtoRpcLineMarkerProvider.kt
@@ -4,11 +4,9 @@ import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.codeInsight.daemon.LineMarkerProvider
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.IndexNotReadyException
-import com.intellij.protobuf.lang.psi.PbServiceDefinition
 import com.intellij.protobuf.lang.psi.PbServiceMethod
 import com.intellij.psi.PsiElement
-import com.intellij.psi.util.PsiTreeUtil
-import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaGrpcRouteCollector
+import com.linecorp.intellij.plugins.armeria.explorer.resolveProtoGrpcMethod
 import com.linecorp.intellij.plugins.armeria.message
 
 internal class ArmeriaProtoRpcLineMarkerProvider : LineMarkerProvider {
@@ -28,13 +26,10 @@ internal class ArmeriaProtoRpcLineMarkerProvider : LineMarkerProvider {
 
     private fun protoRpcMarker(element: PsiElement): LineMarkerInfo<*>? {
         val method = element.parent as? PbServiceMethod ?: return null
-        val methodName = method.name ?: return null
-        val service = PsiTreeUtil.getParentOfType(method, PbServiceDefinition::class.java) ?: return null
-        val fqService = service.qualifiedName?.toString()?.takeIf { it.isNotBlank() } ?: return null
-        val path = ArmeriaGrpcRouteCollector.grpcPath(fqService, methodName)
+        val resolved = resolveProtoGrpcMethod(method) ?: return null
         return ArmeriaRouteLineMarkerSupport.createGrpcMarker(
             element,
-            message("marker.grpc.rpc", path),
+            message("marker.grpc.rpc", resolved.path),
         )
     }
 }

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaProtoRpcLineMarkerProvider.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaProtoRpcLineMarkerProvider.kt
@@ -1,0 +1,40 @@
+package com.linecorp.intellij.plugins.armeria.marker
+
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.codeInsight.daemon.LineMarkerProvider
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.IndexNotReadyException
+import com.intellij.protobuf.lang.psi.PbServiceDefinition
+import com.intellij.protobuf.lang.psi.PbServiceMethod
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaGrpcRouteCollector
+import com.linecorp.intellij.plugins.armeria.message
+
+internal class ArmeriaProtoRpcLineMarkerProvider : LineMarkerProvider {
+    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
+        if (element.text != "rpc") {
+            return null
+        }
+        if (DumbService.isDumb(element.project)) {
+            return null
+        }
+        return try {
+            protoRpcMarker(element)
+        } catch (_: IndexNotReadyException) {
+            null
+        }
+    }
+
+    private fun protoRpcMarker(element: PsiElement): LineMarkerInfo<*>? {
+        val method = element.parent as? PbServiceMethod ?: return null
+        val methodName = method.name ?: return null
+        val service = PsiTreeUtil.getParentOfType(method, PbServiceDefinition::class.java) ?: return null
+        val fqService = service.qualifiedName?.toString()?.takeIf { it.isNotBlank() } ?: return null
+        val path = ArmeriaGrpcRouteCollector.grpcPath(fqService, methodName)
+        return ArmeriaRouteLineMarkerSupport.createGrpcMarker(
+            element,
+            message("marker.grpc.rpc", path),
+        )
+    }
+}

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaProtoRpcLineMarkerProvider.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaProtoRpcLineMarkerProvider.kt
@@ -5,16 +5,21 @@ import com.intellij.codeInsight.daemon.LineMarkerProvider
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.IndexNotReadyException
 import com.intellij.protobuf.lang.psi.PbServiceMethod
+import com.intellij.protobuf.lang.psi.ProtoTokenTypes
 import com.intellij.psi.PsiElement
+import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaGrpcRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.resolveProtoGrpcMethod
 import com.linecorp.intellij.plugins.armeria.message
 
 internal class ArmeriaProtoRpcLineMarkerProvider : LineMarkerProvider {
     override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
-        if (element.text != "rpc") {
+        if (element.node?.elementType != ProtoTokenTypes.RPC) {
             return null
         }
         if (DumbService.isDumb(element.project)) {
+            return null
+        }
+        if (!ArmeriaGrpcRouteCollector.isProtoRouteDiscoveryEnabled()) {
             return null
         }
         return try {

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaRouteLineMarkerSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaRouteLineMarkerSupport.kt
@@ -13,6 +13,17 @@ internal object ArmeriaRouteLineMarkerSupport {
     fun createMarker(
         element: PsiElement,
         tooltip: String,
+    ): LineMarkerInfo<PsiElement> = createMarker(element, tooltip, "marker.route.title")
+
+    fun createGrpcMarker(
+        element: PsiElement,
+        tooltip: String,
+    ): LineMarkerInfo<PsiElement> = createMarker(element, tooltip, "marker.grpc.title")
+
+    private fun createMarker(
+        element: PsiElement,
+        tooltip: String,
+        titleKey: String,
     ): LineMarkerInfo<PsiElement> =
         LineMarkerInfo(
             element,
@@ -21,6 +32,6 @@ internal object ArmeriaRouteLineMarkerSupport {
             { tooltip },
             null,
             GutterIconRenderer.Alignment.CENTER,
-            { message("marker.route.title") },
+            { message(titleKey) },
         )
 }

--- a/plugin/src/main/resources/META-INF/proto-integration.xml
+++ b/plugin/src/main/resources/META-INF/proto-integration.xml
@@ -1,4 +1,8 @@
 <idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <codeInsight.lineMarkerProvider language="protobuf"
+                                        implementationClass="com.linecorp.intellij.plugins.armeria.marker.ArmeriaProtoRpcLineMarkerProvider"/>
+    </extensions>
     <extensions defaultExtensionNs="com.linecorp.intellij.armeria">
         <protoRouteCollector implementation="com.linecorp.intellij.plugins.armeria.explorer.ArmeriaProtoPsiRouteCollector"/>
     </extensions>

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaProtoRpcLineMarkerProviderTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaProtoRpcLineMarkerProviderTest.kt
@@ -1,0 +1,125 @@
+package com.linecorp.intellij.plugins.armeria.marker
+
+import com.intellij.protobuf.lang.psi.PbFile
+import com.intellij.protobuf.lang.psi.PbServiceMethod
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import com.linecorp.intellij.plugins.armeria.ArmeriaIcons
+import com.linecorp.intellij.plugins.armeria.message
+import com.linecorp.intellij.plugins.armeria.test.ArmeriaLightJavaCodeInsightFixtureTestCase
+
+class ArmeriaProtoRpcLineMarkerProviderTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {
+    private val provider = ArmeriaProtoRpcLineMarkerProvider()
+
+    fun testProtoRpcMarkerShowsGrpcPath() {
+        myFixture.configureByText(
+            "greeter.proto",
+            """
+            syntax = "proto3";
+            package com.example;
+
+            service Greeter {
+              rpc SayHello(HelloRequest) returns (HelloResponse);
+            }
+            """.trimIndent(),
+        )
+        assertTrue(myFixture.file is PbFile)
+
+        val rpcKeyword = findRpcKeyword()
+        val marker = provider.getLineMarkerInfo(rpcKeyword)
+
+        assertNotNull(marker)
+        assertEquals(ArmeriaIcons.Armeria, marker!!.icon)
+        assertEquals(
+            message("marker.grpc.rpc", "/com.example.Greeter/SayHello"),
+            marker.lineMarkerTooltip,
+        )
+    }
+
+    fun testProtoRpcMarkerWithoutPackage() {
+        myFixture.configureByText(
+            "greeter.proto",
+            """
+            syntax = "proto3";
+
+            service Greeter {
+              rpc Ping(PingRequest) returns (PingResponse);
+            }
+            """.trimIndent(),
+        )
+        assertTrue(myFixture.file is PbFile)
+
+        val rpcKeyword = findRpcKeyword()
+        val marker = provider.getLineMarkerInfo(rpcKeyword)
+
+        assertNotNull(marker)
+        assertEquals(
+            message("marker.grpc.rpc", "/Greeter/Ping"),
+            marker!!.lineMarkerTooltip,
+        )
+    }
+
+    fun testServiceKeywordHasNoMarker() {
+        myFixture.configureByText(
+            "greeter.proto",
+            """
+            syntax = "proto3";
+            package com.example;
+
+            service Greeter {
+              rpc SayHello(HelloRequest) returns (HelloResponse);
+            }
+            """.trimIndent(),
+        )
+
+        val serviceIndex = myFixture.file.text.indexOf("service")
+        val serviceKeyword = myFixture.file.findElementAt(serviceIndex)!!
+
+        assertNull(provider.getLineMarkerInfo(serviceKeyword))
+    }
+
+    fun testMethodNameIdentifierHasNoMarker() {
+        myFixture.configureByText(
+            "greeter.proto",
+            """
+            syntax = "proto3";
+            package com.example;
+
+            service Greeter {
+              rpc SayHello(HelloRequest) returns (HelloResponse);
+            }
+            """.trimIndent(),
+        )
+
+        val method = PsiTreeUtil.findChildOfType(myFixture.file, PbServiceMethod::class.java)!!
+        val nameIdentifier = method.nameIdentifier!!
+
+        assertNull(provider.getLineMarkerInfo(nameIdentifier))
+    }
+
+    fun testCommentedRpcHasNoMarker() {
+        myFixture.configureByText(
+            "greeter.proto",
+            """
+            syntax = "proto3";
+            package com.example;
+
+            service Greeter {
+              // rpc Deprecated(HelloRequest) returns (HelloResponse);
+              rpc SayHello(HelloRequest) returns (HelloResponse);
+            }
+            """.trimIndent(),
+        )
+
+        val commentedRpcIndex = myFixture.file.text.indexOf("// rpc")
+        val commentedRpcKeyword = myFixture.file.findElementAt(commentedRpcIndex + 3)
+
+        assertNull(provider.getLineMarkerInfo(commentedRpcKeyword!!))
+        assertNotNull(provider.getLineMarkerInfo(findRpcKeyword()))
+    }
+
+    private fun findRpcKeyword(): PsiElement {
+        val method = PsiTreeUtil.findChildOfType(myFixture.file, PbServiceMethod::class.java)!!
+        return method.children.first { it.text == "rpc" }
+    }
+}

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaProtoRpcLineMarkerProviderTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaProtoRpcLineMarkerProviderTest.kt
@@ -97,6 +97,29 @@ class ArmeriaProtoRpcLineMarkerProviderTest : ArmeriaLightJavaCodeInsightFixture
         assertNull(provider.getLineMarkerInfo(nameIdentifier))
     }
 
+    fun testProtoRpcMarkerIgnoresJavaPackageOption() {
+        myFixture.configureByText(
+            "greeter.proto",
+            """
+            syntax = "proto3";
+            package com.example;
+            option java_package = "com.example.java";
+
+            service Greeter {
+              rpc SayHello(HelloRequest) returns (HelloResponse);
+            }
+            """.trimIndent(),
+        )
+
+        val marker = provider.getLineMarkerInfo(findRpcKeyword())
+
+        assertNotNull(marker)
+        assertEquals(
+            message("marker.grpc.rpc", "/com.example.Greeter/SayHello"),
+            marker!!.lineMarkerTooltip,
+        )
+    }
+
     fun testCommentedRpcHasNoMarker() {
         myFixture.configureByText(
             "greeter.proto",

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaProtoRpcLineMarkerProviderTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaProtoRpcLineMarkerProviderTest.kt
@@ -119,7 +119,17 @@ class ArmeriaProtoRpcLineMarkerProviderTest : ArmeriaLightJavaCodeInsightFixture
     }
 
     private fun findRpcKeyword(): PsiElement {
-        val rpcIndex = myFixture.file.text.indexOf("rpc ")
-        return myFixture.file.findElementAt(rpcIndex)!!
+        val method = PsiTreeUtil.findChildOfType(myFixture.file, PbServiceMethod::class.java)!!
+        return findRpcLeaf(method) ?: error("rpc keyword not found under ${method.text}")
+    }
+
+    private fun findRpcLeaf(element: PsiElement): PsiElement? {
+        if (element.text == "rpc") {
+            return element
+        }
+        for (child in element.children) {
+            findRpcLeaf(child)?.let { return it }
+        }
+        return null
     }
 }

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaProtoRpcLineMarkerProviderTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaProtoRpcLineMarkerProviderTest.kt
@@ -120,16 +120,6 @@ class ArmeriaProtoRpcLineMarkerProviderTest : ArmeriaLightJavaCodeInsightFixture
 
     private fun findRpcKeyword(): PsiElement {
         val method = PsiTreeUtil.findChildOfType(myFixture.file, PbServiceMethod::class.java)!!
-        return findRpcLeaf(method) ?: error("rpc keyword not found under ${method.text}")
-    }
-
-    private fun findRpcLeaf(element: PsiElement): PsiElement? {
-        if (element.text == "rpc") {
-            return element
-        }
-        for (child in element.children) {
-            findRpcLeaf(child)?.let { return it }
-        }
-        return null
+        return myFixture.file.findElementAt(method.textRange.startOffset)!!
     }
 }

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaProtoRpcLineMarkerProviderTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaProtoRpcLineMarkerProviderTest.kt
@@ -112,14 +112,14 @@ class ArmeriaProtoRpcLineMarkerProviderTest : ArmeriaLightJavaCodeInsightFixture
         )
 
         val commentedRpcIndex = myFixture.file.text.indexOf("// rpc")
-        val commentedRpcKeyword = myFixture.file.findElementAt(commentedRpcIndex + 3)
+        val commentedRpcKeyword = myFixture.file.findElementAt(commentedRpcIndex + 3)!!
 
-        assertNull(provider.getLineMarkerInfo(commentedRpcKeyword!!))
+        assertNull(provider.getLineMarkerInfo(commentedRpcKeyword))
         assertNotNull(provider.getLineMarkerInfo(findRpcKeyword()))
     }
 
     private fun findRpcKeyword(): PsiElement {
-        val method = PsiTreeUtil.findChildOfType(myFixture.file, PbServiceMethod::class.java)!!
-        return method.children.first { it.text == "rpc" }
+        val rpcIndex = myFixture.file.text.indexOf("rpc ")
+        return myFixture.file.findElementAt(rpcIndex)!!
     }
 }

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaProtoRpcLineMarkerProviderTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaProtoRpcLineMarkerProviderTest.kt
@@ -141,6 +141,95 @@ class ArmeriaProtoRpcLineMarkerProviderTest : ArmeriaLightJavaCodeInsightFixture
         assertNotNull(provider.getLineMarkerInfo(findRpcKeyword()))
     }
 
+    fun testMultipleRpcMarkersInOneService() {
+        myFixture.configureByText(
+            "greeter.proto",
+            """
+            syntax = "proto3";
+            package com.example;
+
+            service Greeter {
+              rpc SayHello(HelloRequest) returns (HelloResponse);
+              rpc SayGoodbye(GoodbyeRequest) returns (GoodbyeResponse);
+            }
+            """.trimIndent(),
+        )
+
+        val methods = PsiTreeUtil.findChildrenOfType(myFixture.file, PbServiceMethod::class.java).toList()
+        assertEquals(2, methods.size)
+
+        val markers =
+            methods.map { method ->
+                val rpcKeyword = myFixture.file.findElementAt(method.textRange.startOffset)!!
+                provider.getLineMarkerInfo(rpcKeyword)
+            }
+        assertEquals(2, markers.filterNotNull().size)
+        assertEquals(
+            listOf(
+                message("marker.grpc.rpc", "/com.example.Greeter/SayGoodbye"),
+                message("marker.grpc.rpc", "/com.example.Greeter/SayHello"),
+            ),
+            markers.mapNotNull { it?.lineMarkerTooltip }.sorted(),
+        )
+    }
+
+    fun testMultipleServicesEachGetRpcMarkers() {
+        myFixture.configureByText(
+            "multi.proto",
+            """
+            syntax = "proto3";
+            package com.example;
+
+            service Greeter {
+              rpc SayHello(HelloRequest) returns (HelloResponse);
+            }
+
+            service Echo {
+              rpc Ping(PingRequest) returns (PingResponse);
+            }
+            """.trimIndent(),
+        )
+
+        val methods = PsiTreeUtil.findChildrenOfType(myFixture.file, PbServiceMethod::class.java).toList()
+        assertEquals(2, methods.size)
+
+        val tooltips =
+            methods
+                .map { method ->
+                    val rpcKeyword = myFixture.file.findElementAt(method.textRange.startOffset)!!
+                    provider.getLineMarkerInfo(rpcKeyword)!!.lineMarkerTooltip
+                }.sorted()
+        assertEquals(
+            listOf(
+                message("marker.grpc.rpc", "/com.example.Echo/Ping"),
+                message("marker.grpc.rpc", "/com.example.Greeter/SayHello"),
+            ),
+            tooltips,
+        )
+    }
+
+    fun testStreamingRpcMarkerShowsGrpcPath() {
+        myFixture.configureByText(
+            "greeter.proto",
+            """
+            syntax = "proto3";
+            package com.example;
+
+            service Greeter {
+              rpc StreamHello(stream HelloRequest) returns (stream HelloResponse);
+            }
+            """.trimIndent(),
+        )
+
+        val marker = provider.getLineMarkerInfo(findRpcKeyword())
+
+        assertNotNull(marker)
+        assertEquals(
+            message("marker.grpc.rpc", "/com.example.Greeter/StreamHello"),
+            marker!!.lineMarkerTooltip,
+        )
+    }
+
     private fun findRpcKeyword(): PsiElement {
         val method = PsiTreeUtil.findChildOfType(myFixture.file, PbServiceMethod::class.java)!!
         return myFixture.file.findElementAt(method.textRange.startOffset)!!


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds gutter icons on `rpc` definitions in `.proto` files when the Protocol Buffers (Proto Editor) plugin is installed. Developers can see the resolved gRPC path (`/package.Service/Method`) directly in proto sources.

Closes #270.

## Changes

- `ArmeriaProtoRpcLineMarkerProvider` marks `rpc` keywords (via `ProtoTokenTypes.RPC`) and shows the computed gRPC path in the tooltip
- `GrpcRoutePath` in `plugin-route-model` centralizes gRPC path formatting (`/package.Service/Method`)
- `ResolvedProtoGrpcMethod` / `resolveProtoGrpcMethod()` shared between the marker and `ArmeriaProtoPsiRouteCollector` so path resolution stays consistent
- Line marker honors `armeria.grpc.proto.routes.enabled` registry (same toggle as Route Explorer proto route discovery)
- Registered in `proto-integration.xml` for the optional Protoeditor dependency
- Bundle strings for gRPC marker tooltips (`marker.grpc.title`, `marker.grpc.rpc`)
- Unit tests covering proto fixture marker discovery (positive, no-package, negative, commented rpc, `java_package` option, multiple rpc, multiple services, streaming rpc)
- CHANGELOG entry for the user-visible gutter icon feature

## Test plan

- [x] `ArmeriaProtoRpcLineMarkerProviderTest` (9 tests) and `ArmeriaProtoPsiRouteCollectorTest`
- [x] `ktlintCheck`
- [ ] With the Protoeditor plugin enabled, open a `.proto` service and confirm gutter icons appear on `rpc` lines
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9247-a86a-72b2-87e5-25d1334a6615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9247-a86a-72b2-87e5-25d1334a6615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

