### PR TITLE
fix: skip blocking-client inspection for main-source *Test files

### DIFF
--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaJUnitServerExtensionSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaJUnitServerExtensionSupport.kt
@@ -140,6 +140,7 @@ internal object ArmeriaJUnitServerExtensionSupport {
     fun fileMayContainRegisterExtension(fileText: String): Boolean =
         REGISTER_EXTENSION_ANNOTATION in fileText || "@$REGISTER_EXTENSION_ANNOTATION_SHORT" in fileText
 
+    /** True when [file] is under a test source root (IDE markers only; filename is not considered). */
     fun isLikelyJUnitTestFile(file: PsiFile): Boolean {
         val virtualFile = file.virtualFile ?: return false
         val project = file.project

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaJUnitServerExtensionSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaJUnitServerExtensionSupport.kt
@@ -144,11 +144,8 @@ internal object ArmeriaJUnitServerExtensionSupport {
         val virtualFile = file.virtualFile ?: return false
         val project = file.project
         val fileIndex = ProjectRootManager.getInstance(project).fileIndex
-        if (fileIndex.isInTestSourceContent(virtualFile) || TestSourcesFilter.isTestSources(virtualFile, project)) {
-            return true
-        }
-        val name = virtualFile.name
-        return name.endsWith("Test.java") || name.endsWith("Test.kt")
+        return fileIndex.isInTestSourceContent(virtualFile) ||
+            TestSourcesFilter.isTestSources(virtualFile, project)
     }
 
     fun escapeStringLiteral(value: String): String =

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientInspectionTest.kt
@@ -2,12 +2,12 @@ package com.linecorp.intellij.plugins.armeria.test
 
 import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.ProblemsHolder
-import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiManager
 import com.intellij.testFramework.PsiTestUtil
+import com.intellij.testFramework.UsefulTestCase.runWriteAction
 import org.junit.Assert.assertTrue
 
 class ArmeriaBlockingClientInspectionTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {
@@ -254,7 +254,7 @@ class ArmeriaBlockingClientInspectionTest : ArmeriaLightJavaCodeInsightFixtureTe
         val mainRoot = myFixture.tempDirFixture.findOrCreateDir("main")
         PsiTestUtil.addSourceRoot(module, mainRoot, false)
         val virtualFile =
-            WriteAction.computeAndWait<com.intellij.openapi.vfs.VirtualFile, RuntimeException> {
+            runWriteAction {
                 mainRoot.createChildData(this, "MisnamedTest.java")
             }
         VfsUtil.saveText(

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientInspectionTest.kt
@@ -2,12 +2,12 @@ package com.linecorp.intellij.plugins.armeria.test
 
 import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiManager
 import com.intellij.testFramework.PsiTestUtil
-import com.intellij.testFramework.UsefulTestCase.runWriteAction
 import org.junit.Assert.assertTrue
 
 class ArmeriaBlockingClientInspectionTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {
@@ -253,12 +253,7 @@ class ArmeriaBlockingClientInspectionTest : ArmeriaLightJavaCodeInsightFixtureTe
     fun testNoInspectionSetupForMainSourceTestNamedFile() {
         val mainRoot = myFixture.tempDirFixture.findOrCreateDir("main")
         PsiTestUtil.addSourceRoot(module, mainRoot, false)
-        val virtualFile =
-            runWriteAction {
-                mainRoot.createChildData(this, "MisnamedTest.java")
-            }
-        VfsUtil.saveText(
-            virtualFile,
+        val content =
             """
             package example;
 
@@ -273,8 +268,13 @@ class ArmeriaBlockingClientInspectionTest : ArmeriaLightJavaCodeInsightFixtureTe
                     server.webClient().get("/slow");
                 }
             }
-            """.trimIndent(),
-        )
+            """.trimIndent()
+        val virtualFile =
+            ApplicationManager.getApplication().runWriteAction<com.intellij.openapi.vfs.VirtualFile> {
+                val file = mainRoot.createChildData(this, "MisnamedTest.java")
+                VfsUtil.saveText(file, content)
+                file
+            }
         PsiDocumentManager.getInstance(project).commitAllDocuments()
         val psiFile = PsiManager.getInstance(project).findFile(virtualFile)!!
 

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientInspectionTest.kt
@@ -2,7 +2,12 @@ package com.linecorp.intellij.plugins.armeria.test
 
 import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiManager
+import com.intellij.testFramework.PsiTestUtil
 import org.junit.Assert.assertTrue
 
 class ArmeriaBlockingClientInspectionTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {
@@ -243,5 +248,39 @@ class ArmeriaBlockingClientInspectionTest : ArmeriaLightJavaCodeInsightFixtureTe
         )
 
         myFixture.testHighlighting(true, false, true)
+    }
+
+    fun testNoInspectionSetupForMainSourceTestNamedFile() {
+        val mainRoot = myFixture.tempDirFixture.findOrCreateDir("main")
+        PsiTestUtil.addSourceRoot(module, mainRoot, false)
+        val virtualFile =
+            WriteAction.computeAndWait<com.intellij.openapi.vfs.VirtualFile, RuntimeException> {
+                mainRoot.createChildData(this, "MisnamedTest.java")
+            }
+        VfsUtil.saveText(
+            virtualFile,
+            """
+            package example;
+
+            import org.junit.jupiter.api.extension.RegisterExtension;
+            import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+            public class MisnamedTest {
+                @RegisterExtension
+                static ServerExtension server = new ServerExtension() {};
+
+                void run() {
+                    server.webClient().get("/slow");
+                }
+            }
+            """.trimIndent(),
+        )
+        PsiDocumentManager.getInstance(project).commitAllDocuments()
+        val psiFile = PsiManager.getInstance(project).findFile(virtualFile)!!
+
+        val manager = InspectionManager.getInstance(project)
+        val holder = ProblemsHolder(manager, psiFile, false)
+        val visitor = ArmeriaBlockingClientInspection().buildVisitor(holder, false)
+        assertTrue(visitor === PsiElementVisitor.EMPTY_VISITOR)
     }
 }

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientKotlinInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientKotlinInspectionTest.kt
@@ -3,8 +3,13 @@ package com.linecorp.intellij.plugins.armeria.test
 import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiManager
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.testFramework.PsiTestUtil
 import com.linecorp.intellij.plugins.armeria.message
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtFile
@@ -509,6 +514,40 @@ class ArmeriaBlockingClientKotlinInspectionTest : ArmeriaLightJavaCodeInsightFix
 
         val manager = InspectionManager.getInstance(project)
         val holder = ProblemsHolder(manager, myFixture.file, false)
+        val visitor = ArmeriaBlockingClientKotlinInspection().buildVisitor(holder, false)
+        assertTrue(visitor === PsiElementVisitor.EMPTY_VISITOR)
+    }
+
+    fun testNoInspectionSetupForMainSourceTestNamedFile() {
+        val mainRoot = myFixture.tempDirFixture.findOrCreateDir("main")
+        PsiTestUtil.addSourceRoot(module, mainRoot, false)
+        val virtualFile =
+            WriteAction.computeAndWait<com.intellij.openapi.vfs.VirtualFile, RuntimeException> {
+                mainRoot.createChildData(this, "MisnamedTest.kt")
+            }
+        VfsUtil.saveText(
+            virtualFile,
+            """
+            package example
+
+            import org.junit.jupiter.api.extension.RegisterExtension
+            import com.linecorp.armeria.testing.junit5.server.ServerExtension
+
+            class MisnamedTest {
+                @RegisterExtension
+                val server: ServerExtension = object : ServerExtension() {}
+
+                fun run() {
+                    server.webClient().get("/slow")
+                }
+            }
+            """.trimIndent(),
+        )
+        PsiDocumentManager.getInstance(project).commitAllDocuments()
+        val psiFile = PsiManager.getInstance(project).findFile(virtualFile)!!
+
+        val manager = InspectionManager.getInstance(project)
+        val holder = ProblemsHolder(manager, psiFile, false)
         val visitor = ArmeriaBlockingClientKotlinInspection().buildVisitor(holder, false)
         assertTrue(visitor === PsiElementVisitor.EMPTY_VISITOR)
     }

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientKotlinInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientKotlinInspectionTest.kt
@@ -3,13 +3,13 @@ package com.linecorp.intellij.plugins.armeria.test
 import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
-import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiManager
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.testFramework.PsiTestUtil
+import com.intellij.testFramework.UsefulTestCase.runWriteAction
 import com.linecorp.intellij.plugins.armeria.message
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtFile
@@ -522,7 +522,7 @@ class ArmeriaBlockingClientKotlinInspectionTest : ArmeriaLightJavaCodeInsightFix
         val mainRoot = myFixture.tempDirFixture.findOrCreateDir("main")
         PsiTestUtil.addSourceRoot(module, mainRoot, false)
         val virtualFile =
-            WriteAction.computeAndWait<com.intellij.openapi.vfs.VirtualFile, RuntimeException> {
+            runWriteAction {
                 mainRoot.createChildData(this, "MisnamedTest.kt")
             }
         VfsUtil.saveText(

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientKotlinInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientKotlinInspectionTest.kt
@@ -3,13 +3,13 @@ package com.linecorp.intellij.plugins.armeria.test
 import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiManager
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.testFramework.PsiTestUtil
-import com.intellij.testFramework.UsefulTestCase.runWriteAction
 import com.linecorp.intellij.plugins.armeria.message
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtFile
@@ -521,12 +521,7 @@ class ArmeriaBlockingClientKotlinInspectionTest : ArmeriaLightJavaCodeInsightFix
     fun testNoInspectionSetupForMainSourceTestNamedFile() {
         val mainRoot = myFixture.tempDirFixture.findOrCreateDir("main")
         PsiTestUtil.addSourceRoot(module, mainRoot, false)
-        val virtualFile =
-            runWriteAction {
-                mainRoot.createChildData(this, "MisnamedTest.kt")
-            }
-        VfsUtil.saveText(
-            virtualFile,
+        val content =
             """
             package example
 
@@ -541,8 +536,13 @@ class ArmeriaBlockingClientKotlinInspectionTest : ArmeriaLightJavaCodeInsightFix
                     server.webClient().get("/slow")
                 }
             }
-            """.trimIndent(),
-        )
+            """.trimIndent()
+        val virtualFile =
+            ApplicationManager.getApplication().runWriteAction<com.intellij.openapi.vfs.VirtualFile> {
+                val file = mainRoot.createChildData(this, "MisnamedTest.kt")
+                VfsUtil.saveText(file, content)
+                file
+            }
         PsiDocumentManager.getInstance(project).commitAllDocuments()
         val psiFile = PsiManager.getInstance(project).findFile(virtualFile)!!
 

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaJUnitTestSupportStubs.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaJUnitTestSupportStubs.kt
@@ -1,8 +1,13 @@
 package com.linecorp.intellij.plugins.armeria.test
 
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.roots.ModuleRootModificationUtil
+import com.intellij.testFramework.UsefulTestCase.runWriteAction
 import com.intellij.testFramework.fixtures.JavaCodeInsightTestFixture
 
 internal fun JavaCodeInsightTestFixture.registerArmeriaJUnitTestSupportStubs() {
+    markDefaultSourceRootAsTestSource(module)
     registerArmeriaAnnotationStubs()
     registerArmeriaBlockingAnnotationStubs()
     addClass(
@@ -75,4 +80,17 @@ internal fun JavaCodeInsightTestFixture.registerArmeriaJUnitTestSupportStubs() {
         }
         """.trimIndent(),
     )
+}
+
+private fun markDefaultSourceRootAsTestSource(module: Module) {
+    val rootManager = ModuleRootManager.getInstance(module)
+    if (rootManager.sourceFolders.any { it.isTestSource }) {
+        return
+    }
+    ModuleRootModificationUtil.updateModel(module) { model ->
+        model.contentEntries
+            .flatMap { it.sourceFolders.toList() }
+            .filter { !it.isTestSource }
+            .forEach { it.isTestSource = true }
+    }
 }

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaJUnitTestSupportStubs.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaJUnitTestSupportStubs.kt
@@ -2,8 +2,7 @@ package com.linecorp.intellij.plugins.armeria.test
 
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.roots.ModuleRootManager
-import com.intellij.openapi.roots.ModuleRootModificationUtil
-import com.intellij.testFramework.UsefulTestCase.runWriteAction
+import com.intellij.testFramework.PsiTestUtil
 import com.intellij.testFramework.fixtures.JavaCodeInsightTestFixture
 
 internal fun JavaCodeInsightTestFixture.registerArmeriaJUnitTestSupportStubs() {
@@ -84,13 +83,10 @@ internal fun JavaCodeInsightTestFixture.registerArmeriaJUnitTestSupportStubs() {
 
 private fun markDefaultSourceRootAsTestSource(module: Module) {
     val rootManager = ModuleRootManager.getInstance(module)
-    if (rootManager.sourceFolders.any { it.isTestSource }) {
+    val contentRoot = rootManager.contentRoots.firstOrNull() ?: return
+    if (rootManager.fileIndex.isInTestSourceContent(contentRoot)) {
         return
     }
-    ModuleRootModificationUtil.updateModel(module) { model ->
-        model.contentEntries
-            .flatMap { it.sourceFolders.toList() }
-            .filter { !it.isTestSource }
-            .forEach { it.isTestSource = true }
-    }
+    PsiTestUtil.removeSourceRoot(module, contentRoot)
+    PsiTestUtil.addSourceRoot(module, contentRoot, true)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Blocking-client inspections no longer treat production-source files named `*Test.java` or `*Test.kt` as JUnit test files. Previously, `isLikelyJUnitTestFile` fell back to filename matching outside test source roots, which could trigger full route collection for misnamed production classes containing `@RegisterExtension`.

Closes #310

## Changes

- Remove filename-based fallback from `ArmeriaJUnitServerExtensionSupport.isLikelyJUnitTestFile`; rely on test source root membership only
- Document that `isLikelyJUnitTestFile` checks IDE test-source markers only (filename is not considered)
- Add Java/Kotlin regression tests that place `MisnamedTest` files in a production source root and assert the inspection returns `EMPTY_VISITOR`
- Mark the light-fixture default source root as test source in `registerArmeriaJUnitTestSupportStubs` so existing JUnit inspection tests continue to exercise the inspection path

## Test plan

- [x] `:plugin:test` — `ArmeriaBlockingClientInspectionTest`
- [x] `:plugin:test` — `ArmeriaBlockingClientKotlinInspectionTest`
- [x] `ktlintCheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9252-c26e-7e6a-919a-51f0ab6c1377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9252-c26e-7e6a-919a-51f0ab6c1377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

