### PR TITLE
refactor: rename test-source helper and clean up blocking-client regression tests

### DIFF
--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientInspection.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientInspection.kt
@@ -28,7 +28,7 @@ class ArmeriaBlockingClientInspection : LocalInspectionTool() {
         if (!ArmeriaJUnitServerExtensionSupport.fileMayContainRegisterExtension(holder.file.text)) {
             return PsiElementVisitor.EMPTY_VISITOR
         }
-        if (!ArmeriaJUnitServerExtensionSupport.isLikelyJUnitTestFile(holder.file)) {
+        if (!ArmeriaJUnitServerExtensionSupport.isInTestSourceContent(holder.file)) {
             return PsiElementVisitor.EMPTY_VISITOR
         }
         val scope = GlobalSearchScope.projectScope(holder.project)

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientKotlinInspection.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientKotlinInspection.kt
@@ -29,7 +29,7 @@ class ArmeriaBlockingClientKotlinInspection : LocalInspectionTool() {
         if (!ArmeriaJUnitServerExtensionSupport.fileMayContainRegisterExtension(holder.file.text)) {
             return PsiElementVisitor.EMPTY_VISITOR
         }
-        if (!ArmeriaJUnitServerExtensionSupport.isLikelyJUnitTestFile(holder.file)) {
+        if (!ArmeriaJUnitServerExtensionSupport.isInTestSourceContent(holder.file)) {
             return PsiElementVisitor.EMPTY_VISITOR
         }
         val scope = GlobalSearchScope.projectScope(holder.project)

--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaJUnitServerExtensionSupport.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaJUnitServerExtensionSupport.kt
@@ -141,7 +141,7 @@ internal object ArmeriaJUnitServerExtensionSupport {
         REGISTER_EXTENSION_ANNOTATION in fileText || "@$REGISTER_EXTENSION_ANNOTATION_SHORT" in fileText
 
     /** True when [file] is under a test source root (IDE markers only; filename is not considered). */
-    fun isLikelyJUnitTestFile(file: PsiFile): Boolean {
+    fun isInTestSourceContent(file: PsiFile): Boolean {
         val virtualFile = file.virtualFile ?: return false
         val project = file.project
         val fileIndex = ProjectRootManager.getInstance(project).fileIndex

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientInspectionTest.kt
@@ -253,34 +253,38 @@ class ArmeriaBlockingClientInspectionTest : ArmeriaLightJavaCodeInsightFixtureTe
     fun testNoInspectionSetupForMainSourceTestNamedFile() {
         val mainRoot = myFixture.tempDirFixture.findOrCreateDir("main")
         PsiTestUtil.addSourceRoot(module, mainRoot, false)
-        val content =
-            """
-            package example;
+        try {
+            val content =
+                """
+                package example;
 
-            import org.junit.jupiter.api.extension.RegisterExtension;
-            import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+                import org.junit.jupiter.api.extension.RegisterExtension;
+                import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
-            public class MisnamedTest {
-                @RegisterExtension
-                static ServerExtension server = new ServerExtension() {};
+                public class MisnamedTest {
+                    @RegisterExtension
+                    static ServerExtension server = new ServerExtension() {};
 
-                void run() {
-                    server.webClient().get("/slow");
+                    void run() {
+                        server.webClient().get("/slow");
+                    }
                 }
-            }
-            """.trimIndent()
-        val virtualFile =
-            ApplicationManager.getApplication().runWriteAction<com.intellij.openapi.vfs.VirtualFile> {
-                val file = mainRoot.createChildData(this, "MisnamedTest.java")
-                VfsUtil.saveText(file, content)
-                file
-            }
-        PsiDocumentManager.getInstance(project).commitAllDocuments()
-        val psiFile = PsiManager.getInstance(project).findFile(virtualFile)!!
+                """.trimIndent()
+            val virtualFile =
+                ApplicationManager.getApplication().runWriteAction<com.intellij.openapi.vfs.VirtualFile> {
+                    val file = mainRoot.createChildData(this, "MisnamedTest.java")
+                    VfsUtil.saveText(file, content)
+                    file
+                }
+            PsiDocumentManager.getInstance(project).commitAllDocuments()
+            val psiFile = PsiManager.getInstance(project).findFile(virtualFile)!!
 
-        val manager = InspectionManager.getInstance(project)
-        val holder = ProblemsHolder(manager, psiFile, false)
-        val visitor = ArmeriaBlockingClientInspection().buildVisitor(holder, false)
-        assertTrue(visitor === PsiElementVisitor.EMPTY_VISITOR)
+            val manager = InspectionManager.getInstance(project)
+            val holder = ProblemsHolder(manager, psiFile, false)
+            val visitor = ArmeriaBlockingClientInspection().buildVisitor(holder, false)
+            assertTrue(visitor === PsiElementVisitor.EMPTY_VISITOR)
+        } finally {
+            PsiTestUtil.removeSourceRoot(module, mainRoot)
+        }
     }
 }

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientInspectionTest.kt
@@ -252,8 +252,8 @@ class ArmeriaBlockingClientInspectionTest : ArmeriaLightJavaCodeInsightFixtureTe
 
     fun testNoInspectionSetupForMainSourceTestNamedFile() {
         val mainRoot = myFixture.tempDirFixture.findOrCreateDir("main")
-        PsiTestUtil.addSourceRoot(module, mainRoot, false)
         try {
+            PsiTestUtil.addSourceRoot(module, mainRoot, false)
             val content =
                 """
                 package example;

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientKotlinInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientKotlinInspectionTest.kt
@@ -521,35 +521,39 @@ class ArmeriaBlockingClientKotlinInspectionTest : ArmeriaLightJavaCodeInsightFix
     fun testNoInspectionSetupForMainSourceTestNamedFile() {
         val mainRoot = myFixture.tempDirFixture.findOrCreateDir("main")
         PsiTestUtil.addSourceRoot(module, mainRoot, false)
-        val content =
-            """
-            package example
+        try {
+            val content =
+                """
+                package example
 
-            import org.junit.jupiter.api.extension.RegisterExtension
-            import com.linecorp.armeria.testing.junit5.server.ServerExtension
+                import org.junit.jupiter.api.extension.RegisterExtension
+                import com.linecorp.armeria.testing.junit5.server.ServerExtension
 
-            class MisnamedTest {
-                @RegisterExtension
-                val server: ServerExtension = object : ServerExtension() {}
+                class MisnamedTest {
+                    @RegisterExtension
+                    val server: ServerExtension = object : ServerExtension() {}
 
-                fun run() {
-                    server.webClient().get("/slow")
+                    fun run() {
+                        server.webClient().get("/slow")
+                    }
                 }
-            }
-            """.trimIndent()
-        val virtualFile =
-            ApplicationManager.getApplication().runWriteAction<com.intellij.openapi.vfs.VirtualFile> {
-                val file = mainRoot.createChildData(this, "MisnamedTest.kt")
-                VfsUtil.saveText(file, content)
-                file
-            }
-        PsiDocumentManager.getInstance(project).commitAllDocuments()
-        val psiFile = PsiManager.getInstance(project).findFile(virtualFile)!!
+                """.trimIndent()
+            val virtualFile =
+                ApplicationManager.getApplication().runWriteAction<com.intellij.openapi.vfs.VirtualFile> {
+                    val file = mainRoot.createChildData(this, "MisnamedTest.kt")
+                    VfsUtil.saveText(file, content)
+                    file
+                }
+            PsiDocumentManager.getInstance(project).commitAllDocuments()
+            val psiFile = PsiManager.getInstance(project).findFile(virtualFile)!!
 
-        val manager = InspectionManager.getInstance(project)
-        val holder = ProblemsHolder(manager, psiFile, false)
-        val visitor = ArmeriaBlockingClientKotlinInspection().buildVisitor(holder, false)
-        assertTrue(visitor === PsiElementVisitor.EMPTY_VISITOR)
+            val manager = InspectionManager.getInstance(project)
+            val holder = ProblemsHolder(manager, psiFile, false)
+            val visitor = ArmeriaBlockingClientKotlinInspection().buildVisitor(holder, false)
+            assertTrue(visitor === PsiElementVisitor.EMPTY_VISITOR)
+        } finally {
+            PsiTestUtil.removeSourceRoot(module, mainRoot)
+        }
     }
 
     private fun findGetCall(file: KtFile): KtCallExpression =

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientKotlinInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientKotlinInspectionTest.kt
@@ -520,8 +520,8 @@ class ArmeriaBlockingClientKotlinInspectionTest : ArmeriaLightJavaCodeInsightFix
 
     fun testNoInspectionSetupForMainSourceTestNamedFile() {
         val mainRoot = myFixture.tempDirFixture.findOrCreateDir("main")
-        PsiTestUtil.addSourceRoot(module, mainRoot, false)
         try {
+            PsiTestUtil.addSourceRoot(module, mainRoot, false)
             val content =
                 """
                 package example


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up from PR #317: rename the JUnit test-source helper so its name matches test-source-only semantics, and tear down the extra production source root added by blocking-client regression tests.

Closes #318 and #319.

## Changes

- Rename `ArmeriaJUnitServerExtensionSupport.isLikelyJUnitTestFile` to `isInTestSourceContent` and update blocking-client inspection call sites
- Wrap `testNoInspectionSetupForMainSourceTestNamedFile` in `try`/`finally` so `PsiTestUtil.removeSourceRoot` runs after each regression test (Java and Kotlin)
- Move `PsiTestUtil.addSourceRoot` into the same `try` block so add/remove source-root pairing is structurally obvious

## Test plan

- [x] `ktlintCheck`
- [x] `:plugin:test` — `ArmeriaBlockingClientInspectionTest.testNoInspectionSetupForMainSourceTestNamedFile`, `ArmeriaBlockingClientKotlinInspectionTest.testNoInspectionSetupForMainSourceTestNamedFile`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9350-c1e5-7406-a7d9-0f00c5fd5f4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9350-c1e5-7406-a7d9-0f00c5fd5f4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

