### PR TITLE
perf: cache proto route merge in Route Explorer collector

### DIFF
--- a/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/collector/ArmeriaRouteCollector.kt
+++ b/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/collector/ArmeriaRouteCollector.kt
@@ -81,7 +81,7 @@ object ArmeriaRouteCollector {
             CachedValueProvider {
                 val baseRoutes = cachedProjectRoutes(project, contributors)
                 CachedValueProvider.Result.create(
-                    mergeProtoRoutesIfEnabled(project, baseRoutes, contributors),
+                    mergeProtoRoutes(project, baseRoutes, contributors),
                     PsiModificationTracker.MODIFICATION_COUNT,
                     ProjectRootModificationTracker.getInstance(project),
                 )
@@ -89,13 +89,15 @@ object ArmeriaRouteCollector {
             false,
         )
 
-    private fun cacheKey(contributors: List<RouteContributor>): Key<CachedValue<List<ArmeriaRoute>>> =
-        cacheKeys.getOrPut(contributorCacheId(contributors)) { Key.create("armeria.route.collector.${contributorCacheId(contributors)}") }
+    private fun cacheKey(contributors: List<RouteContributor>): Key<CachedValue<List<ArmeriaRoute>>> {
+        val id = contributorCacheId(contributors)
+        return cacheKeys.getOrPut(id) { Key.create("armeria.route.collector.$id") }
+    }
 
-    private fun cacheKeyWithProto(contributors: List<RouteContributor>): Key<CachedValue<List<ArmeriaRoute>>> =
-        cacheKeys.getOrPut("${contributorCacheId(contributors)}.with-proto") {
-            Key.create("armeria.route.collector.${contributorCacheId(contributors)}.with-proto")
-        }
+    private fun cacheKeyWithProto(contributors: List<RouteContributor>): Key<CachedValue<List<ArmeriaRoute>>> {
+        val id = contributorCacheId(contributors)
+        return cacheKeys.getOrPut("$id.with-proto") { Key.create("armeria.route.collector.$id.with-proto") }
+    }
 
     private fun contributorCacheId(contributors: List<RouteContributor>): String =
         contributors
@@ -172,6 +174,7 @@ object ArmeriaRouteCollector {
                 compareBy(ArmeriaRoute::moduleName, ArmeriaRoute::path, ArmeriaRoute::httpMethod, ArmeriaRoute::target),
             ),
             PsiModificationTracker.MODIFICATION_COUNT,
+            ProjectRootModificationTracker.getInstance(project),
         )
     }
 
@@ -196,8 +199,11 @@ object ArmeriaRouteCollector {
     /**
      * Overlays proto (gRPC) routes on top of already-cached base routes by invoking
      * [RouteContributor.collectProtoOverlay] on each contributor.
+     *
+     * Registry gating is applied in [collect] before the proto cache is read; overlay
+     * contributors must still respect [ArmeriaProtoRouteDiscoverySupport.isEnabled] themselves.
      */
-    private fun mergeProtoRoutesIfEnabled(
+    private fun mergeProtoRoutes(
         project: Project,
         baseRoutes: List<ArmeriaRoute>,
         contributors: List<RouteContributor>,

--- a/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/collector/ArmeriaRouteCollector.kt
+++ b/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/collector/ArmeriaRouteCollector.kt
@@ -82,8 +82,7 @@ object ArmeriaRouteCollector {
                 val baseRoutes = cachedProjectRoutes(project, contributors)
                 CachedValueProvider.Result.create(
                     mergeProtoRoutes(project, baseRoutes, contributors),
-                    PsiModificationTracker.MODIFICATION_COUNT,
-                    ProjectRootModificationTracker.getInstance(project),
+                    *routeCacheInvalidators(project),
                 )
             },
             false,
@@ -173,10 +172,15 @@ object ArmeriaRouteCollector {
             routes.sortedWith(
                 compareBy(ArmeriaRoute::moduleName, ArmeriaRoute::path, ArmeriaRoute::httpMethod, ArmeriaRoute::target),
             ),
+            *routeCacheInvalidators(project),
+        )
+    }
+
+    private fun routeCacheInvalidators(project: Project): Array<Any> =
+        arrayOf(
             PsiModificationTracker.MODIFICATION_COUNT,
             ProjectRootModificationTracker.getInstance(project),
         )
-    }
 
     private fun buildCollectContext(
         project: Project,

--- a/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/collector/ArmeriaRouteCollector.kt
+++ b/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/collector/ArmeriaRouteCollector.kt
@@ -3,6 +3,7 @@ package com.linecorp.intellij.plugins.armeria.explorer.collector
 import com.intellij.ide.highlighter.JavaFileType
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.registry.Registry
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiElement
@@ -27,6 +28,7 @@ import com.linecorp.intellij.plugins.armeria.explorer.support.RouteCollectContex
 import com.linecorp.intellij.plugins.armeria.explorer.support.RouteContributor
 import org.jetbrains.kotlin.idea.KotlinFileType
 import org.jetbrains.kotlin.psi.KtFile
+import java.util.MissingResourceException
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -47,17 +49,10 @@ object ArmeriaRouteCollector {
         val startedAt = System.nanoTime()
         val routes =
             ArmeriaRouteCollectionMetrics.runWith(metrics) {
-                val cachedRoutes =
-                    CachedValuesManager.getManager(project).getCachedValue(
-                        project,
-                        cacheKey(contributors),
-                        CachedValueProvider { computeProjectRoutes(project, contributors) },
-                        false,
-                    )
-                if (includeProtoRoutes) {
-                    mergeProtoRoutesIfEnabled(project, cachedRoutes, contributors)
+                if (includeProtoRoutes && isProtoRouteDiscoveryEnabled()) {
+                    cachedProjectRoutesWithProto(project, contributors)
                 } else {
-                    cachedRoutes
+                    cachedProjectRoutes(project, contributors)
                 }
             }
         metrics.elapsedMs = (System.nanoTime() - startedAt) / 1_000_000
@@ -65,15 +60,55 @@ object ArmeriaRouteCollector {
         return routes
     }
 
-    private fun cacheKey(contributors: List<RouteContributor>): Key<CachedValue<List<ArmeriaRoute>>> {
-        val id =
-            contributors
-                .map { it.javaClass.name }
-                .sorted()
-                .joinToString(",")
-                .ifEmpty { "core-only" }
-        return cacheKeys.getOrPut(id) { Key.create("armeria.route.collector.$id") }
-    }
+    private fun cachedProjectRoutes(
+        project: Project,
+        contributors: List<RouteContributor>,
+    ): List<ArmeriaRoute> =
+        CachedValuesManager.getManager(project).getCachedValue(
+            project,
+            cacheKey(contributors),
+            CachedValueProvider { computeProjectRoutes(project, contributors) },
+            false,
+        )
+
+    private fun cachedProjectRoutesWithProto(
+        project: Project,
+        contributors: List<RouteContributor>,
+    ): List<ArmeriaRoute> =
+        CachedValuesManager.getManager(project).getCachedValue(
+            project,
+            cacheKeyWithProto(contributors),
+            CachedValueProvider {
+                val baseRoutes = cachedProjectRoutes(project, contributors)
+                CachedValueProvider.Result.create(
+                    mergeProtoRoutesIfEnabled(project, baseRoutes, contributors),
+                    PsiModificationTracker.MODIFICATION_COUNT,
+                )
+            },
+            false,
+        )
+
+    private fun cacheKey(contributors: List<RouteContributor>): Key<CachedValue<List<ArmeriaRoute>>> =
+        cacheKeys.getOrPut(contributorCacheId(contributors)) { Key.create("armeria.route.collector.${contributorCacheId(contributors)}") }
+
+    private fun cacheKeyWithProto(contributors: List<RouteContributor>): Key<CachedValue<List<ArmeriaRoute>>> =
+        cacheKeys.getOrPut("${contributorCacheId(contributors)}.with-proto") {
+            Key.create("armeria.route.collector.${contributorCacheId(contributors)}.with-proto")
+        }
+
+    private fun contributorCacheId(contributors: List<RouteContributor>): String =
+        contributors
+            .map { it.javaClass.name }
+            .sorted()
+            .joinToString(",")
+            .ifEmpty { "core-only" }
+
+    private fun isProtoRouteDiscoveryEnabled(): Boolean =
+        try {
+            Registry.`is`("armeria.grpc.proto.routes.enabled")
+        } catch (_: MissingResourceException) {
+            true
+        }
 
     private fun computeProjectRoutes(
         project: Project,

--- a/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/collector/ArmeriaRouteCollector.kt
+++ b/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/collector/ArmeriaRouteCollector.kt
@@ -2,8 +2,8 @@ package com.linecorp.intellij.plugins.armeria.explorer.collector
 
 import com.intellij.ide.highlighter.JavaFileType
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectRootModificationTracker
 import com.intellij.openapi.util.Key
-import com.intellij.openapi.util.registry.Registry
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiElement
@@ -21,6 +21,7 @@ import com.linecorp.intellij.plugins.armeria.explorer.collector.registration.jav
 import com.linecorp.intellij.plugins.armeria.explorer.collector.registration.kotlin.ArmeriaKotlinExtendedRegistrationCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
 import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaKotlinPluginSupport
+import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaProtoRouteDiscoverySupport
 import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaRouteCollectionMetrics
 import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaRouteSupport
 import com.linecorp.intellij.plugins.armeria.explorer.support.CoreServiceRegistrationSupport
@@ -28,7 +29,6 @@ import com.linecorp.intellij.plugins.armeria.explorer.support.RouteCollectContex
 import com.linecorp.intellij.plugins.armeria.explorer.support.RouteContributor
 import org.jetbrains.kotlin.idea.KotlinFileType
 import org.jetbrains.kotlin.psi.KtFile
-import java.util.MissingResourceException
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -49,7 +49,7 @@ object ArmeriaRouteCollector {
         val startedAt = System.nanoTime()
         val routes =
             ArmeriaRouteCollectionMetrics.runWith(metrics) {
-                if (includeProtoRoutes && isProtoRouteDiscoveryEnabled()) {
+                if (includeProtoRoutes && ArmeriaProtoRouteDiscoverySupport.isEnabled()) {
                     cachedProjectRoutesWithProto(project, contributors)
                 } else {
                     cachedProjectRoutes(project, contributors)
@@ -83,6 +83,7 @@ object ArmeriaRouteCollector {
                 CachedValueProvider.Result.create(
                     mergeProtoRoutesIfEnabled(project, baseRoutes, contributors),
                     PsiModificationTracker.MODIFICATION_COUNT,
+                    ProjectRootModificationTracker.getInstance(project),
                 )
             },
             false,
@@ -102,13 +103,6 @@ object ArmeriaRouteCollector {
             .sorted()
             .joinToString(",")
             .ifEmpty { "core-only" }
-
-    private fun isProtoRouteDiscoveryEnabled(): Boolean =
-        try {
-            Registry.`is`("armeria.grpc.proto.routes.enabled")
-        } catch (_: MissingResourceException) {
-            true
-        }
 
     private fun computeProjectRoutes(
         project: Project,

--- a/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaProtoRouteDiscoverySupport.kt
+++ b/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaProtoRouteDiscoverySupport.kt
@@ -1,0 +1,13 @@
+package com.linecorp.intellij.plugins.armeria.explorer.support
+
+import com.intellij.openapi.util.registry.Registry
+import java.util.MissingResourceException
+
+object ArmeriaProtoRouteDiscoverySupport {
+    fun isEnabled(): Boolean =
+        try {
+            Registry.`is`("armeria.grpc.proto.routes.enabled")
+        } catch (_: MissingResourceException) {
+            true
+        }
+}

--- a/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaProtoRouteDiscoverySupport.kt
+++ b/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaProtoRouteDiscoverySupport.kt
@@ -3,6 +3,13 @@ package com.linecorp.intellij.plugins.armeria.explorer.support
 import com.intellij.openapi.util.registry.Registry
 import java.util.MissingResourceException
 
+/**
+ * Shared gate for gRPC proto route discovery (`armeria.grpc.proto.routes.enabled` in plugin.xml).
+ *
+ * Defaults to enabled when the registry key is absent (e.g. in lightweight test environments).
+ * The registry value is checked outside route caches so toggling the kill-switch takes effect
+ * immediately without waiting for PSI or project-root invalidation.
+ */
 object ArmeriaProtoRouteDiscoverySupport {
     fun isEnabled(): Boolean =
         try {

--- a/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaRouteCollectionMetrics.kt
+++ b/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaRouteCollectionMetrics.kt
@@ -37,9 +37,13 @@ class ArmeriaRouteCollectionMetrics {
         private val LOG = logger<ArmeriaRouteCollectionMetrics>()
         private val active = ThreadLocal<ArmeriaRouteCollectionMetrics?>()
 
-        @Volatile
-        var lastSnapshot: Snapshot? = null
-            private set
+        private val lastSnapshotHolder = ThreadLocal<Snapshot?>()
+
+        var lastSnapshot: Snapshot?
+            get() = lastSnapshotHolder.get()
+            private set(value) {
+                lastSnapshotHolder.set(value)
+            }
 
         fun <T> runWith(
             metrics: ArmeriaRouteCollectionMetrics,

--- a/plugin-route-protocol/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/protocol/ArmeriaGrpcRouteCollector.kt
+++ b/plugin-route-protocol/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/protocol/ArmeriaGrpcRouteCollector.kt
@@ -2,7 +2,6 @@ package com.linecorp.intellij.plugins.armeria.explorer.protocol
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.registry.Registry
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
@@ -13,9 +12,9 @@ import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
 import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRouteMetadata
 import com.linecorp.intellij.plugins.armeria.explorer.model.GrpcRoutePath
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
+import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaProtoRouteDiscoverySupport
 import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaRouteCollectionMetrics
 import com.linecorp.intellij.plugins.armeria.message
-import java.util.MissingResourceException
 
 object ArmeriaGrpcRouteCollector {
     private const val GRPC_SERVICE_CLASS = "com.linecorp.armeria.server.grpc.GrpcService"
@@ -28,7 +27,7 @@ object ArmeriaGrpcRouteCollector {
         scope: GlobalSearchScope,
         routes: MutableList<ArmeriaRoute>,
     ) {
-        if (!isProtoRouteDiscoveryEnabled() || !isGrpcOnClasspath(project, scope)) {
+        if (!ArmeriaProtoRouteDiscoverySupport.isEnabled() || !isGrpcOnClasspath(project, scope)) {
             return
         }
         val seenProtoRoutes = mutableSetOf<String>()
@@ -105,12 +104,7 @@ object ArmeriaGrpcRouteCollector {
             )
     }
 
-    fun isProtoRouteDiscoveryEnabled(): Boolean =
-        try {
-            Registry.`is`("armeria.grpc.proto.routes.enabled")
-        } catch (_: MissingResourceException) {
-            true
-        }
+    fun isProtoRouteDiscoveryEnabled(): Boolean = ArmeriaProtoRouteDiscoverySupport.isEnabled()
 
     internal fun isGrpcOnClasspath(
         project: Project,

--- a/plugin-route-protocol/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollectorTest.kt
+++ b/plugin-route-protocol/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollectorTest.kt
@@ -5,6 +5,7 @@ import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaGrpcRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaProtocolRouteContributor
+import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaRouteCollectionMetrics
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
 
 class ArmeriaGrpcRouteCollectorTest : ArmeriaFixtureTestBase() {
@@ -342,5 +343,47 @@ class ArmeriaGrpcRouteCollectorTest : ArmeriaFixtureTestBase() {
 
         assertNotNull(routes.firstOrNull { it.path == "/grpc" })
         assertNotNull(routes.firstOrNull { it.path == "/com.example.Greeter/SayHello" })
+    }
+
+    fun testProtoRouteMergeIsCachedAcrossCollectCalls() {
+        myFixture.configureByText(
+            "greeter.proto",
+            """
+            syntax = "proto3";
+            package com.example;
+
+            service Greeter {
+              rpc SayHello(HelloRequest) returns (HelloResponse);
+            }
+            """.trimIndent(),
+        )
+
+        val first =
+            ArmeriaRouteCollector.collect(
+                project,
+                includeProtoRoutes = true,
+                contributors = listOf(ArmeriaProtocolRouteContributor),
+            )
+        val firstScan = ArmeriaRouteCollectionMetrics.lastSnapshot!!.filesScanned
+        assertEquals(listOf("/com.example.Greeter/SayHello"), first.map { it.path })
+        assertTrue(firstScan > 0)
+
+        val second =
+            ArmeriaRouteCollector.collect(
+                project,
+                includeProtoRoutes = true,
+                contributors = listOf(ArmeriaProtocolRouteContributor),
+            )
+        val secondScan = ArmeriaRouteCollectionMetrics.lastSnapshot!!.filesScanned
+        assertEquals(first.map { it.path }, second.map { it.path })
+        assertEquals(0, secondScan)
+
+        val withoutProto =
+            ArmeriaRouteCollector.collect(
+                project,
+                includeProtoRoutes = false,
+                contributors = listOf(ArmeriaProtocolRouteContributor),
+            )
+        assertTrue(withoutProto.none { it.path == "/com.example.Greeter/SayHello" })
     }
 }

--- a/plugin-route-protocol/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollectorTest.kt
+++ b/plugin-route-protocol/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollectorTest.kt
@@ -386,4 +386,61 @@ class ArmeriaGrpcRouteCollectorTest : ArmeriaFixtureTestBase() {
             )
         assertTrue(withoutProto.none { it.path == "/com.example.Greeter/SayHello" })
     }
+
+    fun testProtoRouteMergeCacheInvalidatesOnProtoEdit() {
+        myFixture.configureByText(
+            "greeter.proto",
+            """
+            syntax = "proto3";
+            package com.example;
+
+            service Greeter {
+              rpc SayHello(HelloRequest) returns (HelloResponse);
+            }
+            """.trimIndent(),
+        )
+
+        val first =
+            ArmeriaRouteCollector.collect(
+                project,
+                includeProtoRoutes = true,
+                contributors = listOf(ArmeriaProtocolRouteContributor),
+            )
+        assertEquals(listOf("/com.example.Greeter/SayHello"), first.map { it.path })
+        assertTrue(ArmeriaRouteCollectionMetrics.lastSnapshot!!.filesScanned > 0)
+
+        val cached =
+            ArmeriaRouteCollector.collect(
+                project,
+                includeProtoRoutes = true,
+                contributors = listOf(ArmeriaProtocolRouteContributor),
+            )
+        assertEquals(first.map { it.path }, cached.map { it.path })
+        assertEquals(0, ArmeriaRouteCollectionMetrics.lastSnapshot!!.filesScanned)
+
+        myFixture.configureByText(
+            "greeter.proto",
+            """
+            syntax = "proto3";
+            package com.example;
+
+            service Greeter {
+              rpc SayHello(HelloRequest) returns (HelloResponse);
+              rpc SayGoodbye(GoodbyeRequest) returns (GoodbyeResponse);
+            }
+            """.trimIndent(),
+        )
+
+        val afterEdit =
+            ArmeriaRouteCollector.collect(
+                project,
+                includeProtoRoutes = true,
+                contributors = listOf(ArmeriaProtocolRouteContributor),
+            )
+        assertEquals(
+            listOf("/com.example.Greeter/SayGoodbye", "/com.example.Greeter/SayHello"),
+            afterEdit.map { it.path },
+        )
+        assertTrue(ArmeriaRouteCollectionMetrics.lastSnapshot!!.filesScanned > 0)
+    }
 }

--- a/plugin-route-protocol/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollectorTest.kt
+++ b/plugin-route-protocol/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollectorTest.kt
@@ -11,6 +11,7 @@ import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
 class ArmeriaGrpcRouteCollectorTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {
         registerResolvableArmeriaServerStubs()
+        registerArmeriaAnnotationStubs()
         myFixture.addClass(
             """
             package com.linecorp.armeria.server.grpc;
@@ -441,6 +442,81 @@ class ArmeriaGrpcRouteCollectorTest : ArmeriaFixtureTestBase() {
             listOf("/com.example.Greeter/SayGoodbye", "/com.example.Greeter/SayHello"),
             afterEdit.map { it.path },
         )
+        assertTrue(ArmeriaRouteCollectionMetrics.lastSnapshot!!.filesScanned > 0)
+    }
+
+    fun testProtoRouteMergeCacheInvalidatesOnBaseRouteEdit() {
+        myFixture.configureByText(
+            "greeter.proto",
+            """
+            syntax = "proto3";
+            package com.example;
+
+            service Greeter {
+              rpc SayHello(HelloRequest) returns (HelloResponse);
+            }
+            """.trimIndent(),
+        )
+        myFixture.configureByText(
+            "HelloService.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Get;
+
+            public class HelloService {
+                @Get("/hello")
+                public String hello() {
+                    return "hello";
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val first =
+            ArmeriaRouteCollector.collect(
+                project,
+                includeProtoRoutes = true,
+                contributors = listOf(ArmeriaProtocolRouteContributor),
+            )
+        assertTrue(first.any { it.path == "/hello" })
+        assertTrue(first.any { it.path == "/com.example.Greeter/SayHello" })
+        assertTrue(ArmeriaRouteCollectionMetrics.lastSnapshot!!.filesScanned > 0)
+
+        val cached =
+            ArmeriaRouteCollector.collect(
+                project,
+                includeProtoRoutes = true,
+                contributors = listOf(ArmeriaProtocolRouteContributor),
+            )
+        assertEquals(first.map { it.path }.sorted(), cached.map { it.path }.sorted())
+        assertEquals(0, ArmeriaRouteCollectionMetrics.lastSnapshot!!.filesScanned)
+
+        myFixture.configureByText(
+            "HelloService.java",
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Get;
+
+            public class HelloService {
+                @Get("/hello-updated")
+                public String hello() {
+                    return "hello";
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val afterEdit =
+            ArmeriaRouteCollector.collect(
+                project,
+                includeProtoRoutes = true,
+                contributors = listOf(ArmeriaProtocolRouteContributor),
+            )
+        assertTrue(afterEdit.any { it.path == "/hello-updated" })
+        assertTrue(afterEdit.none { it.path == "/hello" })
+        assertTrue(afterEdit.any { it.path == "/com.example.Greeter/SayHello" })
         assertTrue(ArmeriaRouteCollectionMetrics.lastSnapshot!!.filesScanned > 0)
     }
 }

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Fixed
 
+- Route Explorer caches proto route merging so Refresh no longer re-scans `.proto` files on every collect.
 - Spring MVC Route Explorer discovery finds mappings declared on generic base types/interfaces when the concrete controller substitutes type parameters (e.g. `Handler<T>` → `StringHandler`), including multi-level unannotated overrides and interface mappings satisfied by an inherited superclass method.
 - Bundle `plugin-shared` (including `ArmeriaBundle`) into the main plugin JAR so installing only `plugin-*.jar` no longer fails inspection-profile saves with `ClassNotFoundException: ArmeriaBundleKt`.
 - Route Explorer deduplicates GraphQL and Thrift IDL routes per module when the same operation appears in multiple schema or `.thrift` files.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changed
 
+- Route Explorer caches proto route merging so Refresh no longer re-scans `.proto` files on every collect.
 - Route Explorer reads Spring Boot `application.yml` / `.yaml` via IntelliJ YAML PSI (key-level navigation); `.properties` parsing is unchanged. YAML config is skipped when the YAML plugin is unavailable.
 - Split `plugin-route-analysis` `explorer` sources into focused packages (`model`, `collector`, `spring`, `protocol`, `docservice`, `support`, `duplicate`, `navigation`, `ui`).
 - Split the route-analysis codebase into five acyclic Gradle modules: `plugin-route-model` (leaf domain types), `plugin-route-collectors` (annotated / service-registration collectors, decorator/timeout support, `RouteContributor` SPI, public `ArmeriaRouteCollector`, shared test fixtures), `plugin-route-spring` (Spring MVC / Boot / config collectors), `plugin-route-protocol` (GraphQL / gRPC / Thrift), and `plugin-route-analysis` (UI helpers, DocService, navigation, duplicate index, `ArmeriaRouteAnalysisCollector`). `plugin` depends only on `plugin-route-analysis` (transitively `api`-exported to the rest); test fixtures are consumed from `plugin-route-collectors`.
@@ -23,7 +24,6 @@
 
 ### Fixed
 
-- Route Explorer caches proto route merging so Refresh no longer re-scans `.proto` files on every collect.
 - Spring MVC Route Explorer discovery finds mappings declared on generic base types/interfaces when the concrete controller substitutes type parameters (e.g. `Handler<T>` → `StringHandler`), including multi-level unannotated overrides and interface mappings satisfied by an inherited superclass method.
 - Bundle `plugin-shared` (including `ArmeriaBundle`) into the main plugin JAR so installing only `plugin-*.jar` no longer fails inspection-profile saves with `ClassNotFoundException: ArmeriaBundleKt`.
 - Route Explorer deduplicates GraphQL and Thrift IDL routes per module when the same operation appears in multiple schema or `.thrift` files.

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaProtoRouteRegistryGateTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaProtoRouteRegistryGateTest.kt
@@ -1,0 +1,69 @@
+package com.linecorp.intellij.plugins.armeria.explorer
+
+import com.intellij.openapi.util.registry.Registry
+import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
+import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaProtocolRouteContributor
+import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+
+class ArmeriaProtoRouteRegistryGateTest : ArmeriaFixtureTestBase() {
+    override fun registerArmeriaStubs() {
+        myFixture.addClass(
+            """
+            package com.linecorp.armeria.server.grpc;
+
+            public final class GrpcService {
+                public static GrpcServiceBuilder builder(Object bindableService) {
+                    return null;
+                }
+            }
+            """.trimIndent(),
+        )
+    }
+
+    fun testProtoRoutesRespectRegistryKillSwitchWithCache() {
+        myFixture.configureByText(
+            "greeter.proto",
+            """
+            syntax = "proto3";
+            package com.example;
+
+            service Greeter {
+              rpc SayHello(HelloRequest) returns (HelloResponse);
+            }
+            """.trimIndent(),
+        )
+
+        val registryKey = Registry.get("armeria.grpc.proto.routes.enabled")
+        val original = registryKey.asBoolean()
+        try {
+            registryKey.setValue(true)
+            val withProto =
+                ArmeriaRouteCollector.collect(
+                    project,
+                    includeProtoRoutes = true,
+                    contributors = listOf(ArmeriaProtocolRouteContributor),
+                )
+            assertTrue(withProto.any { it.path == "/com.example.Greeter/SayHello" })
+
+            registryKey.setValue(false)
+            val disabled =
+                ArmeriaRouteCollector.collect(
+                    project,
+                    includeProtoRoutes = true,
+                    contributors = listOf(ArmeriaProtocolRouteContributor),
+                )
+            assertTrue(disabled.none { it.path == "/com.example.Greeter/SayHello" })
+
+            registryKey.setValue(true)
+            val reenabled =
+                ArmeriaRouteCollector.collect(
+                    project,
+                    includeProtoRoutes = true,
+                    contributors = listOf(ArmeriaProtocolRouteContributor),
+                )
+            assertTrue(reenabled.any { it.path == "/com.example.Greeter/SayHello" })
+        } finally {
+            registryKey.setValue(original)
+        }
+    }
+}

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaProtoRouteRegistryGateTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaProtoRouteRegistryGateTest.kt
@@ -68,4 +68,57 @@ class ArmeriaProtoRouteRegistryGateTest : ArmeriaFixtureTestBase() {
             registryKey.setValue(original)
         }
     }
+
+    fun testProtoEditWhileRegistryDisabledIsVisibleAfterReenable() {
+        myFixture.configureByText(
+            "greeter.proto",
+            """
+            syntax = "proto3";
+            package com.example;
+
+            service Greeter {
+              rpc SayHello(HelloRequest) returns (HelloResponse);
+            }
+            """.trimIndent(),
+        )
+
+        val registryKey = Registry.get("armeria.grpc.proto.routes.enabled")
+        val original = registryKey.asBoolean()
+        try {
+            registryKey.setValue(true)
+            ArmeriaRouteCollector.collect(
+                project,
+                includeProtoRoutes = true,
+                contributors = listOf(ArmeriaProtocolRouteContributor),
+            )
+
+            registryKey.setValue(false)
+            myFixture.configureByText(
+                "greeter.proto",
+                """
+                syntax = "proto3";
+                package com.example;
+
+                service Greeter {
+                  rpc SayHello(HelloRequest) returns (HelloResponse);
+                  rpc SayGoodbye(GoodbyeRequest) returns (GoodbyeResponse);
+                }
+                """.trimIndent(),
+            )
+
+            registryKey.setValue(true)
+            val reenabled =
+                ArmeriaRouteCollector.collect(
+                    project,
+                    includeProtoRoutes = true,
+                    contributors = listOf(ArmeriaProtocolRouteContributor),
+                )
+            assertEquals(
+                listOf("/com.example.Greeter/SayGoodbye", "/com.example.Greeter/SayHello"),
+                reenabled.map { it.path },
+            )
+        } finally {
+            registryKey.setValue(original)
+        }
+    }
 }

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaProtoRouteRegistryGateTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaProtoRouteRegistryGateTest.kt
@@ -3,6 +3,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.intellij.openapi.util.registry.Registry
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaProtocolRouteContributor
+import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaRouteCollectionMetrics
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
 
 class ArmeriaProtoRouteRegistryGateTest : ArmeriaFixtureTestBase() {
@@ -62,6 +63,7 @@ class ArmeriaProtoRouteRegistryGateTest : ArmeriaFixtureTestBase() {
                     contributors = listOf(ArmeriaProtocolRouteContributor),
                 )
             assertTrue(reenabled.any { it.path == "/com.example.Greeter/SayHello" })
+            assertEquals(0, ArmeriaRouteCollectionMetrics.lastSnapshot!!.filesScanned)
         } finally {
             registryKey.setValue(original)
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Route Explorer refreshes with `includeProtoRoutes=true` re-scanned every `.proto` file on each collect call. Only the non-proto route set was cached, so proto-heavy projects paid a growing cost on every Refresh.

This change caches the with-proto merged route list separately so repeated refreshes reuse the overlay until PSI or project roots change.

Closes #273

## Changes

- Cache the with-proto merged route list via `CachedValuesManager`, invalidated on `PsiModificationTracker.MODIFICATION_COUNT` and `ProjectRootModificationTracker`
- Centralize shared route cache invalidators for base and proto caches
- Keep the base (non-proto) cache for callers with `includeProtoRoutes=false`; base cache now also depends on `ProjectRootModificationTracker` so root-only changes cannot leave stale non-proto routes under a fresh proto overlay
- Gate the proto cache on registry key `armeria.grpc.proto.routes.enabled` so the kill-switch takes effect immediately without using a stale proto cache
- Centralize registry lookup in `ArmeriaProtoRouteDiscoverySupport` (shared by collector and gRPC collector)
- Scope `ArmeriaRouteCollectionMetrics.lastSnapshot` to thread-local for parallel test stability
- Add regression tests for proto merge cache hits, proto-edit invalidation, base-route edit invalidation, registry kill-switch behavior, proto edits while registry is disabled, and warm-cache reuse after re-enabling the registry
- Document the fix in `plugin/CHANGELOG.md` under **Changed**

## Test plan

- [x] `:plugin-route-protocol:test` — `ArmeriaGrpcRouteCollectorTest` (including cache hit/miss, proto edit, base-route edit)
- [x] `:plugin:test` — `ArmeriaProtoRouteRegistryGateTest` (registry kill-switch and proto edit while disabled)
- [x] `ktlintCheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f934f-796c-7977-9420-bae4aa29f0f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f934f-796c-7977-9420-bae4aa29f0f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

