### PR TITLE
test: use kotlin.test assertNotNull for smart cast in tests

### DIFF
--- a/build-logic/src/main/kotlin/com.linecorp.intellij.platform-library.gradle.kts
+++ b/build-logic/src/main/kotlin/com.linecorp.intellij.platform-library.gradle.kts
@@ -17,13 +17,6 @@ java {
     }
 }
 
-val kotlinTest =
-    extensions
-        .getByType(org.gradle.api.artifacts.VersionCatalogsExtension::class.java)
-        .named("libs")
-        .findLibrary("kotlin-test")
-        .get()
-
 dependencies {
     intellijPlatform {
         testFramework(TestFrameworkType.Platform)
@@ -38,7 +31,7 @@ testing {
     suites {
         getByName<JvmTestSuite>("test") {
             dependencies {
-                implementation(kotlinTest)
+                implementation(versionCatalogs.named("libs").findLibrary("kotlin-test").get())
             }
             targets.all {
                 testTask.configure {

--- a/build-logic/src/main/kotlin/com.linecorp.intellij.platform-library.gradle.kts
+++ b/build-logic/src/main/kotlin/com.linecorp.intellij.platform-library.gradle.kts
@@ -18,6 +18,7 @@ java {
 }
 
 dependencies {
+    testImplementation(kotlin("test"))
     intellijPlatform {
         testFramework(TestFrameworkType.Platform)
     }

--- a/build-logic/src/main/kotlin/com.linecorp.intellij.platform-library.gradle.kts
+++ b/build-logic/src/main/kotlin/com.linecorp.intellij.platform-library.gradle.kts
@@ -17,8 +17,14 @@ java {
     }
 }
 
+val kotlinTest =
+    extensions
+        .getByType(org.gradle.api.artifacts.VersionCatalogsExtension::class.java)
+        .named("libs")
+        .findLibrary("kotlin-test")
+        .get()
+
 dependencies {
-    testImplementation(kotlin("test"))
     intellijPlatform {
         testFramework(TestFrameworkType.Platform)
     }
@@ -31,6 +37,9 @@ intellijPlatform {
 testing {
     suites {
         getByName<JvmTestSuite>("test") {
+            dependencies {
+                implementation(kotlinTest)
+            }
             targets.all {
                 testTask.configure {
                     failOnNoDiscoveredTests = false

--- a/build-logic/src/main/kotlin/com.linecorp.intellij.platform-plugin.gradle.kts
+++ b/build-logic/src/main/kotlin/com.linecorp.intellij.platform-plugin.gradle.kts
@@ -17,6 +17,7 @@ java {
 }
 
 dependencies {
+    testImplementation(kotlin("test"))
     intellijPlatform {
         testFramework(TestFrameworkType.Platform)
     }

--- a/build-logic/src/main/kotlin/com.linecorp.intellij.platform-plugin.gradle.kts
+++ b/build-logic/src/main/kotlin/com.linecorp.intellij.platform-plugin.gradle.kts
@@ -16,8 +16,14 @@ java {
     }
 }
 
+val kotlinTest =
+    extensions
+        .getByType(org.gradle.api.artifacts.VersionCatalogsExtension::class.java)
+        .named("libs")
+        .findLibrary("kotlin-test")
+        .get()
+
 dependencies {
-    testImplementation(kotlin("test"))
     intellijPlatform {
         testFramework(TestFrameworkType.Platform)
     }
@@ -30,6 +36,9 @@ intellijPlatform {
 testing {
     suites {
         getByName<JvmTestSuite>("test") {
+            dependencies {
+                implementation(kotlinTest)
+            }
             targets.all {
                 testTask.configure {
                     failOnNoDiscoveredTests = false

--- a/build-logic/src/main/kotlin/com.linecorp.intellij.platform-plugin.gradle.kts
+++ b/build-logic/src/main/kotlin/com.linecorp.intellij.platform-plugin.gradle.kts
@@ -16,13 +16,6 @@ java {
     }
 }
 
-val kotlinTest =
-    extensions
-        .getByType(org.gradle.api.artifacts.VersionCatalogsExtension::class.java)
-        .named("libs")
-        .findLibrary("kotlin-test")
-        .get()
-
 dependencies {
     intellijPlatform {
         testFramework(TestFrameworkType.Platform)
@@ -37,7 +30,7 @@ testing {
     suites {
         getByName<JvmTestSuite>("test") {
             dependencies {
-                implementation(kotlinTest)
+                implementation(versionCatalogs.named("libs").findLibrary("kotlin-test").get())
             }
             targets.all {
                 testTask.configure {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ ktlint = "1.5.0"
 
 [libraries]
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 intellij-platform-gradle-plugin = { module = "org.jetbrains.intellij.platform:org.jetbrains.intellij.platform.gradle.plugin", version.ref = "intellij-platform-plugin" }
 changelog-gradle-plugin = { module = "org.jetbrains.changelog:org.jetbrains.changelog.gradle.plugin", version.ref = "changelog" }
 ktlint-gradle-plugin = { module = "org.jlleitschuh.gradle.ktlint:org.jlleitschuh.gradle.ktlint.gradle.plugin", version.ref = "ktlint-gradle" }

--- a/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpMethodPillTest.kt
+++ b/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpMethodPillTest.kt
@@ -10,10 +10,10 @@ import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
 import com.linecorp.intellij.plugins.armeria.explorer.model.DelegationKind
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.explorer.ui.ArmeriaHttpMethodPill
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class ArmeriaHttpMethodPillTest {
     @Test

--- a/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGeneratorTest.kt
+++ b/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGeneratorTest.kt
@@ -14,6 +14,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaHttpRequestGeneratorTest {
     @Test
@@ -270,7 +271,7 @@ class ArmeriaHttpRequestGeneratorTest {
         val error = runCatching { ArmeriaHttpRequestGenerator.httpMethod(route) }.exceptionOrNull()
 
         assertTrue(error is IllegalStateException)
-        assertTrue(error!!.message!!.contains("NON_HTTP"))
+        assertTrue(kotlinAssertNotNull(error.message).contains("NON_HTTP"))
     }
 
     @Test

--- a/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGeneratorTest.kt
+++ b/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGeneratorTest.kt
@@ -270,6 +270,7 @@ class ArmeriaHttpRequestGeneratorTest {
 
         val error = runCatching { ArmeriaHttpRequestGenerator.httpMethod(route) }.exceptionOrNull()
 
+        kotlinAssertNotNull(error)
         assertTrue(error is IllegalStateException)
         assertTrue(kotlinAssertNotNull(error.message).contains("NON_HTTP"))
     }

--- a/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGeneratorTest.kt
+++ b/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaHttpRequestGeneratorTest.kt
@@ -10,11 +10,11 @@ import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
 import com.linecorp.intellij.plugins.armeria.explorer.model.PathType
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.explorer.ui.ArmeriaHttpRequestGenerator
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Test
-import kotlin.test.assertNotNull as kotlinAssertNotNull
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class ArmeriaHttpRequestGeneratorTest {
     @Test
@@ -270,9 +270,9 @@ class ArmeriaHttpRequestGeneratorTest {
 
         val error = runCatching { ArmeriaHttpRequestGenerator.httpMethod(route) }.exceptionOrNull()
 
-        kotlinAssertNotNull(error)
+        assertNotNull(error)
         assertTrue(error is IllegalStateException)
-        assertTrue(kotlinAssertNotNull(error.message).contains("NON_HTTP"))
+        assertTrue(assertNotNull(error.message).contains("NON_HTTP"))
     }
 
     @Test

--- a/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaObservabilitySummaryTest.kt
+++ b/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaObservabilitySummaryTest.kt
@@ -10,9 +10,9 @@ import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.explorer.ui.ArmeriaObservabilitySummary
 import com.linecorp.intellij.plugins.armeria.message
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ArmeriaObservabilitySummaryTest {
     @Test

--- a/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerTest.kt
+++ b/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerTest.kt
@@ -1,8 +1,8 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
 import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
-import org.junit.Assert.assertEquals
 import org.junit.Test
+import kotlin.test.assertEquals
 
 class ArmeriaRouteExplorerTest {
     @Test

--- a/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteTreeBuilderTest.kt
+++ b/plugin-route-analysis/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteTreeBuilderTest.kt
@@ -9,10 +9,10 @@ import com.intellij.psi.SmartPsiElementPointer
 import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.explorer.ui.ArmeriaRouteTreeBuilder
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Test
 import javax.swing.tree.DefaultMutableTreeNode
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class ArmeriaRouteTreeBuilderTest {
     @Test

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaAnnotatedMetadataSupportTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaAnnotatedMetadataSupportTest.kt
@@ -5,6 +5,8 @@ import com.linecorp.intellij.plugins.armeria.explorer.model.PathType
 import com.linecorp.intellij.plugins.armeria.explorer.ui.ArmeriaRouteDetailFormatter
 import com.linecorp.intellij.plugins.armeria.message
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ArmeriaAnnotatedMetadataSupportTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDocServiceEndpointValidatorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDocServiceEndpointValidatorTest.kt
@@ -1,9 +1,9 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
 import com.linecorp.intellij.plugins.armeria.explorer.docservice.ArmeriaDocServiceEndpointValidator
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class ArmeriaDocServiceEndpointValidatorTest {
     @Test

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDocServiceMountResolverTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDocServiceMountResolverTest.kt
@@ -9,8 +9,8 @@ import com.intellij.psi.SmartPsiElementPointer
 import com.linecorp.intellij.plugins.armeria.explorer.docservice.ArmeriaDocServiceMountResolver
 import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
-import org.junit.Assert.assertEquals
 import org.junit.Test
+import kotlin.test.assertEquals
 
 class ArmeriaDocServiceMountResolverTest {
     @Test

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDocServiceSpecificationParserTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDocServiceSpecificationParserTest.kt
@@ -1,9 +1,9 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
 import com.linecorp.intellij.plugins.armeria.explorer.docservice.ArmeriaDocServiceSpecificationParser
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ArmeriaDocServiceSpecificationParserTest {
     @Test

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDocServiceSupportTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDocServiceSupportTest.kt
@@ -9,11 +9,11 @@ import com.intellij.psi.SmartPsiElementPointer
 import com.linecorp.intellij.plugins.armeria.explorer.docservice.ArmeriaDocServiceSupport
 import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class ArmeriaDocServiceSupportTest {
     @Test

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinAnnotatedRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinAnnotatedRouteCollectorTest.kt
@@ -4,6 +4,9 @@ import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteColl
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.explorer.ui.ArmeriaRouteDetailFormatter
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaKotlinAnnotatedRouteCollectorTest : ArmeriaFixtureTestBase() {

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinAnnotatedRouteCollectorTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinAnnotatedRouteCollectorTest.kt
@@ -4,6 +4,7 @@ import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteColl
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.explorer.ui.ArmeriaRouteDetailFormatter
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaKotlinAnnotatedRouteCollectorTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {
@@ -67,8 +68,8 @@ class ArmeriaKotlinAnnotatedRouteCollectorTest : ArmeriaFixtureTestBase() {
         val routes = ArmeriaRouteCollector.collect(project)
 
         val registrationRoute = routes.firstOrNull { it.routeMatch == RouteMatch.ANNOTATED_SERVICE }
-        assertNotNull(registrationRoute)
-        assertEquals("/", registrationRoute!!.path)
+        kotlinAssertNotNull(registrationRoute)
+        assertEquals("/", registrationRoute.path)
         assertFalse(registrationRoute.annotatedServiceHasPathPrefix)
         assertEquals(
             "Server.builder().annotatedService(…)",
@@ -76,8 +77,8 @@ class ArmeriaKotlinAnnotatedRouteCollectorTest : ArmeriaFixtureTestBase() {
         )
 
         val annotatedMethodRoute = routes.firstOrNull { it.path == "/hello" }
-        assertNotNull(annotatedMethodRoute)
-        assertEquals(RouteMatch.ANNOTATED_HTTP, annotatedMethodRoute!!.routeMatch)
+        kotlinAssertNotNull(annotatedMethodRoute)
+        assertEquals(RouteMatch.ANNOTATED_HTTP, annotatedMethodRoute.routeMatch)
     }
 
     fun testCollectPathPrefix() {
@@ -135,8 +136,8 @@ class ArmeriaKotlinAnnotatedRouteCollectorTest : ArmeriaFixtureTestBase() {
         val routes = ArmeriaRouteCollector.collect(project)
 
         val registrationRoute = routes.firstOrNull { it.routeMatch == RouteMatch.ANNOTATED_SERVICE }
-        assertNotNull(registrationRoute)
-        assertEquals("/v1", registrationRoute!!.path)
+        kotlinAssertNotNull(registrationRoute)
+        assertEquals("/v1", registrationRoute.path)
         assertTrue(registrationRoute.annotatedServiceHasPathPrefix)
     }
 
@@ -172,8 +173,8 @@ class ArmeriaKotlinAnnotatedRouteCollectorTest : ArmeriaFixtureTestBase() {
         val routes = ArmeriaRouteCollector.collect(project)
 
         val registrationRoute = routes.firstOrNull { it.routeMatch == RouteMatch.ANNOTATED_SERVICE }
-        assertNotNull(registrationRoute)
-        assertEquals("/v1", registrationRoute!!.path)
+        kotlinAssertNotNull(registrationRoute)
+        assertEquals("/v1", registrationRoute.path)
         assertTrue(registrationRoute.annotatedServiceHasPathPrefix)
     }
 }

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinServiceRegistrationCollectorVariantsTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinServiceRegistrationCollectorVariantsTest.kt
@@ -4,6 +4,7 @@ import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteColl
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.explorer.ui.ArmeriaRouteDetailFormatter
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaKotlinServiceRegistrationCollectorVariantsTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {
@@ -28,10 +29,10 @@ class ArmeriaKotlinServiceRegistrationCollectorVariantsTest : ArmeriaFixtureTest
             ArmeriaRouteCollector
                 .collect(project)
                 .firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
+        kotlinAssertNotNull(serviceRoute)
         assertEquals(
             "Server.builder().service(\"/api\", …)",
-            ArmeriaRouteDetailFormatter.registrationSummary(serviceRoute!!),
+            ArmeriaRouteDetailFormatter.registrationSummary(serviceRoute),
         )
     }
 
@@ -63,8 +64,8 @@ class ArmeriaKotlinServiceRegistrationCollectorVariantsTest : ArmeriaFixtureTest
             ArmeriaRouteCollector
                 .collect(project)
                 .firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals("example.HelloService", serviceRoute!!.target)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals("example.HelloService", serviceRoute.target)
         assertFalse(serviceRoute.targetUnresolved)
     }
 
@@ -97,8 +98,8 @@ class ArmeriaKotlinServiceRegistrationCollectorVariantsTest : ArmeriaFixtureTest
             ArmeriaRouteCollector
                 .collect(project)
                 .firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals("example.HelloService", serviceRoute!!.target)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals("example.HelloService", serviceRoute.target)
     }
 
     fun testCollectServiceRegistrationFromAnnotatedServerBuilderVariable() {
@@ -132,8 +133,8 @@ class ArmeriaKotlinServiceRegistrationCollectorVariantsTest : ArmeriaFixtureTest
             ArmeriaRouteCollector
                 .collect(project)
                 .firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals("example.HelloService", serviceRoute!!.target)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals("example.HelloService", serviceRoute.target)
         assertFalse(serviceRoute.targetUnresolved)
     }
 
@@ -165,8 +166,8 @@ class ArmeriaKotlinServiceRegistrationCollectorVariantsTest : ArmeriaFixtureTest
             ArmeriaRouteCollector
                 .collect(project)
                 .firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals("example.HelloService", serviceRoute!!.target)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals("example.HelloService", serviceRoute.target)
         assertFalse(serviceRoute.targetUnresolved)
     }
 
@@ -207,7 +208,7 @@ class ArmeriaKotlinServiceRegistrationCollectorVariantsTest : ArmeriaFixtureTest
             ArmeriaRouteCollector
                 .collect(project)
                 .firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
+        kotlinAssertNotNull(serviceRoute)
     }
 
     fun testCollectServiceRegistrationFromServerBuilderExtensionFunction() {
@@ -243,8 +244,8 @@ class ArmeriaKotlinServiceRegistrationCollectorVariantsTest : ArmeriaFixtureTest
             ArmeriaRouteCollector
                 .collect(project)
                 .firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals("example.HelloService", serviceRoute!!.target)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals("example.HelloService", serviceRoute.target)
     }
 
     fun testCollectServiceRegistrationFromServerBuilderTypeAlias() {
@@ -278,8 +279,8 @@ class ArmeriaKotlinServiceRegistrationCollectorVariantsTest : ArmeriaFixtureTest
             ArmeriaRouteCollector
                 .collect(project)
                 .firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals("example.HelloService", serviceRoute!!.target)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals("example.HelloService", serviceRoute.target)
     }
 
     fun testCollectServiceRegistrationFromParenthesizedServerBuilderReceiver() {
@@ -311,7 +312,7 @@ class ArmeriaKotlinServiceRegistrationCollectorVariantsTest : ArmeriaFixtureTest
             ArmeriaRouteCollector
                 .collect(project)
                 .firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals("example.HelloService", serviceRoute!!.target)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals("example.HelloService", serviceRoute.target)
     }
 }

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinServiceRegistrationCollectorVariantsTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinServiceRegistrationCollectorVariantsTest.kt
@@ -4,6 +4,8 @@ import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteColl
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.explorer.ui.ArmeriaRouteDetailFormatter
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaKotlinServiceRegistrationCollectorVariantsTest : ArmeriaFixtureTestBase() {

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollectorAnnotatedRouteTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollectorAnnotatedRouteTest.kt
@@ -4,6 +4,9 @@ import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteColl
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.explorer.ui.ArmeriaRouteDetailFormatter
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaRouteCollectorAnnotatedRouteTest : ArmeriaFixtureTestBase() {

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollectorAnnotatedRouteTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollectorAnnotatedRouteTest.kt
@@ -4,6 +4,7 @@ import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteColl
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.explorer.ui.ArmeriaRouteDetailFormatter
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaRouteCollectorAnnotatedRouteTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {
@@ -73,8 +74,8 @@ class ArmeriaRouteCollectorAnnotatedRouteTest : ArmeriaFixtureTestBase() {
         val routes = ArmeriaRouteCollector.collect(project)
 
         val registrationRoute = routes.firstOrNull { it.routeMatch == RouteMatch.ANNOTATED_SERVICE }
-        assertNotNull(registrationRoute)
-        assertEquals("/", registrationRoute!!.path)
+        kotlinAssertNotNull(registrationRoute)
+        assertEquals("/", registrationRoute.path)
         assertFalse(registrationRoute.annotatedServiceHasPathPrefix)
         assertEquals(
             "Server.builder().annotatedService(…)",
@@ -82,8 +83,8 @@ class ArmeriaRouteCollectorAnnotatedRouteTest : ArmeriaFixtureTestBase() {
         )
 
         val annotatedMethodRoute = routes.firstOrNull { it.path == "/hello" }
-        assertNotNull(annotatedMethodRoute)
-        assertEquals(RouteMatch.ANNOTATED_HTTP, annotatedMethodRoute!!.routeMatch)
+        kotlinAssertNotNull(annotatedMethodRoute)
+        assertEquals(RouteMatch.ANNOTATED_HTTP, annotatedMethodRoute.routeMatch)
     }
 
     fun testCollectPathPrefix() {

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDetailFormatterTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDetailFormatterTest.kt
@@ -14,6 +14,9 @@ import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.explorer.ui.ArmeriaRouteDetailFormatter
 import com.linecorp.intellij.plugins.armeria.message
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class ArmeriaRouteDetailFormatterTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndexConflictTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndexConflictTest.kt
@@ -4,6 +4,8 @@ import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteColl
 import com.linecorp.intellij.plugins.armeria.explorer.duplicate.ArmeriaRouteDuplicateIndex
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ArmeriaRouteDuplicateIndexConflictTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndexCoreTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndexCoreTest.kt
@@ -4,6 +4,8 @@ import com.linecorp.intellij.plugins.armeria.explorer.duplicate.ArmeriaRouteDupl
 import com.linecorp.intellij.plugins.armeria.explorer.duplicate.DuplicateRegistrationGroup
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ArmeriaRouteDuplicateIndexCoreTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndexFluentHealthCheckTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndexFluentHealthCheckTest.kt
@@ -3,6 +3,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.duplicate.ArmeriaRouteDuplicateIndex
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaRouteDuplicateIndexFluentHealthCheckTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {
@@ -246,7 +247,7 @@ class ArmeriaRouteDuplicateIndexFluentHealthCheckTest : ArmeriaFixtureTestBase()
 
         val hits = ArmeriaRouteDuplicateIndex.duplicateHitsInFile(project, myFixture.file)
         val healthHit = hits.firstOrNull { it.registrationLabel.startsWith("GET ") }
-        assertNotNull(healthHit)
-        assertEquals("GET /internal/healthcheck", healthHit!!.registrationLabel)
+        kotlinAssertNotNull(healthHit)
+        assertEquals("GET /internal/healthcheck", healthHit.registrationLabel)
     }
 }

--- a/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndexFluentHealthCheckTest.kt
+++ b/plugin-route-analysis/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteDuplicateIndexFluentHealthCheckTest.kt
@@ -3,6 +3,8 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.duplicate.ArmeriaRouteDuplicateIndex
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaRouteDuplicateIndexFluentHealthCheckTest : ArmeriaFixtureTestBase() {

--- a/plugin-route-collectors/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDecoratorSupportTest.kt
+++ b/plugin-route-collectors/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDecoratorSupportTest.kt
@@ -3,6 +3,9 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.decorator.ArmeriaDecoratorSupport
 import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaRouteSupport
 import junit.framework.TestCase
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class ArmeriaDecoratorSupportTest : TestCase() {
     fun testLabelDecoratorKnownService() {

--- a/plugin-route-collectors/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRegistrationChainReducerTest.kt
+++ b/plugin-route-collectors/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRegistrationChainReducerTest.kt
@@ -3,8 +3,8 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.registration.ArmeriaRegistrationChainReducer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.registration.RegistrationChainStep
 import com.linecorp.intellij.plugins.armeria.message
-import org.junit.Assert.assertEquals
 import org.junit.Test
+import kotlin.test.assertEquals
 
 class ArmeriaRegistrationChainReducerTest {
     @Test

--- a/plugin-route-collectors/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupportApplicationDetectionTest.kt
+++ b/plugin-route-collectors/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupportApplicationDetectionTest.kt
@@ -1,9 +1,9 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
 import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaRouteSupport
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class ArmeriaRouteSupportApplicationDetectionTest {
     @Test

--- a/plugin-route-collectors/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupportPathFormattingTest.kt
+++ b/plugin-route-collectors/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteSupportPathFormattingTest.kt
@@ -1,8 +1,8 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
 import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaRouteSupport
-import org.junit.Assert.assertEquals
 import org.junit.Test
+import kotlin.test.assertEquals
 
 class ArmeriaRouteSupportPathFormattingTest {
     @Test

--- a/plugin-route-collectors/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaScalaTextSupportTest.kt
+++ b/plugin-route-collectors/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaScalaTextSupportTest.kt
@@ -1,10 +1,10 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
 import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaScalaTextSupport
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class ArmeriaScalaTextSupportTest {
     @Test

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollectorBasicTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollectorBasicTest.kt
@@ -4,6 +4,7 @@ import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteColl
 import com.linecorp.intellij.plugins.armeria.explorer.model.PathType
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaExtendedRegistrationCollectorBasicTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {
@@ -31,8 +32,8 @@ class ArmeriaExtendedRegistrationCollectorBasicTest : ArmeriaFixtureTestBase() {
 
         val routes = ArmeriaRouteCollector.collect(project)
         val fileRoute = routes.firstOrNull { it.routeMatch == RouteMatch.FILE_SERVICE }
-        assertNotNull(fileRoute)
-        assertEquals("/files/", fileRoute!!.path)
+        kotlinAssertNotNull(fileRoute)
+        assertEquals("/files/", fileRoute.path)
     }
 
     fun testCollectFileServiceWithJavaConstantPath() {
@@ -58,8 +59,8 @@ class ArmeriaExtendedRegistrationCollectorBasicTest : ArmeriaFixtureTestBase() {
 
         val routes = ArmeriaRouteCollector.collect(project)
         val fileRoute = routes.firstOrNull { it.routeMatch == RouteMatch.FILE_SERVICE }
-        assertNotNull(fileRoute)
-        assertEquals("/files/", fileRoute!!.path)
+        kotlinAssertNotNull(fileRoute)
+        assertEquals("/files/", fileRoute.path)
     }
 
     fun testCollectHealthCheckRegistration() {
@@ -82,8 +83,8 @@ class ArmeriaExtendedRegistrationCollectorBasicTest : ArmeriaFixtureTestBase() {
 
         val routes = ArmeriaRouteCollector.collect(project)
         val healthRoute = routes.firstOrNull { it.routeMatch == RouteMatch.HEALTH_CHECK }
-        assertNotNull(healthRoute)
-        assertEquals("/internal/healthcheck", healthRoute!!.path)
+        kotlinAssertNotNull(healthRoute)
+        assertEquals("/internal/healthcheck", healthRoute.path)
     }
 
     fun testCollectFluentRouteRegistration() {
@@ -108,8 +109,8 @@ class ArmeriaExtendedRegistrationCollectorBasicTest : ArmeriaFixtureTestBase() {
 
         val routes = ArmeriaRouteCollector.collect(project)
         val fluentRoute = routes.firstOrNull { it.routeMatch == RouteMatch.ROUTE_FLUENT }
-        assertNotNull(fluentRoute)
-        assertEquals("POST", fluentRoute!!.httpMethod)
+        kotlinAssertNotNull(fluentRoute)
+        assertEquals("POST", fluentRoute.httpMethod)
         assertEquals("/api/items", fluentRoute.path)
     }
 
@@ -134,8 +135,8 @@ class ArmeriaExtendedRegistrationCollectorBasicTest : ArmeriaFixtureTestBase() {
 
         val routes = ArmeriaRouteCollector.collect(project)
         val decoratorRoute = routes.firstOrNull { it.routeMatch == RouteMatch.DECORATOR_UNDER }
-        assertNotNull(decoratorRoute)
-        assertEquals("/public", decoratorRoute!!.path)
+        kotlinAssertNotNull(decoratorRoute)
+        assertEquals("/public", decoratorRoute.path)
     }
 
     fun testCollectPathAnnotationAndPathType() {
@@ -236,8 +237,8 @@ class ArmeriaExtendedRegistrationCollectorBasicTest : ArmeriaFixtureTestBase() {
 
         val routes = ArmeriaRouteCollector.collect(project)
         val fluentRoute = routes.firstOrNull { it.routeMatch == RouteMatch.ROUTE_FLUENT }
-        assertNotNull(fluentRoute)
-        assertEquals(PathType.EXACT, fluentRoute!!.pathType)
+        kotlinAssertNotNull(fluentRoute)
+        assertEquals(PathType.EXACT, fluentRoute.pathType)
         assertEquals("/api/items", fluentRoute.path)
         assertEquals("GET", fluentRoute.httpMethod)
     }

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollectorBasicTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollectorBasicTest.kt
@@ -4,6 +4,7 @@ import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteColl
 import com.linecorp.intellij.plugins.armeria.explorer.model.PathType
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaExtendedRegistrationCollectorBasicTest : ArmeriaFixtureTestBase() {

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollectorIgnoreTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollectorIgnoreTest.kt
@@ -3,6 +3,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertTrue
 
 class ArmeriaExtendedRegistrationCollectorIgnoreTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollectorRouteDecoratorTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollectorRouteDecoratorTest.kt
@@ -4,6 +4,7 @@ import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteColl
 import com.linecorp.intellij.plugins.armeria.explorer.model.PathType
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaExtendedRegistrationCollectorRouteDecoratorTest : ArmeriaFixtureTestBase() {

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollectorRouteDecoratorTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollectorRouteDecoratorTest.kt
@@ -4,6 +4,7 @@ import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteColl
 import com.linecorp.intellij.plugins.armeria.explorer.model.PathType
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaExtendedRegistrationCollectorRouteDecoratorTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {
@@ -32,8 +33,8 @@ class ArmeriaExtendedRegistrationCollectorRouteDecoratorTest : ArmeriaFixtureTes
 
         val routes = ArmeriaRouteCollector.collect(project)
         val decoratorRoute = routes.firstOrNull { it.routeMatch == RouteMatch.ROUTE_DECORATOR }
-        assertNotNull(decoratorRoute)
-        assertEquals(PathType.GLOB, decoratorRoute!!.pathType)
+        kotlinAssertNotNull(decoratorRoute)
+        assertEquals(PathType.GLOB, decoratorRoute.pathType)
         assertEquals("/**", decoratorRoute.path)
     }
 
@@ -61,8 +62,8 @@ class ArmeriaExtendedRegistrationCollectorRouteDecoratorTest : ArmeriaFixtureTes
 
         val routes = ArmeriaRouteCollector.collect(project)
         val decoratorRoute = routes.firstOrNull { it.routeMatch == RouteMatch.ROUTE_DECORATOR }
-        assertNotNull(decoratorRoute)
-        assertEquals("POST, PUT", decoratorRoute!!.httpMethod)
+        kotlinAssertNotNull(decoratorRoute)
+        assertEquals("POST, PUT", decoratorRoute.httpMethod)
     }
 
     fun testCollectRouteDecoratorIgnoresUnrelatedCallsInSameBlock() {
@@ -89,8 +90,8 @@ class ArmeriaExtendedRegistrationCollectorRouteDecoratorTest : ArmeriaFixtureTes
 
         val routes = ArmeriaRouteCollector.collect(project)
         val decoratorRoute = routes.firstOrNull { it.routeMatch == RouteMatch.ROUTE_DECORATOR }
-        assertNotNull(decoratorRoute)
-        assertEquals("/decorated/**", decoratorRoute!!.path)
+        kotlinAssertNotNull(decoratorRoute)
+        assertEquals("/decorated/**", decoratorRoute.path)
         assertEquals(1, routes.count { it.routeMatch == RouteMatch.ROUTE_DECORATOR })
     }
 
@@ -122,8 +123,8 @@ class ArmeriaExtendedRegistrationCollectorRouteDecoratorTest : ArmeriaFixtureTes
 
         val routes = ArmeriaRouteCollector.collect(project)
         val decoratorRoute = routes.firstOrNull { it.routeMatch == RouteMatch.ROUTE_DECORATOR }
-        assertNotNull(decoratorRoute)
-        assertEquals("/decorated/**", decoratorRoute!!.path)
+        kotlinAssertNotNull(decoratorRoute)
+        assertEquals("/decorated/**", decoratorRoute.path)
     }
 
     fun testCollectRouteDecoratorRegistration() {
@@ -149,6 +150,6 @@ class ArmeriaExtendedRegistrationCollectorRouteDecoratorTest : ArmeriaFixtureTes
 
         val routes = ArmeriaRouteCollector.collect(project)
         val decoratorRoute = routes.firstOrNull { it.routeMatch == RouteMatch.ROUTE_DECORATOR }
-        assertNotNull(decoratorRoute)
+        kotlinAssertNotNull(decoratorRoute)
     }
 }

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollectorVirtualHostTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollectorVirtualHostTest.kt
@@ -3,6 +3,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaExtendedRegistrationCollectorVirtualHostTest : ArmeriaFixtureTestBase() {

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollectorVirtualHostTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollectorVirtualHostTest.kt
@@ -3,6 +3,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaExtendedRegistrationCollectorVirtualHostTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {
@@ -29,8 +30,8 @@ class ArmeriaExtendedRegistrationCollectorVirtualHostTest : ArmeriaFixtureTestBa
 
         val routes = ArmeriaRouteCollector.collect(project)
         val virtualHostRoute = routes.firstOrNull { it.routeMatch == RouteMatch.VIRTUAL_HOST }
-        assertNotNull(virtualHostRoute)
-        assertEquals("api.example.com", virtualHostRoute!!.target)
+        kotlinAssertNotNull(virtualHostRoute)
+        assertEquals("api.example.com", virtualHostRoute.target)
         assertEquals("api.example.com", virtualHostRoute.virtualHostName)
     }
 
@@ -56,8 +57,8 @@ class ArmeriaExtendedRegistrationCollectorVirtualHostTest : ArmeriaFixtureTestBa
 
         val routes = ArmeriaRouteCollector.collect(project)
         val serviceRoute = routes.firstOrNull { it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals("/api", serviceRoute!!.path)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals("/api", serviceRoute.path)
         assertEquals("", serviceRoute.virtualHostName)
     }
 
@@ -83,8 +84,8 @@ class ArmeriaExtendedRegistrationCollectorVirtualHostTest : ArmeriaFixtureTestBa
 
         val routes = ArmeriaRouteCollector.collect(project)
         val serviceRoute = routes.firstOrNull { it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals("/api", serviceRoute!!.path)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals("/api", serviceRoute.path)
         assertEquals("api.example.com", serviceRoute.virtualHostName)
     }
 
@@ -112,10 +113,10 @@ class ArmeriaExtendedRegistrationCollectorVirtualHostTest : ArmeriaFixtureTestBa
         val routes = ArmeriaRouteCollector.collect(project)
         val defaultRoute = routes.firstOrNull { it.path == "/default" }
         val hostedRoute = routes.firstOrNull { it.path == "/hosted" }
-        assertNotNull(defaultRoute)
-        assertNotNull(hostedRoute)
-        assertEquals("", defaultRoute!!.virtualHostName)
-        assertEquals("api.example.com", hostedRoute!!.virtualHostName)
+        kotlinAssertNotNull(defaultRoute)
+        kotlinAssertNotNull(hostedRoute)
+        assertEquals("", defaultRoute.virtualHostName)
+        assertEquals("api.example.com", hostedRoute.virtualHostName)
     }
 
     fun testCollectNestedVirtualHostLambdaUsesInnerHostname() {
@@ -141,8 +142,8 @@ class ArmeriaExtendedRegistrationCollectorVirtualHostTest : ArmeriaFixtureTestBa
 
         val routes = ArmeriaRouteCollector.collect(project)
         val serviceRoute = routes.firstOrNull { it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals("/api", serviceRoute!!.path)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals("/api", serviceRoute.path)
         assertEquals("inner.example.com", serviceRoute.virtualHostName)
     }
 
@@ -167,8 +168,8 @@ class ArmeriaExtendedRegistrationCollectorVirtualHostTest : ArmeriaFixtureTestBa
 
         val routes = ArmeriaRouteCollector.collect(project)
         val fileRoute = routes.firstOrNull { it.routeMatch == RouteMatch.FILE_SERVICE }
-        assertNotNull(fileRoute)
-        assertEquals("/files/", fileRoute!!.path)
+        kotlinAssertNotNull(fileRoute)
+        assertEquals("/files/", fileRoute.path)
         assertEquals("api.example.com", fileRoute.virtualHostName)
     }
 }

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollectorWithRouteTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollectorWithRouteTest.kt
@@ -3,6 +3,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
 
 class ArmeriaExtendedRegistrationCollectorWithRouteTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinDecoratorRouteCollectorBasicTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinDecoratorRouteCollectorBasicTest.kt
@@ -3,6 +3,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaKotlinDecoratorRouteCollectorBasicTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {
@@ -40,8 +41,8 @@ class ArmeriaKotlinDecoratorRouteCollectorBasicTest : ArmeriaFixtureTestBase() {
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals(listOf("CORS", "Logging"), serviceRoute!!.decorators)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals(listOf("CORS", "Logging"), serviceRoute.decorators)
     }
 
     fun testCollectProgrammaticDecoratorWithNewDecoratorFactory() {
@@ -73,8 +74,8 @@ class ArmeriaKotlinDecoratorRouteCollectorBasicTest : ArmeriaFixtureTestBase() {
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals(listOf("Logging"), serviceRoute!!.decorators)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals(listOf("Logging"), serviceRoute.decorators)
     }
 
     fun testCollectProgrammaticDecoratorWithBuilderNewDecoratorFactory() {
@@ -106,8 +107,8 @@ class ArmeriaKotlinDecoratorRouteCollectorBasicTest : ArmeriaFixtureTestBase() {
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals(listOf("Logging"), serviceRoute!!.decorators)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals(listOf("Logging"), serviceRoute.decorators)
     }
 
     fun testCollectProgrammaticDecoratorOnKotlinBuilderVariable() {
@@ -139,8 +140,8 @@ class ArmeriaKotlinDecoratorRouteCollectorBasicTest : ArmeriaFixtureTestBase() {
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals(listOf("Logging"), serviceRoute!!.decorators)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals(listOf("Logging"), serviceRoute.decorators)
     }
 
     fun testCollectProgrammaticDecoratorFromLocalVariable() {
@@ -173,7 +174,7 @@ class ArmeriaKotlinDecoratorRouteCollectorBasicTest : ArmeriaFixtureTestBase() {
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals(listOf("Logging"), serviceRoute!!.decorators)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals(listOf("Logging"), serviceRoute.decorators)
     }
 }

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinDecoratorRouteCollectorBasicTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinDecoratorRouteCollectorBasicTest.kt
@@ -3,6 +3,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaKotlinDecoratorRouteCollectorBasicTest : ArmeriaFixtureTestBase() {

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinDecoratorRouteCollectorPathScopedTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinDecoratorRouteCollectorPathScopedTest.kt
@@ -3,6 +3,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaKotlinDecoratorRouteCollectorPathScopedTest : ArmeriaFixtureTestBase() {

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinDecoratorRouteCollectorPathScopedTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinDecoratorRouteCollectorPathScopedTest.kt
@@ -3,6 +3,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaKotlinDecoratorRouteCollectorPathScopedTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {
@@ -38,8 +39,8 @@ class ArmeriaKotlinDecoratorRouteCollectorPathScopedTest : ArmeriaFixtureTestBas
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals(listOf("Logging"), serviceRoute!!.decorators)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals(listOf("Logging"), serviceRoute.decorators)
     }
 
     fun testCollectPathScopedDecoratorFiltersByRoute() {
@@ -73,10 +74,10 @@ class ArmeriaKotlinDecoratorRouteCollectorPathScopedTest : ArmeriaFixtureTestBas
 
         val apiRoute = routes.firstOrNull { it.path == "/api" }
         val otherRoute = routes.firstOrNull { it.path == "/other" }
-        assertNotNull(apiRoute)
-        assertNotNull(otherRoute)
-        assertEquals(listOf("Logging"), apiRoute!!.decorators)
-        assertEquals(emptyList<String>(), otherRoute!!.decorators)
+        kotlinAssertNotNull(apiRoute)
+        kotlinAssertNotNull(otherRoute)
+        assertEquals(listOf("Logging"), apiRoute.decorators)
+        assertEquals(emptyList<String>(), otherRoute.decorators)
     }
 
     fun testCollectPathScopedDecoratorWithConstValPathPattern() {
@@ -110,7 +111,7 @@ class ArmeriaKotlinDecoratorRouteCollectorPathScopedTest : ArmeriaFixtureTestBas
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals(listOf("Logging"), serviceRoute!!.decorators)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals(listOf("Logging"), serviceRoute.decorators)
     }
 }

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinDecoratorRouteCollectorScopeBlockTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinDecoratorRouteCollectorScopeBlockTest.kt
@@ -3,6 +3,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaKotlinDecoratorRouteCollectorScopeBlockTest : ArmeriaFixtureTestBase() {

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinDecoratorRouteCollectorScopeBlockTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinDecoratorRouteCollectorScopeBlockTest.kt
@@ -3,6 +3,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaKotlinDecoratorRouteCollectorScopeBlockTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {
@@ -38,8 +39,8 @@ class ArmeriaKotlinDecoratorRouteCollectorScopeBlockTest : ArmeriaFixtureTestBas
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals(listOf("Logging"), serviceRoute!!.decorators)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals(listOf("Logging"), serviceRoute.decorators)
     }
 
     fun testCollectProgrammaticDecoratorInAlsoBlock() {
@@ -71,8 +72,8 @@ class ArmeriaKotlinDecoratorRouteCollectorScopeBlockTest : ArmeriaFixtureTestBas
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals(listOf("Logging"), serviceRoute!!.decorators)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals(listOf("Logging"), serviceRoute.decorators)
     }
 
     fun testCollectProgrammaticDecoratorInAlsoBlockChainedAfterAlso() {
@@ -104,8 +105,8 @@ class ArmeriaKotlinDecoratorRouteCollectorScopeBlockTest : ArmeriaFixtureTestBas
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals(listOf("Logging"), serviceRoute!!.decorators)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals(listOf("Logging"), serviceRoute.decorators)
     }
 
     fun testCollectProgrammaticDecoratorInApplyBlockChainedAfterApply() {
@@ -137,8 +138,8 @@ class ArmeriaKotlinDecoratorRouteCollectorScopeBlockTest : ArmeriaFixtureTestBas
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals(listOf("Logging"), serviceRoute!!.decorators)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals(listOf("Logging"), serviceRoute.decorators)
     }
 
     fun testCollectProgrammaticDecoratorInChainedApplyBlocks() {
@@ -170,8 +171,8 @@ class ArmeriaKotlinDecoratorRouteCollectorScopeBlockTest : ArmeriaFixtureTestBas
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals(listOf("Logging"), serviceRoute!!.decorators)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals(listOf("Logging"), serviceRoute.decorators)
     }
 
     fun testCollectProgrammaticDecoratorInApplyBlockStopsAfterRegistrationStatement() {
@@ -205,8 +206,8 @@ class ArmeriaKotlinDecoratorRouteCollectorScopeBlockTest : ArmeriaFixtureTestBas
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals(listOf("Logging"), serviceRoute!!.decorators)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals(listOf("Logging"), serviceRoute.decorators)
     }
 
     fun testCollectProgrammaticDecoratorInApplyBlockStopsWithinRegistrationStatement() {
@@ -241,7 +242,7 @@ class ArmeriaKotlinDecoratorRouteCollectorScopeBlockTest : ArmeriaFixtureTestBas
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals(listOf("Logging"), serviceRoute!!.decorators)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals(listOf("Logging"), serviceRoute.decorators)
     }
 }

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinExtendedRegistrationCollectorBasicTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinExtendedRegistrationCollectorBasicTest.kt
@@ -4,6 +4,7 @@ import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteColl
 import com.linecorp.intellij.plugins.armeria.explorer.model.PathType
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaKotlinExtendedRegistrationCollectorBasicTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {
@@ -29,8 +30,8 @@ class ArmeriaKotlinExtendedRegistrationCollectorBasicTest : ArmeriaFixtureTestBa
 
         val routes = ArmeriaRouteCollector.collect(project)
         val fileRoute = routes.firstOrNull { it.routeMatch == RouteMatch.FILE_SERVICE }
-        assertNotNull(fileRoute)
-        assertEquals("/files/", fileRoute!!.path)
+        kotlinAssertNotNull(fileRoute)
+        assertEquals("/files/", fileRoute.path)
     }
 
     fun testCollectKotlinFluentRouteRegistration() {
@@ -53,8 +54,8 @@ class ArmeriaKotlinExtendedRegistrationCollectorBasicTest : ArmeriaFixtureTestBa
 
         val routes = ArmeriaRouteCollector.collect(project)
         val fluentRoute = routes.firstOrNull { it.routeMatch == RouteMatch.ROUTE_FLUENT }
-        assertNotNull(fluentRoute)
-        assertEquals("POST", fluentRoute!!.httpMethod)
+        kotlinAssertNotNull(fluentRoute)
+        assertEquals("POST", fluentRoute.httpMethod)
         assertEquals("/api/items", fluentRoute.path)
     }
 
@@ -77,8 +78,8 @@ class ArmeriaKotlinExtendedRegistrationCollectorBasicTest : ArmeriaFixtureTestBa
 
         val routes = ArmeriaRouteCollector.collect(project)
         val decoratorRoute = routes.firstOrNull { it.routeMatch == RouteMatch.DECORATOR_UNDER }
-        assertNotNull(decoratorRoute)
-        assertEquals("/public", decoratorRoute!!.path)
+        kotlinAssertNotNull(decoratorRoute)
+        assertEquals("/public", decoratorRoute.path)
     }
 
     fun testCollectKotlinWithRouteRegistration() {
@@ -151,8 +152,8 @@ class ArmeriaKotlinExtendedRegistrationCollectorBasicTest : ArmeriaFixtureTestBa
 
         val routes = ArmeriaRouteCollector.collect(project)
         val healthRoute = routes.firstOrNull { it.routeMatch == RouteMatch.HEALTH_CHECK }
-        assertNotNull(healthRoute)
-        assertEquals("/internal/healthcheck", healthRoute!!.path)
+        kotlinAssertNotNull(healthRoute)
+        assertEquals("/internal/healthcheck", healthRoute.path)
     }
 
     fun testCollectKotlinFluentRoutePathPrefix() {
@@ -176,8 +177,8 @@ class ArmeriaKotlinExtendedRegistrationCollectorBasicTest : ArmeriaFixtureTestBa
 
         val routes = ArmeriaRouteCollector.collect(project)
         val fluentRoute = routes.firstOrNull { it.routeMatch == RouteMatch.ROUTE_FLUENT }
-        assertNotNull(fluentRoute)
-        assertEquals(PathType.EXACT, fluentRoute!!.pathType)
+        kotlinAssertNotNull(fluentRoute)
+        assertEquals(PathType.EXACT, fluentRoute.pathType)
         assertEquals("/api/items", fluentRoute.path)
         assertEquals("GET", fluentRoute.httpMethod)
     }
@@ -203,7 +204,7 @@ class ArmeriaKotlinExtendedRegistrationCollectorBasicTest : ArmeriaFixtureTestBa
 
         val routes = ArmeriaRouteCollector.collect(project)
         val fileRoute = routes.firstOrNull { it.routeMatch == RouteMatch.FILE_SERVICE }
-        assertNotNull(fileRoute)
-        assertEquals("/files/", fileRoute!!.path)
+        kotlinAssertNotNull(fileRoute)
+        assertEquals("/files/", fileRoute.path)
     }
 }

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinExtendedRegistrationCollectorBasicTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinExtendedRegistrationCollectorBasicTest.kt
@@ -4,6 +4,7 @@ import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteColl
 import com.linecorp.intellij.plugins.armeria.explorer.model.PathType
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaKotlinExtendedRegistrationCollectorBasicTest : ArmeriaFixtureTestBase() {

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinExtendedRegistrationCollectorIgnoreTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinExtendedRegistrationCollectorIgnoreTest.kt
@@ -3,6 +3,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertTrue
 
 class ArmeriaKotlinExtendedRegistrationCollectorIgnoreTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinExtendedRegistrationCollectorRouteDecoratorTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinExtendedRegistrationCollectorRouteDecoratorTest.kt
@@ -4,6 +4,7 @@ import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteColl
 import com.linecorp.intellij.plugins.armeria.explorer.model.PathType
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaKotlinExtendedRegistrationCollectorRouteDecoratorTest : ArmeriaFixtureTestBase() {

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinExtendedRegistrationCollectorRouteDecoratorTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinExtendedRegistrationCollectorRouteDecoratorTest.kt
@@ -4,6 +4,7 @@ import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteColl
 import com.linecorp.intellij.plugins.armeria.explorer.model.PathType
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaKotlinExtendedRegistrationCollectorRouteDecoratorTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {
@@ -30,8 +31,8 @@ class ArmeriaKotlinExtendedRegistrationCollectorRouteDecoratorTest : ArmeriaFixt
 
         val routes = ArmeriaRouteCollector.collect(project)
         val decoratorRoute = routes.firstOrNull { it.routeMatch == RouteMatch.ROUTE_DECORATOR }
-        assertNotNull(decoratorRoute)
-        assertEquals(PathType.GLOB, decoratorRoute!!.pathType)
+        kotlinAssertNotNull(decoratorRoute)
+        assertEquals(PathType.GLOB, decoratorRoute.pathType)
         assertEquals("/**", decoratorRoute.path)
     }
 
@@ -56,8 +57,8 @@ class ArmeriaKotlinExtendedRegistrationCollectorRouteDecoratorTest : ArmeriaFixt
 
         val routes = ArmeriaRouteCollector.collect(project)
         val decoratorRoute = routes.firstOrNull { it.routeMatch == RouteMatch.ROUTE_DECORATOR }
-        assertNotNull(decoratorRoute)
-        assertEquals(PathType.EXACT, decoratorRoute!!.pathType)
+        kotlinAssertNotNull(decoratorRoute)
+        assertEquals(PathType.EXACT, decoratorRoute.pathType)
         assertEquals("/decorated/**", decoratorRoute.path)
     }
 
@@ -83,8 +84,8 @@ class ArmeriaKotlinExtendedRegistrationCollectorRouteDecoratorTest : ArmeriaFixt
 
         val routes = ArmeriaRouteCollector.collect(project)
         val decoratorRoute = routes.firstOrNull { it.routeMatch == RouteMatch.ROUTE_DECORATOR }
-        assertNotNull(decoratorRoute)
-        assertEquals("POST, PUT", decoratorRoute!!.httpMethod)
+        kotlinAssertNotNull(decoratorRoute)
+        assertEquals("POST, PUT", decoratorRoute.httpMethod)
     }
 
     fun testCollectKotlinRouteDecoratorIgnoresPathCallsInsideDecoratorLambda() {
@@ -113,7 +114,7 @@ class ArmeriaKotlinExtendedRegistrationCollectorRouteDecoratorTest : ArmeriaFixt
 
         val routes = ArmeriaRouteCollector.collect(project)
         val decoratorRoute = routes.firstOrNull { it.routeMatch == RouteMatch.ROUTE_DECORATOR }
-        assertNotNull(decoratorRoute)
-        assertEquals("/decorated/**", decoratorRoute!!.path)
+        kotlinAssertNotNull(decoratorRoute)
+        assertEquals("/decorated/**", decoratorRoute.path)
     }
 }

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinExtendedRegistrationCollectorVirtualHostTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinExtendedRegistrationCollectorVirtualHostTest.kt
@@ -3,6 +3,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaKotlinExtendedRegistrationCollectorVirtualHostTest : ArmeriaFixtureTestBase() {

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinExtendedRegistrationCollectorVirtualHostTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinExtendedRegistrationCollectorVirtualHostTest.kt
@@ -3,6 +3,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaKotlinExtendedRegistrationCollectorVirtualHostTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {
@@ -29,8 +30,8 @@ class ArmeriaKotlinExtendedRegistrationCollectorVirtualHostTest : ArmeriaFixture
 
         val routes = ArmeriaRouteCollector.collect(project)
         val serviceRoute = routes.firstOrNull { it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals("/api", serviceRoute!!.path)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals("/api", serviceRoute.path)
         assertEquals("", serviceRoute.virtualHostName)
     }
 
@@ -54,8 +55,8 @@ class ArmeriaKotlinExtendedRegistrationCollectorVirtualHostTest : ArmeriaFixture
 
         val routes = ArmeriaRouteCollector.collect(project)
         val serviceRoute = routes.firstOrNull { it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals("/api", serviceRoute!!.path)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals("/api", serviceRoute.path)
         assertEquals("api.example.com", serviceRoute.virtualHostName)
     }
 
@@ -82,8 +83,8 @@ class ArmeriaKotlinExtendedRegistrationCollectorVirtualHostTest : ArmeriaFixture
 
         val routes = ArmeriaRouteCollector.collect(project)
         val serviceRoute = routes.firstOrNull { it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals("/api", serviceRoute!!.path)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals("/api", serviceRoute.path)
         assertEquals("inner.example.com", serviceRoute.virtualHostName)
     }
 
@@ -105,8 +106,8 @@ class ArmeriaKotlinExtendedRegistrationCollectorVirtualHostTest : ArmeriaFixture
 
         val routes = ArmeriaRouteCollector.collect(project)
         val virtualHostRoute = routes.firstOrNull { it.routeMatch == RouteMatch.VIRTUAL_HOST }
-        assertNotNull(virtualHostRoute)
-        assertEquals("api.example.com", virtualHostRoute!!.virtualHostName)
+        kotlinAssertNotNull(virtualHostRoute)
+        assertEquals("api.example.com", virtualHostRoute.virtualHostName)
     }
 
     fun testCollectKotlinVirtualHostLambdaAnnotatesFileService() {
@@ -130,8 +131,8 @@ class ArmeriaKotlinExtendedRegistrationCollectorVirtualHostTest : ArmeriaFixture
 
         val routes = ArmeriaRouteCollector.collect(project)
         val fileRoute = routes.firstOrNull { it.routeMatch == RouteMatch.FILE_SERVICE }
-        assertNotNull(fileRoute)
-        assertEquals("/files/", fileRoute!!.path)
+        kotlinAssertNotNull(fileRoute)
+        assertEquals("/files/", fileRoute.path)
         assertEquals("api.example.com", fileRoute.virtualHostName)
     }
 }

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorEdgeCaseTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorEdgeCaseTest.kt
@@ -2,6 +2,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaKotlinRouteCollectorEdgeCaseTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {
@@ -177,8 +178,8 @@ class ArmeriaKotlinRouteCollectorEdgeCaseTest : ArmeriaFixtureTestBase() {
         )
 
         val serviceRoute = ArmeriaRouteCollector.collect(project).firstOrNull { it.path == "/api" }
-        assertNotNull(serviceRoute)
-        assertTrue(serviceRoute!!.targetUnresolved)
+        kotlinAssertNotNull(serviceRoute)
+        assertTrue(serviceRoute.targetUnresolved)
     }
 
     fun testCollectUnresolvedFactoryMethodTarget() {
@@ -200,8 +201,8 @@ class ArmeriaKotlinRouteCollectorEdgeCaseTest : ArmeriaFixtureTestBase() {
         )
 
         val serviceRoute = ArmeriaRouteCollector.collect(project).firstOrNull { it.path == "/api" }
-        assertNotNull(serviceRoute)
-        assertTrue(serviceRoute!!.targetUnresolved)
+        kotlinAssertNotNull(serviceRoute)
+        assertTrue(serviceRoute.targetUnresolved)
     }
 
     fun testCollectUnresolvedGrpcServiceBuilderTarget() {
@@ -222,8 +223,8 @@ class ArmeriaKotlinRouteCollectorEdgeCaseTest : ArmeriaFixtureTestBase() {
         )
 
         val serviceRoute = ArmeriaRouteCollector.collect(project).firstOrNull { it.path == "/grpc" }
-        assertNotNull(serviceRoute)
-        assertTrue(serviceRoute!!.targetUnresolved)
+        kotlinAssertNotNull(serviceRoute)
+        assertTrue(serviceRoute.targetUnresolved)
     }
 
     fun testNoFalsePositiveForNonArmeriaQualifiedServerBuilder() {

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorEdgeCaseTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinRouteCollectorEdgeCaseTest.kt
@@ -2,6 +2,8 @@ package com.linecorp.intellij.plugins.armeria.explorer
 
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaKotlinRouteCollectorEdgeCaseTest : ArmeriaFixtureTestBase() {

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinServiceRegistrationCollectorBasicTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinServiceRegistrationCollectorBasicTest.kt
@@ -3,6 +3,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaKotlinServiceRegistrationCollectorBasicTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {
@@ -37,8 +38,8 @@ class ArmeriaKotlinServiceRegistrationCollectorBasicTest : ArmeriaFixtureTestBas
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals("example.HelloService", serviceRoute!!.target)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals("example.HelloService", serviceRoute.target)
     }
 
     fun testCollectServiceRegistration() {
@@ -74,8 +75,8 @@ class ArmeriaKotlinServiceRegistrationCollectorBasicTest : ArmeriaFixtureTestBas
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals("/api", serviceRoute!!.path)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals("/api", serviceRoute.path)
         assertEquals("example.HelloService", serviceRoute.target)
     }
 
@@ -149,8 +150,8 @@ class ArmeriaKotlinServiceRegistrationCollectorBasicTest : ArmeriaFixtureTestBas
         val routes = ArmeriaRouteCollector.collect(project)
 
         val grpcRoute = routes.firstOrNull { it.routeMatch == RouteMatch.NON_HTTP }
-        assertNotNull(grpcRoute)
-        assertEquals("example.HelloGrpcService", grpcRoute!!.target)
+        kotlinAssertNotNull(grpcRoute)
+        assertEquals("example.HelloGrpcService", grpcRoute.target)
         assertFalse(grpcRoute.target.equals("build", ignoreCase = true))
     }
 
@@ -174,8 +175,8 @@ class ArmeriaKotlinServiceRegistrationCollectorBasicTest : ArmeriaFixtureTestBas
         val routes = ArmeriaRouteCollector.collect(project)
 
         val docRoute = routes.firstOrNull { it.isDocService }
-        assertNotNull(docRoute)
-        assertEquals("com.linecorp.armeria.server.docs.DocService", docRoute!!.target)
+        kotlinAssertNotNull(docRoute)
+        assertEquals("com.linecorp.armeria.server.docs.DocService", docRoute.target)
     }
 
     fun testCollectUnresolvedNewExpressionTarget() {
@@ -197,8 +198,8 @@ class ArmeriaKotlinServiceRegistrationCollectorBasicTest : ArmeriaFixtureTestBas
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" }
-        assertNotNull(serviceRoute)
-        assertTrue(serviceRoute!!.targetUnresolved)
+        kotlinAssertNotNull(serviceRoute)
+        assertTrue(serviceRoute.targetUnresolved)
     }
 
     fun testCollectServiceRegistrationWithNamedArgumentsReversedOrder() {
@@ -228,8 +229,8 @@ class ArmeriaKotlinServiceRegistrationCollectorBasicTest : ArmeriaFixtureTestBas
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals("example.HelloService", serviceRoute!!.target)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals("example.HelloService", serviceRoute.target)
     }
 
     fun testCollectServiceRegistrationInApplyBlock() {
@@ -259,8 +260,8 @@ class ArmeriaKotlinServiceRegistrationCollectorBasicTest : ArmeriaFixtureTestBas
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals("example.HelloService", serviceRoute!!.target)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals("example.HelloService", serviceRoute.target)
     }
 
     fun testCollectServiceRegistrationInAlsoBlockWithExplicitReceiver() {
@@ -290,8 +291,8 @@ class ArmeriaKotlinServiceRegistrationCollectorBasicTest : ArmeriaFixtureTestBas
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals("example.HelloService", serviceRoute!!.target)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals("example.HelloService", serviceRoute.target)
     }
 
     fun testCollectServiceRegistrationWithConstValPath() {
@@ -323,6 +324,6 @@ class ArmeriaKotlinServiceRegistrationCollectorBasicTest : ArmeriaFixtureTestBas
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
+        kotlinAssertNotNull(serviceRoute)
     }
 }

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinServiceRegistrationCollectorBasicTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinServiceRegistrationCollectorBasicTest.kt
@@ -3,6 +3,9 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaKotlinServiceRegistrationCollectorBasicTest : ArmeriaFixtureTestBase() {

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinServiceRegistrationCollectorServiceUnderTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinServiceRegistrationCollectorServiceUnderTest.kt
@@ -3,6 +3,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaKotlinServiceRegistrationCollectorServiceUnderTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {
@@ -36,8 +37,8 @@ class ArmeriaKotlinServiceRegistrationCollectorServiceUnderTest : ArmeriaFixture
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.routeMatch == RouteMatch.SERVICE_UNDER }
-        assertNotNull(serviceRoute)
-        assertEquals("/v1", serviceRoute!!.path)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals("/v1", serviceRoute.path)
         assertEquals("example.HelloService", serviceRoute.target)
     }
 
@@ -68,8 +69,8 @@ class ArmeriaKotlinServiceRegistrationCollectorServiceUnderTest : ArmeriaFixture
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.routeMatch == RouteMatch.SERVICE_UNDER }
-        assertNotNull(serviceRoute)
-        assertEquals("/v1", serviceRoute!!.path)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals("/v1", serviceRoute.path)
         assertEquals("example.HelloService", serviceRoute.target)
     }
 }

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinServiceRegistrationCollectorServiceUnderTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinServiceRegistrationCollectorServiceUnderTest.kt
@@ -3,6 +3,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaKotlinServiceRegistrationCollectorServiceUnderTest : ArmeriaFixtureTestBase() {

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollectorDecoratorTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollectorDecoratorTest.kt
@@ -3,6 +3,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaRouteCollectorDecoratorTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {
@@ -40,8 +41,8 @@ class ArmeriaRouteCollectorDecoratorTest : ArmeriaFixtureTestBase() {
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals(listOf("Logging"), serviceRoute!!.decorators)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals(listOf("Logging"), serviceRoute.decorators)
     }
 
     fun testCollectProgrammaticDecoratorDoesNotBleedAcrossRegistrations() {
@@ -81,10 +82,10 @@ class ArmeriaRouteCollectorDecoratorTest : ArmeriaFixtureTestBase() {
 
         val routeA = routes.firstOrNull { it.path == "/a" }
         val routeB = routes.firstOrNull { it.path == "/b" }
-        assertNotNull(routeA)
-        assertNotNull(routeB)
-        assertEquals(listOf("Logging"), routeA!!.decorators)
-        assertEquals(listOf("CORS"), routeB!!.decorators)
+        kotlinAssertNotNull(routeA)
+        kotlinAssertNotNull(routeB)
+        assertEquals(listOf("Logging"), routeA.decorators)
+        assertEquals(listOf("CORS"), routeB.decorators)
     }
 
     fun testCollectPathScopedDecoratorUsesDecoratorArgument() {
@@ -118,8 +119,8 @@ class ArmeriaRouteCollectorDecoratorTest : ArmeriaFixtureTestBase() {
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals(listOf("Logging"), serviceRoute!!.decorators)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals(listOf("Logging"), serviceRoute.decorators)
     }
 
     fun testCollectPathScopedDecoratorFiltersByRoute() {
@@ -153,8 +154,8 @@ class ArmeriaRouteCollectorDecoratorTest : ArmeriaFixtureTestBase() {
         val routes = ArmeriaRouteCollector.collect(project)
 
         val otherRoute = routes.firstOrNull { it.path == "/other" }
-        assertNotNull(otherRoute)
-        assertEquals(emptyList<String>(), otherRoute!!.decorators)
+        kotlinAssertNotNull(otherRoute)
+        assertEquals(emptyList<String>(), otherRoute.decorators)
     }
 
     fun testCollectPathScopedDecoratorWithStaticFinalPathPattern() {
@@ -190,7 +191,7 @@ class ArmeriaRouteCollectorDecoratorTest : ArmeriaFixtureTestBase() {
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals(listOf("Logging"), serviceRoute!!.decorators)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals(listOf("Logging"), serviceRoute.decorators)
     }
 }

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollectorDecoratorTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollectorDecoratorTest.kt
@@ -3,6 +3,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaRouteCollectorDecoratorTest : ArmeriaFixtureTestBase() {

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollectorServiceRegistrationTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollectorServiceRegistrationTest.kt
@@ -3,6 +3,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaRouteCollectorServiceRegistrationTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {
@@ -39,8 +40,8 @@ class ArmeriaRouteCollectorServiceRegistrationTest : ArmeriaFixtureTestBase() {
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals("example.HelloService", serviceRoute!!.target)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals("example.HelloService", serviceRoute.target)
     }
 
     fun testCollectServiceRegistration() {
@@ -78,8 +79,8 @@ class ArmeriaRouteCollectorServiceRegistrationTest : ArmeriaFixtureTestBase() {
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals("/api", serviceRoute!!.path)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals("/api", serviceRoute.path)
         assertEquals("example.HelloService", serviceRoute.target)
     }
 
@@ -113,8 +114,8 @@ class ArmeriaRouteCollectorServiceRegistrationTest : ArmeriaFixtureTestBase() {
         val routes = ArmeriaRouteCollector.collect(project)
 
         val grpcRoute = routes.firstOrNull { it.routeMatch == RouteMatch.NON_HTTP }
-        assertNotNull(grpcRoute)
-        assertEquals("example.HelloGrpcService", grpcRoute!!.target)
+        kotlinAssertNotNull(grpcRoute)
+        assertEquals("example.HelloGrpcService", grpcRoute.target)
         assertFalse(grpcRoute.target.equals("build", ignoreCase = true))
     }
 
@@ -140,8 +141,8 @@ class ArmeriaRouteCollectorServiceRegistrationTest : ArmeriaFixtureTestBase() {
         val routes = ArmeriaRouteCollector.collect(project)
 
         val docRoute = routes.firstOrNull { it.isDocService }
-        assertNotNull(docRoute)
-        assertEquals("com.linecorp.armeria.server.docs.DocService", docRoute!!.target)
+        kotlinAssertNotNull(docRoute)
+        assertEquals("com.linecorp.armeria.server.docs.DocService", docRoute.target)
     }
 
     fun testCollectUnresolvedNewExpressionTarget() {
@@ -165,8 +166,8 @@ class ArmeriaRouteCollectorServiceRegistrationTest : ArmeriaFixtureTestBase() {
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" }
-        assertNotNull(serviceRoute)
-        assertTrue(serviceRoute!!.targetUnresolved)
+        kotlinAssertNotNull(serviceRoute)
+        assertTrue(serviceRoute.targetUnresolved)
     }
 
     fun testCollectUnresolvedParenthesizedNewExpressionTarget() {
@@ -188,8 +189,8 @@ class ArmeriaRouteCollectorServiceRegistrationTest : ArmeriaFixtureTestBase() {
         )
 
         val serviceRoute = ArmeriaRouteCollector.collect(project).firstOrNull { it.path == "/api" }
-        assertNotNull(serviceRoute)
-        assertTrue(serviceRoute!!.targetUnresolved)
+        kotlinAssertNotNull(serviceRoute)
+        assertTrue(serviceRoute.targetUnresolved)
     }
 
     fun testCollectUnresolvedFactoryMethodTarget() {
@@ -215,8 +216,8 @@ class ArmeriaRouteCollectorServiceRegistrationTest : ArmeriaFixtureTestBase() {
         )
 
         val serviceRoute = ArmeriaRouteCollector.collect(project).firstOrNull { it.path == "/api" }
-        assertNotNull(serviceRoute)
-        assertTrue(serviceRoute!!.targetUnresolved)
+        kotlinAssertNotNull(serviceRoute)
+        assertTrue(serviceRoute.targetUnresolved)
     }
 
     fun testCollectServiceRegistration_requestTimeoutOnBuilderChain() {

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollectorServiceRegistrationTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteCollectorServiceRegistrationTest.kt
@@ -3,6 +3,9 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaRouteCollectorServiceRegistrationTest : ArmeriaFixtureTestBase() {

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaScalaRouteCollectorEdgeCaseTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaScalaRouteCollectorEdgeCaseTest.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiDocumentManager
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaScalaRouteCollectorEdgeCaseTest : ArmeriaFixtureTestBase() {
     fun testNoFalsePositiveForUnrelatedServiceCall() {
@@ -128,15 +129,15 @@ class ArmeriaScalaRouteCollectorEdgeCaseTest : ArmeriaFixtureTestBase() {
 
         val routes = ArmeriaRouteCollector.collect(project)
         val serviceRoute = routes.firstOrNull { it.path == "/api" }
-        assertNotNull(serviceRoute)
-        val offset = serviceRoute!!.sourceOffset
-        assertNotNull(offset)
+        kotlinAssertNotNull(serviceRoute)
+        val offset = serviceRoute.sourceOffset
+        kotlinAssertNotNull(offset)
         val document =
             PsiDocumentManager
                 .getInstance(project)
                 .getDocument(myFixture.file)
-        assertNotNull(document)
-        val line = document!!.getLineNumber(offset!!)
+        kotlinAssertNotNull(document)
+        val line = document.getLineNumber(offset)
         val lineText = document.getText(TextRange(document.getLineStartOffset(line), document.getLineEndOffset(line)))
         assertTrue(lineText.contains(".service"))
     }

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaScalaRouteCollectorEdgeCaseTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaScalaRouteCollectorEdgeCaseTest.kt
@@ -4,6 +4,8 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiDocumentManager
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaScalaRouteCollectorEdgeCaseTest : ArmeriaFixtureTestBase() {

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaScalaRouteCollectorTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaScalaRouteCollectorTest.kt
@@ -3,6 +3,9 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaScalaRouteCollectorTest : ArmeriaFixtureTestBase() {

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaScalaRouteCollectorTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaScalaRouteCollectorTest.kt
@@ -3,6 +3,7 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaScalaRouteCollectorTest : ArmeriaFixtureTestBase() {
     fun testCollectServiceRegistrationFromScalaBuilderChain() {
@@ -32,11 +33,11 @@ class ArmeriaScalaRouteCollectorTest : ArmeriaFixtureTestBase() {
         val routes = ArmeriaRouteCollector.collect(project)
 
         val serviceRoute = routes.firstOrNull { it.path == "/api" && it.routeMatch == RouteMatch.SERVICE }
-        assertNotNull(serviceRoute)
-        assertEquals("HelloService", serviceRoute!!.target)
+        kotlinAssertNotNull(serviceRoute)
+        assertEquals("HelloService", serviceRoute.target)
         assertFalse(serviceRoute.targetUnresolved)
-        assertNotNull(serviceRoute.sourceOffset)
-        assertTrue(serviceRoute.sourceOffset!! > 0)
+        val sourceOffset = kotlinAssertNotNull(serviceRoute.sourceOffset)
+        assertTrue(sourceOffset > 0)
         assertFalse(serviceRoute.resolveSourceHint().endsWith(":1"))
     }
 
@@ -109,7 +110,7 @@ class ArmeriaScalaRouteCollectorTest : ArmeriaFixtureTestBase() {
         val routes = ArmeriaRouteCollector.collect(project)
 
         val route = routes.firstOrNull { it.path == "/prefix" && it.routeMatch == RouteMatch.ANNOTATED_SERVICE }
-        assertNotNull(route)
-        assertEquals("AnnotatedService", route!!.target)
+        kotlinAssertNotNull(route)
+        assertEquals("AnnotatedService", route.target)
     }
 }

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaTimeoutSupportTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaTimeoutSupportTest.kt
@@ -7,6 +7,7 @@ import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteColl
 import com.linecorp.intellij.plugins.armeria.explorer.collector.annotation.ArmeriaTimeoutSupport
 import com.linecorp.intellij.plugins.armeria.message
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
 
 class ArmeriaTimeoutSupportTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {

--- a/plugin-route-protocol/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaProtoTextSupportTest.kt
+++ b/plugin-route-protocol/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaProtoTextSupportTest.kt
@@ -1,8 +1,8 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
 import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaProtoTextSupport
-import org.junit.Assert.assertEquals
 import org.junit.Test
+import kotlin.test.assertEquals
 
 class ArmeriaProtoTextSupportTest {
     @Test

--- a/plugin-route-protocol/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollectorGateTest.kt
+++ b/plugin-route-protocol/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollectorGateTest.kt
@@ -5,6 +5,8 @@ import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteColl
 import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaGrpcRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaProtocolRouteContributor
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class ArmeriaGrpcRouteCollectorGateTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {

--- a/plugin-route-protocol/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollectorTest.kt
+++ b/plugin-route-protocol/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollectorTest.kt
@@ -6,6 +6,7 @@ import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaGrpcRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaProtocolRouteContributor
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaGrpcRouteCollectorTest : ArmeriaFixtureTestBase() {

--- a/plugin-route-protocol/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollectorTest.kt
+++ b/plugin-route-protocol/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaGrpcRouteCollectorTest.kt
@@ -6,6 +6,7 @@ import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaGrpcRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaProtocolRouteContributor
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaGrpcRouteCollectorTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {
@@ -143,8 +144,8 @@ class ArmeriaGrpcRouteCollectorTest : ArmeriaFixtureTestBase() {
             )
         val protoRoute = routes.firstOrNull { it.path == "/com.example.Greeter/SayHello" }
 
-        assertNotNull(protoRoute)
-        assertEquals("com.example.Greeter.SayHello", protoRoute!!.target)
+        kotlinAssertNotNull(protoRoute)
+        assertEquals("com.example.Greeter.SayHello", protoRoute.target)
     }
 
     fun testCollectGrpcRoutesFromMultipleServicesInOneProto() {
@@ -340,7 +341,7 @@ class ArmeriaGrpcRouteCollectorTest : ArmeriaFixtureTestBase() {
                 contributors = listOf(ArmeriaProtocolRouteContributor),
             )
 
-        assertNotNull(routes.firstOrNull { it.path == "/grpc" })
-        assertNotNull(routes.firstOrNull { it.path == "/com.example.Greeter/SayHello" })
+        kotlinAssertNotNull(routes.firstOrNull { it.path == "/grpc" })
+        kotlinAssertNotNull(routes.firstOrNull { it.path == "/com.example.Greeter/SayHello" })
     }
 }

--- a/plugin-route-protocol/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaIdlRouteCollectorMultiModuleTest.kt
+++ b/plugin-route-protocol/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaIdlRouteCollectorMultiModuleTest.kt
@@ -12,6 +12,7 @@ import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteColl
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteProtocol
 import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaProtocolRouteContributor
 import java.io.File
+import kotlin.test.assertEquals
 
 class ArmeriaIdlRouteCollectorMultiModuleTest : HeavyPlatformTestCase() {
     override fun setUp() {

--- a/plugin-route-protocol/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaIdlRouteCollectorTest.kt
+++ b/plugin-route-protocol/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaIdlRouteCollectorTest.kt
@@ -10,6 +10,8 @@ import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaThriftRout
 import com.linecorp.intellij.plugins.armeria.explorer.protocol.GraphqlOperation
 import com.linecorp.intellij.plugins.armeria.explorer.protocol.ThriftOperation
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ArmeriaIdlRouteCollectorTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {

--- a/plugin-route-spring/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollectorParseTest.kt
+++ b/plugin-route-spring/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollectorParseTest.kt
@@ -3,8 +3,8 @@ package com.linecorp.intellij.plugins.armeria.explorer
 import com.linecorp.intellij.plugins.armeria.explorer.spring.ArmeriaSpringConfigRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.spring.SpringArmeriaConfigSemantics
 import com.linecorp.intellij.plugins.armeria.explorer.spring.SpringArmeriaPortBinding
-import org.junit.Assert.assertEquals
 import org.junit.Test
+import kotlin.test.assertEquals
 
 class ArmeriaSpringConfigRouteCollectorParseTest {
     @Test

--- a/plugin-route-spring/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/SpringArmeriaConfigSemanticsTest.kt
+++ b/plugin-route-spring/src/fastTest/kotlin/com/linecorp/intellij/plugins/armeria/explorer/SpringArmeriaConfigSemanticsTest.kt
@@ -1,8 +1,8 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
 import com.linecorp.intellij.plugins.armeria.explorer.spring.SpringArmeriaConfigSemantics
-import org.junit.Assert.assertEquals
 import org.junit.Test
+import kotlin.test.assertEquals
 
 class SpringArmeriaConfigSemanticsTest {
     @Test

--- a/plugin-route-spring/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
+++ b/plugin-route-spring/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
@@ -12,6 +12,10 @@ import com.linecorp.intellij.plugins.armeria.explorer.spring.ArmeriaSpringRouteC
 import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaDelegationSupport
 import com.linecorp.intellij.plugins.armeria.message
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
@@ -378,9 +382,9 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
             )
         val springMounts = routes.filter { it.path == "/spring/" }
         assertTrue(
+            springMounts.any { it.delegationKind == DelegationKind.SPRING_MVC },
             "expected Spring MVC–badged /spring/ mount; got: " +
                 springMounts.map { "${it.target}/${it.routeMatch}/${it.delegationKind}" },
-            springMounts.any { it.delegationKind == DelegationKind.SPRING_MVC },
         )
         kotlinAssertNotNull(routes.singleOrNull { it.path == "/spring/hello" && it.routeMatch == RouteMatch.DELEGATED })
     }

--- a/plugin-route-spring/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
+++ b/plugin-route-spring/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaDelegatedRouteCollectorTest.kt
@@ -12,6 +12,7 @@ import com.linecorp.intellij.plugins.armeria.explorer.spring.ArmeriaSpringRouteC
 import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaDelegationSupport
 import com.linecorp.intellij.plugins.armeria.message
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
     override fun setUp() {
@@ -338,13 +339,13 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
                 contributors = listOf(ArmeriaSpringRouteContributor),
             )
 
-        assertNotNull(
+        kotlinAssertNotNull(
             routes.singleOrNull {
                 it.path == "/spring/" &&
                     it.delegationKind == DelegationKind.SPRING_MVC
             },
         )
-        assertNotNull(routes.singleOrNull { it.path == "/spring/hello" && it.routeMatch == RouteMatch.DELEGATED })
+        kotlinAssertNotNull(routes.singleOrNull { it.path == "/spring/hello" && it.routeMatch == RouteMatch.DELEGATED })
     }
 
     fun testKotlinTomcatServiceBeanMountIsDetected() {
@@ -381,7 +382,7 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
                 springMounts.map { "${it.target}/${it.routeMatch}/${it.delegationKind}" },
             springMounts.any { it.delegationKind == DelegationKind.SPRING_MVC },
         )
-        assertNotNull(routes.singleOrNull { it.path == "/spring/hello" && it.routeMatch == RouteMatch.DELEGATED })
+        kotlinAssertNotNull(routes.singleOrNull { it.path == "/spring/hello" && it.routeMatch == RouteMatch.DELEGATED })
     }
 
     fun testClassLevelMultiPathRequestMappingEmitsAllPrefixes() {
@@ -559,7 +560,7 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
                     it.delegationKind == DelegationKind.SPRING_MVC
             },
         )
-        assertNotNull(routes.singleOrNull { it.path == "/spring/hello" && it.routeMatch == RouteMatch.DELEGATED })
+        kotlinAssertNotNull(routes.singleOrNull { it.path == "/spring/hello" && it.routeMatch == RouteMatch.DELEGATED })
     }
 
     fun testAmbiguousSameModuleMountsExpandOnlyUnderShortestPath() {
@@ -613,7 +614,7 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
         val delegated = routes.filter { it.routeMatch == RouteMatch.DELEGATED }
         assertTrue(delegated.isNotEmpty())
         assertEquals(setOf("/"), delegated.map { it.delegationMountPath }.toSet())
-        assertNotNull(
+        kotlinAssertNotNull(
             delegated.singleOrNull {
                 it.path == "/api" &&
                     it.httpMethod == "GET" &&
@@ -622,7 +623,7 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
             },
         )
         // Root mapping "" under preferred "/" becomes "/".
-        assertNotNull(
+        kotlinAssertNotNull(
             delegated.singleOrNull {
                 it.path == "/" &&
                     it.httpMethod == "GET" &&
@@ -663,7 +664,7 @@ class ArmeriaDelegatedRouteCollectorTest : ArmeriaFixtureTestBase() {
                 project,
                 contributors = listOf(ArmeriaSpringRouteContributor),
             )
-        assertNotNull(routes)
+        kotlinAssertNotNull(routes)
     }
 
     fun testNoDelegatedRoutesWithoutServletMount() {

--- a/plugin-route-spring/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinSpringBootRouteCollectorTest.kt
+++ b/plugin-route-spring/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaKotlinSpringBootRouteCollectorTest.kt
@@ -4,6 +4,9 @@ import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteColl
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.explorer.spring.ArmeriaSpringRouteContributor
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class ArmeriaKotlinSpringBootRouteCollectorTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {

--- a/plugin-route-spring/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringBootRouteCollectorTest.kt
+++ b/plugin-route-spring/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringBootRouteCollectorTest.kt
@@ -4,6 +4,9 @@ import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteColl
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.explorer.spring.ArmeriaSpringRouteContributor
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class ArmeriaSpringBootRouteCollectorTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {

--- a/plugin-route-spring/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollectorTest.kt
+++ b/plugin-route-spring/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollectorTest.kt
@@ -13,6 +13,7 @@ import com.linecorp.intellij.plugins.armeria.message
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaLightJavaCodeInsightFixtureTestCase
 import org.jetbrains.yaml.psi.YAMLFile
 import org.jetbrains.yaml.psi.YAMLKeyValue
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaSpringConfigRouteCollectorTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {
     fun testCollectPortsAndInternalServicesFromYaml() {
@@ -388,7 +389,7 @@ class ArmeriaSpringConfigRouteCollectorTest : ArmeriaLightJavaCodeInsightFixture
 
         val portRoute = routes.single { it.path == ":8080" }
         val element = portRoute.pointer.element
-        assertNotNull(element)
+        kotlinAssertNotNull(element)
         assertTrue(
             "Port route should navigate to the YAML port key, not the whole file",
             element is YAMLKeyValue,
@@ -602,7 +603,7 @@ class ArmeriaSpringConfigRouteCollectorTest : ArmeriaLightJavaCodeInsightFixture
         assertFalse(docs.resolveSourceHint().endsWith(":1"))
         assertFalse(health.resolveSourceHint().endsWith(":1"))
         assertFalse(metrics.resolveSourceHint().endsWith(":1"))
-        assertSame(psiFile, docs.pointer.element!!.containingFile)
+        assertSame(psiFile, kotlinAssertNotNull(docs.pointer.element).containingFile)
     }
 
     fun testYamlCommentOnlyIncludeThenBlockList() {

--- a/plugin-route-spring/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollectorTest.kt
+++ b/plugin-route-spring/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringConfigRouteCollectorTest.kt
@@ -13,6 +13,10 @@ import com.linecorp.intellij.plugins.armeria.message
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaLightJavaCodeInsightFixtureTestCase
 import org.jetbrains.yaml.psi.YAMLFile
 import org.jetbrains.yaml.psi.YAMLKeyValue
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaSpringConfigRouteCollectorTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {
@@ -368,7 +372,7 @@ class ArmeriaSpringConfigRouteCollectorTest : ArmeriaLightJavaCodeInsightFixture
         assertTrue(health.httpMethod.isNotBlank())
         assertEquals("GET", health.httpMethod)
         // CONFIG is a static-analysis match, not a runtime route.
-        assertFalse("CONFIG route must not be RUNTIME", health.routeMatch == RouteMatch.RUNTIME)
+        assertFalse(health.routeMatch == RouteMatch.RUNTIME, "CONFIG route must not be RUNTIME")
     }
 
     fun testYamlPortNavigationTargetsKeyElement() {
@@ -391,8 +395,8 @@ class ArmeriaSpringConfigRouteCollectorTest : ArmeriaLightJavaCodeInsightFixture
         val element = portRoute.pointer.element
         kotlinAssertNotNull(element)
         assertTrue(
-            "Port route should navigate to the YAML port key, not the whole file",
             element is YAMLKeyValue,
+            "Port route should navigate to the YAML port key, not the whole file",
         )
         assertEquals("port", (element as YAMLKeyValue).keyText)
         assertFalse(portRoute.resolveSourceHint().endsWith(":1"))
@@ -643,8 +647,8 @@ class ArmeriaSpringConfigRouteCollectorTest : ArmeriaLightJavaCodeInsightFixture
                 content,
             )
         assertFalse(
-            "Fixture must not be YAMLFile for this regression",
             psiFile is YAMLFile,
+            "Fixture must not be YAMLFile for this regression",
         )
 
         val routes = mutableListOf<ArmeriaRoute>()

--- a/plugin-route-spring/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcInheritanceRouteCollectorTest.kt
+++ b/plugin-route-spring/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaSpringMvcInheritanceRouteCollectorTest.kt
@@ -11,6 +11,8 @@ import com.linecorp.intellij.plugins.armeria.explorer.spring.ArmeriaSpringMvcRou
 import com.linecorp.intellij.plugins.armeria.explorer.spring.ArmeriaSpringRouteContributor
 import com.linecorp.intellij.plugins.armeria.message
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ArmeriaSpringMvcInheritanceRouteCollectorTest : ArmeriaFixtureTestBase() {
     override fun setUp() {

--- a/plugin-wizard/src/test/kotlin/com/linecorp/intellij/plugins/armeria/module/ArmeriaWizardTemplateCoverageTest.kt
+++ b/plugin-wizard/src/test/kotlin/com/linecorp/intellij/plugins/armeria/module/ArmeriaWizardTemplateCoverageTest.kt
@@ -1,8 +1,8 @@
 package com.linecorp.intellij.plugins.armeria.module
 
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.nio.charset.StandardCharsets
+import kotlin.test.assertTrue
 
 class ArmeriaWizardTemplateCoverageTest {
     @Test
@@ -30,8 +30,8 @@ class ArmeriaWizardTemplateCoverageTest {
         val template = readClasspathResource(templateResource)
         armeriaWizardLibraryIds.forEach { libraryId ->
             assertTrue(
-                "$templateResource is missing hasLibrary(\"$libraryId\")",
                 template.contains("""hasLibrary("$libraryId")"""),
+                "$templateResource is missing hasLibrary(\"$libraryId\")",
             )
         }
     }

--- a/plugin-wizard/src/test/kotlin/com/linecorp/intellij/plugins/armeria/module/ArmeriaWizardTemplateRenderingTest.kt
+++ b/plugin-wizard/src/test/kotlin/com/linecorp/intellij/plugins/armeria/module/ArmeriaWizardTemplateRenderingTest.kt
@@ -1,8 +1,8 @@
 package com.linecorp.intellij.plugins.armeria.module
 
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * Regression tests for the representative wizard matrix from the New Project Wizard review.

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaClientCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaClientCollectorTest.kt
@@ -1,6 +1,9 @@
 package com.linecorp.intellij.plugins.armeria.client
 
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaClientFixtureTestBase
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class ArmeriaClientCollectorTest : ArmeriaClientFixtureTestBase() {
     fun testCollectWebClientOf() {

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaKotlinClientCollectorFallbackTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaKotlinClientCollectorFallbackTest.kt
@@ -1,6 +1,7 @@
 package com.linecorp.intellij.plugins.armeria.client
 
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaLightJavaCodeInsightFixtureTestCase
+import kotlin.test.assertEquals
 
 class ArmeriaKotlinClientCollectorFallbackTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {
     fun testCollectWebClientOfViaImportWhenMethodResolutionFails() {

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaKotlinClientCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaKotlinClientCollectorTest.kt
@@ -1,6 +1,9 @@
 package com.linecorp.intellij.plugins.armeria.client
 
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaClientFixtureTestBase
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class ArmeriaKotlinClientCollectorTest : ArmeriaClientFixtureTestBase() {
     fun testCollectWebClientOfFromKotlin() {

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaScalaClientCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaScalaClientCollectorTest.kt
@@ -1,6 +1,7 @@
 package com.linecorp.intellij.plugins.armeria.client
 
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaLightJavaCodeInsightFixtureTestCase
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaScalaClientCollectorTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {
     fun testCollectWebClientOfFromScala() {
@@ -32,8 +33,8 @@ class ArmeriaScalaClientCollectorTest : ArmeriaLightJavaCodeInsightFixtureTestCa
         assertEquals("HTTP", endpoint.clientType)
         assertEquals("https://example.com", endpoint.uri)
         assertEquals("WebClient", endpoint.target)
-        assertNotNull(endpoint.sourceOffset)
-        assertTrue(endpoint.sourceOffset!! > 0)
+        val sourceOffset = kotlinAssertNotNull(endpoint.sourceOffset)
+        assertTrue(sourceOffset > 0)
     }
 
     fun testIgnoresWebClientOfInsideStringLiteral() {

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaScalaClientCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/client/ArmeriaScalaClientCollectorTest.kt
@@ -1,6 +1,9 @@
 package com.linecorp.intellij.plugins.armeria.client
 
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaLightJavaCodeInsightFixtureTestCase
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaScalaClientCollectorTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
@@ -7,6 +7,9 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaLightJavaCodeInsightFixtureTestCase
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaRouteNavigationSupportTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/editor/ArmeriaRouteNavigationSupportTest.kt
@@ -7,6 +7,7 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaLightJavaCodeInsightFixtureTestCase
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaRouteNavigationSupportTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {
     override fun setUp() {
@@ -337,8 +338,8 @@ class ArmeriaRouteNavigationSupportTest : ArmeriaLightJavaCodeInsightFixtureTest
 
         val resolved = ArmeriaRouteNavigationSupport.findClassByTarget(project, "HelloService")
 
-        assertNotNull(resolved)
-        assertEquals("services.HelloService", resolved!!.qualifiedName)
+        kotlinAssertNotNull(resolved)
+        assertEquals("services.HelloService", resolved.qualifiedName)
     }
 
     fun testFindClassByTargetReturnsNullWhenAmbiguous() {
@@ -426,10 +427,10 @@ class ArmeriaRouteNavigationSupportTest : ArmeriaLightJavaCodeInsightFixtureTest
                 className,
                 GlobalSearchScope.projectScope(project),
             )
-        assertNotNull(clazz)
-        val method = clazz!!.findMethodsByName(name, false).singleOrNull()
-        assertNotNull(method)
-        return method!!
+        kotlinAssertNotNull(clazz)
+        val method = clazz.findMethodsByName(name, false).singleOrNull()
+        kotlinAssertNotNull(method)
+        return method
     }
 
     private fun findMethod(name: String): PsiMethod = findMethod("example.HelloService", name)

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaProtoPsiRouteCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaProtoPsiRouteCollectorTest.kt
@@ -10,6 +10,9 @@ import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaProtoRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.protocol.ArmeriaProtocolRouteContributor
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaLightJavaCodeInsightFixtureTestCase
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class ArmeriaProtoPsiRouteCollectorTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {
     override fun setUp() {
@@ -32,7 +35,7 @@ class ArmeriaProtoPsiRouteCollectorTest : ArmeriaLightJavaCodeInsightFixtureTest
                 }
                 """.trimIndent(),
             )
-        assertTrue("Expected Proto Editor PSI for .proto fixture", file is PbFile)
+        assertTrue(file is PbFile, "Expected Proto Editor PSI for .proto fixture")
 
         val routes = mutableListOf<ArmeriaRoute>()
         assertTrue(ArmeriaProtoPsiRouteCollector().collectFromFile(file, routes, mutableSetOf()))

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerRouteStateTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRouteExplorerRouteStateTest.kt
@@ -8,8 +8,8 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.SmartPsiElementPointer
 import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
-import org.junit.Assert.assertEquals
 import org.junit.Test
+import kotlin.test.assertEquals
 
 class ArmeriaRouteExplorerRouteStateTest {
     @Test

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRuntimeRouteFetcherTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaRuntimeRouteFetcherTest.kt
@@ -1,9 +1,9 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ArmeriaRuntimeRouteFetcherTest {
     @Test

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRegistrationInspectionTest.kt
@@ -9,6 +9,8 @@ import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {
@@ -39,8 +41,8 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
             clazz.declarations.filterIsInstance<KtNamedFunction>().single { it.name == functionName }
         val functionOffset = function.nameIdentifier!!.textRange.startOffset
         assertTrue(
-            "Expected registration duplicate highlight on $className.$functionName",
             functionOffset in duplicateHighlights.map { it.startOffset }.toSet(),
+            "Expected registration duplicate highlight on $className.$functionName",
         )
     }
 
@@ -62,8 +64,8 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
         val method = clazz.findMethodsByName(methodName, false).single()
         val methodOffset = method.nameIdentifier!!.textRange.startOffset
         assertTrue(
-            "Expected registration duplicate highlight on $className.$methodName",
             methodOffset in duplicateHighlights.map { it.startOffset }.toSet(),
+            "Expected registration duplicate highlight on $className.$methodName",
         )
     }
 
@@ -122,7 +124,7 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
                 .openFiles
                 .map { it.name }
                 .toSet()
-        assertTrue("Expected Extra.java among open files but found $openFileNames", "Extra.java" in openFileNames)
+        assertTrue("Extra.java" in openFileNames, "Expected Extra.java among open files but found $openFileNames")
     }
 
     fun testJavaCrossFileAnnotatedRoutesAreHighlighted() {
@@ -322,8 +324,8 @@ class ArmeriaDuplicateRegistrationInspectionTest : ArmeriaFixtureTestBase() {
         PlatformTestUtil.dispatchAllInvocationEventsInIdeEventQueue()
         val openFileNames = FileEditorManager.getInstance(project).openFiles.map { it.name }
         assertTrue(
-            "Timed out waiting for $expectedFileName to open; open files: $openFileNames",
             expectedFileName in openFileNames,
+            "Timed out waiting for $expectedFileName to open; open files: $openFileNames",
         )
     }
 

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRouteInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaDuplicateRouteInspectionTest.kt
@@ -3,6 +3,8 @@ package com.linecorp.intellij.plugins.armeria.inspection
 import com.intellij.psi.PsiJavaFile
 import com.linecorp.intellij.plugins.armeria.message
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ArmeriaDuplicateRouteInspectionTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {
@@ -119,8 +121,8 @@ class ArmeriaDuplicateRouteInspectionTest : ArmeriaFixtureTestBase() {
             val method = clazz.findMethodsByName(methodName, false).single()
             val methodOffset = method.nameIdentifier!!.textRange.startOffset
             assertTrue(
-                "Expected duplicate route highlight on $className.$methodName",
                 methodOffset in highlightedOffsets,
+                "Expected duplicate route highlight on $className.$methodName",
             )
         }
     }

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaKotlinMethodRouteTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/inspection/ArmeriaKotlinMethodRouteTest.kt
@@ -4,6 +4,8 @@ import com.linecorp.intellij.plugins.armeria.test.ArmeriaLightJavaCodeInsightFix
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ArmeriaKotlinMethodRouteTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {
     override fun setUp() {

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/intention/ArmeriaGenerateRouteMethodIntentionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/intention/ArmeriaGenerateRouteMethodIntentionTest.kt
@@ -1,6 +1,8 @@
 package com.linecorp.intellij.plugins.armeria.intention
 
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class ArmeriaGenerateRouteMethodIntentionTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaProtoRpcLineMarkerProviderTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaProtoRpcLineMarkerProviderTest.kt
@@ -7,6 +7,9 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.linecorp.intellij.plugins.armeria.ArmeriaIcons
 import com.linecorp.intellij.plugins.armeria.message
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaLightJavaCodeInsightFixtureTestCase
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaProtoRpcLineMarkerProviderTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaProtoRpcLineMarkerProviderTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaProtoRpcLineMarkerProviderTest.kt
@@ -7,6 +7,7 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.linecorp.intellij.plugins.armeria.ArmeriaIcons
 import com.linecorp.intellij.plugins.armeria.message
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaLightJavaCodeInsightFixtureTestCase
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaProtoRpcLineMarkerProviderTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {
     private val provider = ArmeriaProtoRpcLineMarkerProvider()
@@ -28,8 +29,8 @@ class ArmeriaProtoRpcLineMarkerProviderTest : ArmeriaLightJavaCodeInsightFixture
         val rpcKeyword = findRpcKeyword()
         val marker = provider.getLineMarkerInfo(rpcKeyword)
 
-        assertNotNull(marker)
-        assertEquals(ArmeriaIcons.Armeria, marker!!.icon)
+        kotlinAssertNotNull(marker)
+        assertEquals(ArmeriaIcons.Armeria, marker.icon)
         assertEquals(
             message("marker.grpc.rpc", "/com.example.Greeter/SayHello"),
             marker.lineMarkerTooltip,
@@ -52,10 +53,10 @@ class ArmeriaProtoRpcLineMarkerProviderTest : ArmeriaLightJavaCodeInsightFixture
         val rpcKeyword = findRpcKeyword()
         val marker = provider.getLineMarkerInfo(rpcKeyword)
 
-        assertNotNull(marker)
+        kotlinAssertNotNull(marker)
         assertEquals(
             message("marker.grpc.rpc", "/Greeter/Ping"),
-            marker!!.lineMarkerTooltip,
+            marker.lineMarkerTooltip,
         )
     }
 
@@ -113,10 +114,10 @@ class ArmeriaProtoRpcLineMarkerProviderTest : ArmeriaLightJavaCodeInsightFixture
 
         val marker = provider.getLineMarkerInfo(findRpcKeyword())
 
-        assertNotNull(marker)
+        kotlinAssertNotNull(marker)
         assertEquals(
             message("marker.grpc.rpc", "/com.example.Greeter/SayHello"),
-            marker!!.lineMarkerTooltip,
+            marker.lineMarkerTooltip,
         )
     }
 
@@ -138,7 +139,7 @@ class ArmeriaProtoRpcLineMarkerProviderTest : ArmeriaLightJavaCodeInsightFixture
         val commentedRpcKeyword = myFixture.file.findElementAt(commentedRpcIndex + 3)!!
 
         assertNull(provider.getLineMarkerInfo(commentedRpcKeyword))
-        assertNotNull(provider.getLineMarkerInfo(findRpcKeyword()))
+        kotlinAssertNotNull(provider.getLineMarkerInfo(findRpcKeyword()))
     }
 
     fun testMultipleRpcMarkersInOneService() {
@@ -223,10 +224,10 @@ class ArmeriaProtoRpcLineMarkerProviderTest : ArmeriaLightJavaCodeInsightFixture
 
         val marker = provider.getLineMarkerInfo(findRpcKeyword())
 
-        assertNotNull(marker)
+        kotlinAssertNotNull(marker)
         assertEquals(
             message("marker.grpc.rpc", "/com.example.Greeter/StreamHello"),
-            marker!!.lineMarkerTooltip,
+            marker.lineMarkerTooltip,
         )
     }
 

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaRouteLineMarkerProviderTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaRouteLineMarkerProviderTest.kt
@@ -6,6 +6,8 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.linecorp.intellij.plugins.armeria.ArmeriaIcons
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaLightJavaCodeInsightFixtureTestCase
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaRouteLineMarkerProviderTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaRouteLineMarkerProviderTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/marker/ArmeriaRouteLineMarkerProviderTest.kt
@@ -6,6 +6,7 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.linecorp.intellij.plugins.armeria.ArmeriaIcons
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaLightJavaCodeInsightFixtureTestCase
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaRouteLineMarkerProviderTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {
     private val javaProvider = ArmeriaJavaRouteLineMarkerProvider()
@@ -36,8 +37,8 @@ class ArmeriaRouteLineMarkerProviderTest : ArmeriaLightJavaCodeInsightFixtureTes
         val method = PsiTreeUtil.findChildOfType(myFixture.file, PsiMethod::class.java)!!
         val marker = javaProvider.getLineMarkerInfo(method.nameIdentifier!!)
 
-        assertNotNull(marker)
-        assertEquals(ArmeriaIcons.Armeria, marker!!.icon)
+        kotlinAssertNotNull(marker)
+        assertEquals(ArmeriaIcons.Armeria, marker.icon)
     }
 
     fun testKotlinAnnotatedRouteMarker() {
@@ -58,8 +59,8 @@ class ArmeriaRouteLineMarkerProviderTest : ArmeriaLightJavaCodeInsightFixtureTes
         val function = PsiTreeUtil.findChildOfType(myFixture.file, KtNamedFunction::class.java)!!
         val marker = kotlinProvider.getLineMarkerInfo(function.nameIdentifier!!)
 
-        assertNotNull(marker)
-        assertEquals(ArmeriaIcons.Armeria, marker!!.icon)
+        kotlinAssertNotNull(marker)
+        assertEquals(ArmeriaIcons.Armeria, marker.icon)
     }
 
     fun testServiceRegistrationMarker() {
@@ -85,8 +86,8 @@ class ArmeriaRouteLineMarkerProviderTest : ArmeriaLightJavaCodeInsightFixtureTes
         val element = myFixture.file.findElementAt(serviceIndex)!!
         val marker = javaProvider.getLineMarkerInfo(element)
 
-        assertNotNull(marker)
-        assertEquals(ArmeriaIcons.Armeria, marker!!.icon)
+        kotlinAssertNotNull(marker)
+        assertEquals(ArmeriaIcons.Armeria, marker.icon)
     }
 
     fun testJavaServiceRegistrationMarkerResolvesStringConstant() {
@@ -125,7 +126,7 @@ class ArmeriaRouteLineMarkerProviderTest : ArmeriaLightJavaCodeInsightFixtureTes
         assertEquals("/api", path)
         val marker = javaProvider.getLineMarkerInfo(element)
 
-        assertNotNull(marker)
+        kotlinAssertNotNull(marker)
     }
 
     fun testKotlinServiceRegistrationMarker() {
@@ -149,8 +150,8 @@ class ArmeriaRouteLineMarkerProviderTest : ArmeriaLightJavaCodeInsightFixtureTes
         val element = myFixture.file.findElementAt(serviceIndex)!!
         val marker = kotlinProvider.getLineMarkerInfo(element)
 
-        assertNotNull(marker)
-        assertEquals(ArmeriaIcons.Armeria, marker!!.icon)
+        kotlinAssertNotNull(marker)
+        assertEquals(ArmeriaIcons.Armeria, marker.icon)
     }
 
     fun testExtendedRegistrationMethodsDoNotGetMarkers() {

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/run/ArmeriaMainClassResolverTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/run/ArmeriaMainClassResolverTest.kt
@@ -1,6 +1,8 @@
 package com.linecorp.intellij.plugins.armeria.run
 
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaLightJavaCodeInsightFixtureTestCase
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaMainClassResolverTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/run/ArmeriaMainClassResolverTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/run/ArmeriaMainClassResolverTest.kt
@@ -1,6 +1,7 @@
 package com.linecorp.intellij.plugins.armeria.run
 
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaLightJavaCodeInsightFixtureTestCase
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaMainClassResolverTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {
     fun testFindsJavaMainClass() {
@@ -21,8 +22,8 @@ class ArmeriaMainClassResolverTest : ArmeriaLightJavaCodeInsightFixtureTestCase(
 
         val mainClass = ArmeriaMainClassResolver.findArmeriaMainClass(myFixture.file.findElementAt(myFixture.caretOffset))
 
-        assertNotNull(mainClass)
-        assertEquals("example.Main", mainClass!!.qualifiedName)
+        kotlinAssertNotNull(mainClass)
+        assertEquals("example.Main", mainClass.qualifiedName)
     }
 
     fun testFindsKotlinTopLevelMainFacade() {
@@ -41,8 +42,8 @@ class ArmeriaMainClassResolverTest : ArmeriaLightJavaCodeInsightFixtureTestCase(
 
         val mainClass = ArmeriaMainClassResolver.findArmeriaMainClass(myFixture.file.findElementAt(myFixture.caretOffset))
 
-        assertNotNull(mainClass)
-        assertEquals("example.MainKt", mainClass!!.qualifiedName)
+        kotlinAssertNotNull(mainClass)
+        assertEquals("example.MainKt", mainClass.qualifiedName)
     }
 
     fun testIgnoresNonArmeriaMain() {

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/springboot/config/ArmeriaSpringBootConfigParserTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/springboot/config/ArmeriaSpringBootConfigParserTest.kt
@@ -1,11 +1,11 @@
 package com.linecorp.intellij.plugins.armeria.springboot.config
 
 import com.linecorp.intellij.plugins.armeria.message
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class ArmeriaSpringBootConfigParserTest {
     @Test

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientInspectionTest.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiManager
 import com.intellij.testFramework.PsiTestUtil
-import org.junit.Assert.assertTrue
+import kotlin.test.assertTrue
 
 class ArmeriaBlockingClientInspectionTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {
     override fun setUp() {

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientKotlinInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientKotlinInspectionTest.kt
@@ -13,8 +13,8 @@ import com.intellij.testFramework.PsiTestUtil
 import com.linecorp.intellij.plugins.armeria.message
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtFile
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ArmeriaBlockingClientKotlinInspectionTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {
     override fun setUp() {

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaJUnitServerExtensionCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaJUnitServerExtensionCollectorTest.kt
@@ -1,6 +1,7 @@
 package com.linecorp.intellij.plugins.armeria.test
 
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaLightJavaCodeInsightFixtureTestCase
+import kotlin.test.assertEquals
 
 class ArmeriaJUnitServerExtensionCollectorTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {
     override fun setUp() {

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaKotlinJUnitServerExtensionCollectorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaKotlinJUnitServerExtensionCollectorTest.kt
@@ -1,6 +1,7 @@
 package com.linecorp.intellij.plugins.armeria.test
 
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaLightJavaCodeInsightFixtureTestCase
+import kotlin.test.assertEquals
 
 class ArmeriaKotlinJUnitServerExtensionCollectorTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {
     fun testCollectsRegisterExtensionFromClassProperty() {

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaTestMethodGeneratorTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaTestMethodGeneratorTest.kt
@@ -9,10 +9,10 @@ import com.intellij.psi.SmartPsiElementPointer
 import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.message
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class ArmeriaTestMethodGeneratorTest {
     @Test

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaTestMethodInserterTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaTestMethodInserterTest.kt
@@ -14,9 +14,9 @@ import org.jetbrains.kotlin.asJava.toLightClass
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaTestMethodInserterTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaTestMethodInserterTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaTestMethodInserterTest.kt
@@ -15,9 +15,9 @@ import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import kotlin.test.assertNotNull as kotlinAssertNotNull
 
 class ArmeriaTestMethodInserterTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {
     override fun setUp() {
@@ -71,8 +71,8 @@ class ArmeriaTestMethodInserterTest : ArmeriaLightJavaCodeInsightFixtureTestCase
 
         val testClass = javaFile.classes.single()
         val method = testClass.methods.singleOrNull { it.name == "apiReturnsSuccess" }
-        assertNotNull(method)
-        assertTrue(method!!.text.contains("WebClient.of"))
+        kotlinAssertNotNull(method)
+        assertTrue(method.text.contains("WebClient.of"))
     }
 
     fun testInsertsKotlinTestMethodIntoServerExtensionClass() {
@@ -111,8 +111,8 @@ class ArmeriaTestMethodInserterTest : ArmeriaLightJavaCodeInsightFixtureTestCase
 
         val function =
             ktClass.declarations.filterIsInstance<KtNamedFunction>().singleOrNull { it.name == "apiReturnsSuccess" }
-        assertNotNull(function)
-        assertTrue(function!!.text.contains("WebClient.of"))
+        kotlinAssertNotNull(function)
+        assertTrue(function.text.contains("WebClient.of"))
     }
 
     fun testDoesNotTargetFirstClassInMultiClassKotlinFile() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

JUnit's `assertNotNull` does not enable Kotlin smart casts, so many tests were unwrapping nullable routes or PSI elements with `!!` immediately after asserting they were non-null. This change switches those checks to `kotlin.test`'s contract-based assertions and removes the unnecessary `!!` operators.

On subclasses of `LightJavaCodeInsightFixtureTestCase`, JUnit's inherited instance methods shadow plain `kotlin.test` imports, so `assertNotNull` uses the `kotlinAssertNotNull` alias. All other interchangeable JUnit assertions now use `kotlin.test` directly.

## Changes

- Declare `kotlin-test` on the `test` JVM test suite in the platform plugin and library Gradle conventions
- Add `kotlin-test` to `gradle/libs.versions.toml` and resolve it from build-logic precompiled scripts via `versionCatalogs`
- Migrate all test and fastTest sources from `org.junit.Assert` / inherited `TestCase` assertions to `kotlin.test` (`assertEquals`, `assertTrue`, `assertFalse`, `assertNull`, `assertSame`, and `kotlinAssertNotNull`)
- Remove `!!` after `kotlinAssertNotNull` where smart cast applies; keep local vals for cross-module properties where it does not
- Reorder message-first JUnit `assertTrue` / `assertFalse` calls to kotlin.test argument order (message last)

## Test plan

- [x] `:plugin:compileTestKotlin`
- [x] `:plugin-route-collectors:compileTestKotlin`
- [x] `:plugin-route-analysis:compileTestKotlin` / `compileFastTestKotlin`
- [x] `:plugin-route-spring:compileTestKotlin`
- [x] `:plugin-route-protocol:compileTestKotlin`
- [x] `:plugin-wizard:compileTestKotlin`
- [x] `ktlintCheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f934f-1343-7e9d-b8c3-d0c37a9a5d0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f934f-1343-7e9d-b8c3-d0c37a9a5d0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

