### PR TITLE
test: externalize PSI fixtures to testData/ and add route assertion helpers

### DIFF
--- a/.cursor/skills/armeria-route-psi-analysis/SKILL.md
+++ b/.cursor/skills/armeria-route-psi-analysis/SKILL.md
@@ -223,10 +223,12 @@ For PSI fixture tests that extend `ArmeriaFixtureTestBase` or
 
 - Place fixture sources under `src/test/testData/<suite>/<case>/` in the owning module
   (e.g. `plugin-route-collectors/src/test/testData/extendedRegistration/basic/fileService/Main.java`).
-- Load fixtures with `configureFixture("relative/path")` — sets `myFixture.testDataPath` to
-  `src/test/testData` relative to the **Gradle test task working directory** (module root).
-  Do not override `getTestDataPath()` on the shared base; consumer modules without `testData/`
-  rely on the platform default.
+- Load fixtures with `configureFixture("relative/path")` on `ArmeriaFixtureTestBase` — sets
+  `myFixture.testDataPath` to `src/test/testData` relative to the **Gradle test task working
+  directory** (module root). Do not override `getTestDataPath()` on the shared base; consumer
+  modules without `testData/` rely on the platform default. Subclasses of
+  `ArmeriaLightJavaCodeInsightFixtureTestCase` that do not extend `ArmeriaFixtureTestBase` must
+  set `myFixture.testDataPath` themselves (or override `getTestDataPath()` locally).
 - Assert collected routes with `collectRoutes().assertRoute(...)` from
   `ArmeriaRouteTestSupport` in `plugin-route-collectors` testFixtures.
 - Keep Armeria/Spring API **stubs** in `ArmeriaFixture*Stubs.kt` via `addClass(...)`; only

--- a/.cursor/skills/armeria-route-psi-analysis/SKILL.md
+++ b/.cursor/skills/armeria-route-psi-analysis/SKILL.md
@@ -224,18 +224,30 @@ For PSI fixture tests that extend `ArmeriaFixtureTestBase` or
 - Place fixture sources under `src/test/testData/<suite>/<case>/` in the owning module
   (e.g. `plugin-route-collectors/src/test/testData/extendedRegistration/basic/fileService/Main.java`).
 - Load fixtures with `configureFixture("relative/path")` on `ArmeriaFixtureTestBase` — sets
-  `myFixture.testDataPath` to `src/test/testData` relative to the **Gradle test task working
-  directory** (module root). Gradle `:module:test` tasks set CWD to the module project dir, so
+  `myFixture.testDataPath` to `src/test/testData` via the `armeria.moduleTestDataPath` system
+  property (set by Gradle when `src/test/testData` exists) or relative to the test task working
+  directory (module root). Gradle `:module:test` tasks set CWD to the module project dir, so
   `./gradlew :plugin-route-collectors:test` works out of the box; ad-hoc JUnit runners launched
-  from the repo root will fail unless the working directory is the owning module. Do not override
-  `getTestDataPath()` on the shared base; consumer modules without `testData/` rely on the
-  platform default. Subclasses of `ArmeriaLightJavaCodeInsightFixtureTestCase` that do not extend
-  `ArmeriaFixtureTestBase` must set `myFixture.testDataPath` themselves (or override
+  from the repo root need `-Darmeria.moduleTestDataPath=<module>/src/test/testData` or module-root
+  CWD. Do not override `getTestDataPath()` on the shared base; consumer modules without `testData/`
+  rely on the platform default. Subclasses of `ArmeriaLightJavaCodeInsightFixtureTestCase` that do
+  not extend `ArmeriaFixtureTestBase` must set `myFixture.testDataPath` themselves (or override
   `getTestDataPath()` locally).
+- `collectRoutes()` on `ArmeriaFixtureTestBase` uses `ArmeriaRouteCollector` (core annotated +
+  service registration only). Tests needing Spring or protocol routes must call
+  `ArmeriaRouteAnalysisCollector.collect(project)` or a module-specific collector.
 - Assert collected routes with `collectRoutes().assertRoute(...)` from
-  `ArmeriaRouteTestSupport` in `plugin-route-collectors` testFixtures. When replacing
-  `routes.single()`, call `collectRoutes().also { it.singleRoute() }.assertRoute(...)` so the
-  test still fails if the collector emits extra routes at other paths.
+  `ArmeriaRouteTestSupport` in `plugin-route-collectors` testFixtures. Migration patterns:
+
+  | Old pattern | New pattern |
+  |---|---|
+  | `routes.single()` + field asserts | `collectRoutes().also { it.singleRoute() }.assertRoute(...)` |
+  | `routes.firstOrNull { it.routeMatch == X }` + field asserts | `collectRoutes().assertRoute(RouteMatch.X, path = ...)` |
+  | Uniqueness **and** field match | `collectRoutes().also { it.singleRoute() }.assertRoute(...)` |
+
+  `assertRoute()` with no expected fields is rejected — use `singleRoute()` for cardinality-only
+  checks. Registration tests that only matched on `routeMatch` may omit `singleRoute()` (parity
+  with old `firstOrNull`); annotated tests should keep `singleRoute()` so extra routes fail.
 - Keep Armeria/Spring API **stubs** in `ArmeriaFixture*Stubs.kt` via `addClass(...)`; only
   user source under test belongs in `testData/`.
 

--- a/.cursor/skills/armeria-route-psi-analysis/SKILL.md
+++ b/.cursor/skills/armeria-route-psi-analysis/SKILL.md
@@ -216,6 +216,22 @@ plugin-route-analysis/src/fastTest/...   — UI helper (`Http*`, `RouteTreeBuild
 
 Name tests after the behavior (`virtualHost_doesNotAnnotateEarlierRegistrations`), not the PR number.
 
+### PSI fixture layout (`testData/`)
+
+For PSI fixture tests that extend `ArmeriaFixtureTestBase` or
+`ArmeriaLightJavaCodeInsightFixtureTestCase`:
+
+- Place fixture sources under `src/test/testData/<suite>/<case>/` in the owning module
+  (e.g. `plugin-route-collectors/src/test/testData/extendedRegistration/basic/fileService/Main.java`).
+- Load fixtures with `configureFixture("relative/path")` — the shared base resolves
+  `getTestDataPath()` to the module's `src/test/testData/`.
+- Assert collected routes with `collectRoutes().assertRoute(...)` from
+  `ArmeriaRouteTestSupport` in `plugin-route-collectors` testFixtures.
+- Keep Armeria/Spring API **stubs** in `ArmeriaFixture*Stubs.kt` via `addClass(...)`; only
+  user source under test belongs in `testData/`.
+
+Reference migration: `ArmeriaExtendedRegistrationCollectorBasicTest`.
+
 ## Related skills
 
 - `intellij-armeria-plugin` — UI/i18n, index readiness, module placement, test task paths

--- a/.cursor/skills/armeria-route-psi-analysis/SKILL.md
+++ b/.cursor/skills/armeria-route-psi-analysis/SKILL.md
@@ -225,13 +225,16 @@ For PSI fixture tests that extend `ArmeriaFixtureTestBase` or
   (e.g. `plugin-route-collectors/src/test/testData/extendedRegistration/basic/fileService/Main.java`).
 - Load fixtures with `configureFixture("relative/path")` on `ArmeriaFixtureTestBase` — sets
   `myFixture.testDataPath` to `src/test/testData` via the `armeria.moduleTestDataPath` system
-  property (set by Gradle when `src/test/testData` exists) or relative to the test task working
-  directory (module root). Gradle `:module:test` tasks set CWD to the module project dir, so
-  `./gradlew :plugin-route-collectors:test` works out of the box; ad-hoc JUnit runners launched
-  from the repo root need `-Darmeria.moduleTestDataPath=<module>/src/test/testData` or module-root
-  CWD. Do not override `getTestDataPath()` on the shared base; consumer modules without `testData/`
-  rely on the platform default. Subclasses of `ArmeriaLightJavaCodeInsightFixtureTestCase` that do
-  not extend `ArmeriaFixtureTestBase` must set `myFixture.testDataPath` themselves (or override
+  property or relative to the test task working directory (module root). When introducing
+  `src/test/testData/` in a module, add the `tasks.withType<Test>()` block from
+  `plugin-route-collectors/build.gradle.kts` (sets `armeria.moduleTestDataPath` when the directory
+  exists) or rely on module-root CWD for Gradle-only runs. Gradle `:module:test` tasks set CWD to
+  the module project dir, so `./gradlew :plugin-route-collectors:test` works out of the box;
+  ad-hoc JUnit runners launched from the repo root need
+  `-Darmeria.moduleTestDataPath=<module>/src/test/testData` or module-root CWD. Do not override
+  `getTestDataPath()` on the shared base; consumer modules without `testData/` rely on the platform
+  default. Subclasses of `ArmeriaLightJavaCodeInsightFixtureTestCase` that do not extend
+  `ArmeriaFixtureTestBase` must set `myFixture.testDataPath` themselves (or override
   `getTestDataPath()` locally).
 - `collectRoutes()` on `ArmeriaFixtureTestBase` uses `ArmeriaRouteCollector` (core annotated +
   service registration only). Tests needing Spring or protocol routes must call

--- a/.cursor/skills/armeria-route-psi-analysis/SKILL.md
+++ b/.cursor/skills/armeria-route-psi-analysis/SKILL.md
@@ -223,8 +223,10 @@ For PSI fixture tests that extend `ArmeriaFixtureTestBase` or
 
 - Place fixture sources under `src/test/testData/<suite>/<case>/` in the owning module
   (e.g. `plugin-route-collectors/src/test/testData/extendedRegistration/basic/fileService/Main.java`).
-- Load fixtures with `configureFixture("relative/path")` — the shared base resolves
-  `getTestDataPath()` to the module's `src/test/testData/`.
+- Load fixtures with `configureFixture("relative/path")` — sets `myFixture.testDataPath` to
+  `src/test/testData` relative to the **Gradle test task working directory** (module root).
+  Do not override `getTestDataPath()` on the shared base; consumer modules without `testData/`
+  rely on the platform default.
 - Assert collected routes with `collectRoutes().assertRoute(...)` from
   `ArmeriaRouteTestSupport` in `plugin-route-collectors` testFixtures.
 - Keep Armeria/Spring API **stubs** in `ArmeriaFixture*Stubs.kt` via `addClass(...)`; only

--- a/.cursor/skills/armeria-route-psi-analysis/SKILL.md
+++ b/.cursor/skills/armeria-route-psi-analysis/SKILL.md
@@ -225,8 +225,10 @@ For PSI fixture tests that extend `ArmeriaFixtureTestBase` or
   (e.g. `plugin-route-collectors/src/test/testData/extendedRegistration/basic/fileService/Main.java`).
 - Load fixtures with `configureFixture("relative/path")` on `ArmeriaFixtureTestBase` — sets
   `myFixture.testDataPath` to `src/test/testData` via the `armeria.moduleTestDataPath` system
-  property or relative to the test task working directory (module root). When introducing
-  `src/test/testData/` in a module, add the `tasks.withType<Test>()` block from
+  property or relative to the test task working directory (module root). Do not mix
+  `configureFixture()` and `configureByText()` in one test — `testDataPath` stays set for the
+  method and inline text would resolve relative to `testData/`. When introducing
+  `src/test/testData/` in a module, add the `tasks.named<Test>("test")` block from
   `plugin-route-collectors/build.gradle.kts` (sets `armeria.moduleTestDataPath` when the directory
   exists) or rely on module-root CWD for Gradle-only runs. Gradle `:module:test` tasks set CWD to
   the module project dir, so `./gradlew :plugin-route-collectors:test` works out of the box;

--- a/.cursor/skills/armeria-route-psi-analysis/SKILL.md
+++ b/.cursor/skills/armeria-route-psi-analysis/SKILL.md
@@ -225,12 +225,17 @@ For PSI fixture tests that extend `ArmeriaFixtureTestBase` or
   (e.g. `plugin-route-collectors/src/test/testData/extendedRegistration/basic/fileService/Main.java`).
 - Load fixtures with `configureFixture("relative/path")` on `ArmeriaFixtureTestBase` — sets
   `myFixture.testDataPath` to `src/test/testData` relative to the **Gradle test task working
-  directory** (module root). Do not override `getTestDataPath()` on the shared base; consumer
-  modules without `testData/` rely on the platform default. Subclasses of
-  `ArmeriaLightJavaCodeInsightFixtureTestCase` that do not extend `ArmeriaFixtureTestBase` must
-  set `myFixture.testDataPath` themselves (or override `getTestDataPath()` locally).
+  directory** (module root). Gradle `:module:test` tasks set CWD to the module project dir, so
+  `./gradlew :plugin-route-collectors:test` works out of the box; ad-hoc JUnit runners launched
+  from the repo root will fail unless the working directory is the owning module. Do not override
+  `getTestDataPath()` on the shared base; consumer modules without `testData/` rely on the
+  platform default. Subclasses of `ArmeriaLightJavaCodeInsightFixtureTestCase` that do not extend
+  `ArmeriaFixtureTestBase` must set `myFixture.testDataPath` themselves (or override
+  `getTestDataPath()` locally).
 - Assert collected routes with `collectRoutes().assertRoute(...)` from
-  `ArmeriaRouteTestSupport` in `plugin-route-collectors` testFixtures.
+  `ArmeriaRouteTestSupport` in `plugin-route-collectors` testFixtures. When replacing
+  `routes.single()`, call `collectRoutes().also { it.singleRoute() }.assertRoute(...)` so the
+  test still fails if the collector emits extra routes at other paths.
 - Keep Armeria/Spring API **stubs** in `ArmeriaFixture*Stubs.kt` via `addClass(...)`; only
   user source under test belongs in `testData/`.
 

--- a/.cursor/skills/armeria-route-psi-analysis/SKILL.md
+++ b/.cursor/skills/armeria-route-psi-analysis/SKILL.md
@@ -247,12 +247,12 @@ For PSI fixture tests that extend `ArmeriaFixtureTestBase` or
   | Old pattern | New pattern |
   |---|---|
   | `routes.single()` + field asserts | `collectRoutes().also { it.singleRoute() }.assertRoute(...)` |
-  | `routes.firstOrNull { it.routeMatch == X }` + field asserts | `collectRoutes().assertRoute(RouteMatch.X, path = ...)` |
+  | `routes.firstOrNull { it.routeMatch == X }` + field asserts | `collectRoutes().also { it.singleRoute() }.assertRoute(RouteMatch.X, path = ...)` |
   | Uniqueness **and** field match | `collectRoutes().also { it.singleRoute() }.assertRoute(...)` |
 
   `assertRoute()` with no expected fields is rejected — use `singleRoute()` for cardinality-only
-  checks. Registration tests that only matched on `routeMatch` may omit `singleRoute()` (parity
-  with old `firstOrNull`); annotated tests should keep `singleRoute()` so extra routes fail.
+  checks. Prefer `singleRoute()` before `assertRoute()` so extra routes from stubs or fixture
+  leakage fail the test.
 - Keep Armeria/Spring API **stubs** in `ArmeriaFixture*Stubs.kt` via `addClass(...)`; only
   user source under test belongs in `testData/`.
 

--- a/.cursor/skills/armeria-route-psi-analysis/SKILL.md
+++ b/.cursor/skills/armeria-route-psi-analysis/SKILL.md
@@ -227,10 +227,10 @@ For PSI fixture tests that extend `ArmeriaFixtureTestBase` or
   `myFixture.testDataPath` to `src/test/testData` via the `armeria.moduleTestDataPath` system
   property or relative to the test task working directory (module root). Do not mix
   `configureFixture()` and `configureByText()` in one test — `testDataPath` stays set for the
-  method and inline text would resolve relative to `testData/`. When introducing
-  `src/test/testData/` in a module, add the `tasks.named<Test>("test")` block from
-  `plugin-route-collectors/build.gradle.kts` (sets `armeria.moduleTestDataPath` when the directory
-  exists) or rely on module-root CWD for Gradle-only runs. Gradle `:module:test` tasks set CWD to
+  method and inline text would resolve relative to `testData/`.   When introducing
+  `src/test/testData/` in a module, add the `testing.suites { getByName<JvmTestSuite>("test") { targets.all { testTask.configure { ... } } } }`
+  block from `plugin-route-collectors/build.gradle.kts` (sets `armeria.moduleTestDataPath` when the
+  directory exists) or rely on module-root CWD for Gradle-only runs. Gradle `:module:test` tasks set CWD to
   the module project dir, so `./gradlew :plugin-route-collectors:test` works out of the box;
   ad-hoc JUnit runners launched from the repo root need
   `-Darmeria.moduleTestDataPath=<module>/src/test/testData` or module-root CWD. Do not override
@@ -241,7 +241,7 @@ For PSI fixture tests that extend `ArmeriaFixtureTestBase` or
 - `collectRoutes()` on `ArmeriaFixtureTestBase` uses `ArmeriaRouteCollector` (core annotated +
   service registration only). Tests needing Spring or protocol routes must call
   `ArmeriaRouteAnalysisCollector.collect(project)` or a module-specific collector.
-- Assert collected routes with `collectRoutes().assertRoute(...)` from
+- Assert collected routes with `collectRoutes().also { it.singleRoute() }.assertRoute(...)` from
   `ArmeriaRouteTestSupport` in `plugin-route-collectors` testFixtures. Migration patterns:
 
   | Old pattern | New pattern |

--- a/plugin-route-collectors/build.gradle.kts
+++ b/plugin-route-collectors/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
         testFramework(TestFrameworkType.Plugin.Java, configurationName = "testFixturesImplementation")
     }
     testFixturesImplementation(libs.junit4)
+    testFixturesImplementation(libs.kotlin.test)
 }
 
 testing {
@@ -79,4 +80,11 @@ extensions.configure<KotlinJvmProjectExtension>("kotlin") {
 
 tasks.named("check") {
     dependsOn(testing.suites.named("fastTest"))
+}
+
+tasks.withType<Test>().configureEach {
+    val testDataDir = file("src/test/testData")
+    if (testDataDir.isDirectory) {
+        systemProperty("armeria.moduleTestDataPath", testDataDir.absolutePath)
+    }
 }

--- a/plugin-route-collectors/build.gradle.kts
+++ b/plugin-route-collectors/build.gradle.kts
@@ -31,6 +31,14 @@ testing {
                 implementation(testFixtures(project()))
                 implementation(libs.junit4)
             }
+            targets.all {
+                testTask.configure {
+                    val testDataDir = project.file("src/test/testData")
+                    if (testDataDir.isDirectory) {
+                        systemProperty("armeria.moduleTestDataPath", testDataDir.absolutePath)
+                    }
+                }
+            }
         }
 
         register("fastTest", JvmTestSuite::class) {
@@ -80,11 +88,4 @@ extensions.configure<KotlinJvmProjectExtension>("kotlin") {
 
 tasks.named("check") {
     dependsOn(testing.suites.named("fastTest"))
-}
-
-tasks.named<Test>("test").configure {
-    val testDataDir = file("src/test/testData")
-    if (testDataDir.isDirectory) {
-        systemProperty("armeria.moduleTestDataPath", testDataDir.absolutePath)
-    }
 }

--- a/plugin-route-collectors/build.gradle.kts
+++ b/plugin-route-collectors/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
         testFramework(TestFrameworkType.Plugin.Java, configurationName = "testFixturesImplementation")
     }
     testFixturesImplementation(libs.junit4)
-    testFixturesImplementation(libs.kotlin.test)
+    testFixturesApi(libs.kotlin.test)
 }
 
 testing {

--- a/plugin-route-collectors/build.gradle.kts
+++ b/plugin-route-collectors/build.gradle.kts
@@ -82,7 +82,7 @@ tasks.named("check") {
     dependsOn(testing.suites.named("fastTest"))
 }
 
-tasks.withType<Test>().configureEach {
+tasks.named<Test>("test").configure {
     val testDataDir = file("src/test/testData")
     if (testDataDir.isDirectory) {
         systemProperty("armeria.moduleTestDataPath", testDataDir.absolutePath)

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollectorBasicTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollectorBasicTest.kt
@@ -1,11 +1,9 @@
 package com.linecorp.intellij.plugins.armeria.explorer
 
-import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
 import com.linecorp.intellij.plugins.armeria.explorer.model.PathType
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull as kotlinAssertNotNull
+import com.linecorp.intellij.plugins.armeria.test.assertRoute
 
 class ArmeriaExtendedRegistrationCollectorBasicTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {
@@ -13,234 +11,56 @@ class ArmeriaExtendedRegistrationCollectorBasicTest : ArmeriaFixtureTestBase() {
     }
 
     fun testCollectFileServiceRegistration() {
-        myFixture.configureByText(
-            "Main.java",
-            """
-            package example;
-
-            import com.linecorp.armeria.server.Server;
-            import java.io.File;
-
-            public class Main {
-                public static void main(String[] args) {
-                    Server.builder()
-                        .fileService("/files/", new File("/tmp"))
-                        .build();
-                }
-            }
-            """.trimIndent(),
-        )
-
-        val routes = ArmeriaRouteCollector.collect(project)
-        val fileRoute = routes.firstOrNull { it.routeMatch == RouteMatch.FILE_SERVICE }
-        kotlinAssertNotNull(fileRoute)
-        assertEquals("/files/", fileRoute.path)
+        configureFixture("extendedRegistration/basic/fileService/Main.java")
+        collectRoutes().assertRoute(RouteMatch.FILE_SERVICE, path = "/files/")
     }
 
     fun testCollectFileServiceWithJavaConstantPath() {
-        myFixture.configureByText(
-            "Main.java",
-            """
-            package example;
-
-            import com.linecorp.armeria.server.Server;
-            import java.io.File;
-
-            public class Main {
-                private static final String FILES_PATH = "/files/";
-
-                public static void main(String[] args) {
-                    Server.builder()
-                        .fileService(FILES_PATH, new File("/tmp"))
-                        .build();
-                }
-            }
-            """.trimIndent(),
-        )
-
-        val routes = ArmeriaRouteCollector.collect(project)
-        val fileRoute = routes.firstOrNull { it.routeMatch == RouteMatch.FILE_SERVICE }
-        kotlinAssertNotNull(fileRoute)
-        assertEquals("/files/", fileRoute.path)
+        configureFixture("extendedRegistration/basic/fileServiceWithConstant/Main.java")
+        collectRoutes().assertRoute(RouteMatch.FILE_SERVICE, path = "/files/")
     }
 
     fun testCollectHealthCheckRegistration() {
-        myFixture.configureByText(
-            "Main.java",
-            """
-            package example;
-
-            import com.linecorp.armeria.server.Server;
-
-            public class Main {
-                public static void main(String[] args) {
-                    Server.builder()
-                        .healthCheckService()
-                        .build();
-                }
-            }
-            """.trimIndent(),
-        )
-
-        val routes = ArmeriaRouteCollector.collect(project)
-        val healthRoute = routes.firstOrNull { it.routeMatch == RouteMatch.HEALTH_CHECK }
-        kotlinAssertNotNull(healthRoute)
-        assertEquals("/internal/healthcheck", healthRoute.path)
+        configureFixture("extendedRegistration/basic/healthCheck/Main.java")
+        collectRoutes().assertRoute(RouteMatch.HEALTH_CHECK, path = "/internal/healthcheck")
     }
 
     fun testCollectFluentRouteRegistration() {
-        myFixture.configureByText(
-            "Main.java",
-            """
-            package example;
-
-            import com.linecorp.armeria.server.Server;
-
-            public class Main {
-                public static void main(String[] args) {
-                    Server.builder()
-                        .route()
-                        .post("/api/items")
-                        .build((ctx, req) -> null)
-                        .build();
-                }
-            }
-            """.trimIndent(),
+        configureFixture("extendedRegistration/basic/fluentRoute/Main.java")
+        collectRoutes().assertRoute(
+            RouteMatch.ROUTE_FLUENT,
+            path = "/api/items",
+            httpMethod = "POST",
         )
-
-        val routes = ArmeriaRouteCollector.collect(project)
-        val fluentRoute = routes.firstOrNull { it.routeMatch == RouteMatch.ROUTE_FLUENT }
-        kotlinAssertNotNull(fluentRoute)
-        assertEquals("POST", fluentRoute.httpMethod)
-        assertEquals("/api/items", fluentRoute.path)
     }
 
     fun testCollectDecoratorUnderRegistration() {
-        myFixture.configureByText(
-            "Main.java",
-            """
-            package example;
-
-            import com.linecorp.armeria.server.Server;
-            import com.linecorp.armeria.server.logging.LoggingService;
-
-            public class Main {
-                public static void main(String[] args) {
-                    Server.builder()
-                        .decoratorUnder("/public", LoggingService.newDecorator())
-                        .build();
-                }
-            }
-            """.trimIndent(),
-        )
-
-        val routes = ArmeriaRouteCollector.collect(project)
-        val decoratorRoute = routes.firstOrNull { it.routeMatch == RouteMatch.DECORATOR_UNDER }
-        kotlinAssertNotNull(decoratorRoute)
-        assertEquals("/public", decoratorRoute.path)
+        configureFixture("extendedRegistration/basic/decoratorUnder/Main.java")
+        collectRoutes().assertRoute(RouteMatch.DECORATOR_UNDER, path = "/public")
     }
 
     fun testCollectPathAnnotationAndPathType() {
-        myFixture.configureByText(
-            "HelloService.java",
-            """
-            package example;
-
-            import com.linecorp.armeria.server.annotation.Get;
-            import com.linecorp.armeria.server.annotation.Path;
-
-            public class HelloService {
-                @Get
-                @Path("prefix:/hello")
-                public String hello() {
-                    return "hello";
-                }
-            }
-            """.trimIndent(),
-        )
-
-        val routes = ArmeriaRouteCollector.collect(project)
-        val route = routes.single()
-        assertEquals(PathType.PREFIX, route.pathType)
-        assertEquals("/hello", route.path)
+        configureFixture("extendedRegistration/basic/pathAnnotation/HelloService.java")
+        collectRoutes().assertRoute(path = "/hello", pathType = PathType.PREFIX)
     }
 
     fun testCollectRegexPathAnnotationTrimsWhitespace() {
-        myFixture.configureByText(
-            "HelloService.java",
-            """
-            package example;
-
-            import com.linecorp.armeria.server.annotation.Get;
-            import com.linecorp.armeria.server.annotation.Path;
-
-            public class HelloService {
-                @Get
-                @Path("regex: /foo")
-                public String hello() {
-                    return "hello";
-                }
-            }
-            """.trimIndent(),
-        )
-
-        val routes = ArmeriaRouteCollector.collect(project)
-        val route = routes.single()
-        assertEquals(PathType.REGEX, route.pathType)
-        assertEquals("/foo", route.path)
+        configureFixture("extendedRegistration/basic/regexPathAnnotation/HelloService.java")
+        collectRoutes().assertRoute(path = "/foo", pathType = PathType.REGEX)
     }
 
     fun testCollectGlobPathAnnotationNormalizesLeadingSlash() {
-        myFixture.configureByText(
-            "HelloService.java",
-            """
-            package example;
-
-            import com.linecorp.armeria.server.annotation.Get;
-            import com.linecorp.armeria.server.annotation.Path;
-
-            public class HelloService {
-                @Get
-                @Path("glob:foo/**")
-                public String hello() {
-                    return "hello";
-                }
-            }
-            """.trimIndent(),
-        )
-
-        val routes = ArmeriaRouteCollector.collect(project)
-        val route = routes.single()
-        assertEquals(PathType.GLOB, route.pathType)
-        assertEquals("/foo/**", route.path)
+        configureFixture("extendedRegistration/basic/globPathAnnotation/HelloService.java")
+        collectRoutes().assertRoute(path = "/foo/**", pathType = PathType.GLOB)
     }
 
     fun testCollectFluentRoutePathPrefix() {
-        myFixture.configureByText(
-            "Main.java",
-            """
-            package example;
-
-            import com.linecorp.armeria.server.Server;
-
-            public class Main {
-                public static void main(String[] args) {
-                    Server.builder()
-                        .route()
-                        .pathPrefix("/api")
-                        .get("/items")
-                        .build((ctx, req) -> null)
-                        .build();
-                }
-            }
-            """.trimIndent(),
+        configureFixture("extendedRegistration/basic/fluentRoutePathPrefix/Main.java")
+        collectRoutes().assertRoute(
+            RouteMatch.ROUTE_FLUENT,
+            path = "/api/items",
+            httpMethod = "GET",
+            pathType = PathType.EXACT,
         )
-
-        val routes = ArmeriaRouteCollector.collect(project)
-        val fluentRoute = routes.firstOrNull { it.routeMatch == RouteMatch.ROUTE_FLUENT }
-        kotlinAssertNotNull(fluentRoute)
-        assertEquals(PathType.EXACT, fluentRoute.pathType)
-        assertEquals("/api/items", fluentRoute.path)
-        assertEquals("GET", fluentRoute.httpMethod)
     }
 }

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollectorBasicTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollectorBasicTest.kt
@@ -13,22 +13,22 @@ class ArmeriaExtendedRegistrationCollectorBasicTest : ArmeriaFixtureTestBase() {
 
     fun testCollectFileServiceRegistration() {
         configureFixture("extendedRegistration/basic/fileService/Main.java")
-        collectRoutes().assertRoute(RouteMatch.FILE_SERVICE, path = "/files/")
+        collectRoutes().also { it.singleRoute() }.assertRoute(RouteMatch.FILE_SERVICE, path = "/files/")
     }
 
     fun testCollectFileServiceWithJavaConstantPath() {
         configureFixture("extendedRegistration/basic/fileServiceWithConstant/Main.java")
-        collectRoutes().assertRoute(RouteMatch.FILE_SERVICE, path = "/files/")
+        collectRoutes().also { it.singleRoute() }.assertRoute(RouteMatch.FILE_SERVICE, path = "/files/")
     }
 
     fun testCollectHealthCheckRegistration() {
         configureFixture("extendedRegistration/basic/healthCheck/Main.java")
-        collectRoutes().assertRoute(RouteMatch.HEALTH_CHECK, path = "/internal/healthcheck")
+        collectRoutes().also { it.singleRoute() }.assertRoute(RouteMatch.HEALTH_CHECK, path = "/internal/healthcheck")
     }
 
     fun testCollectFluentRouteRegistration() {
         configureFixture("extendedRegistration/basic/fluentRoute/Main.java")
-        collectRoutes().assertRoute(
+        collectRoutes().also { it.singleRoute() }.assertRoute(
             RouteMatch.ROUTE_FLUENT,
             path = "/api/items",
             httpMethod = "POST",
@@ -37,7 +37,7 @@ class ArmeriaExtendedRegistrationCollectorBasicTest : ArmeriaFixtureTestBase() {
 
     fun testCollectDecoratorUnderRegistration() {
         configureFixture("extendedRegistration/basic/decoratorUnder/Main.java")
-        collectRoutes().assertRoute(RouteMatch.DECORATOR_UNDER, path = "/public")
+        collectRoutes().also { it.singleRoute() }.assertRoute(RouteMatch.DECORATOR_UNDER, path = "/public")
     }
 
     fun testCollectPathAnnotationAndPathType() {
@@ -57,7 +57,7 @@ class ArmeriaExtendedRegistrationCollectorBasicTest : ArmeriaFixtureTestBase() {
 
     fun testCollectFluentRoutePathPrefix() {
         configureFixture("extendedRegistration/basic/fluentRoutePathPrefix/Main.java")
-        collectRoutes().assertRoute(
+        collectRoutes().also { it.singleRoute() }.assertRoute(
             RouteMatch.ROUTE_FLUENT,
             path = "/api/items",
             httpMethod = "GET",

--- a/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollectorBasicTest.kt
+++ b/plugin-route-collectors/src/test/kotlin/com/linecorp/intellij/plugins/armeria/explorer/ArmeriaExtendedRegistrationCollectorBasicTest.kt
@@ -4,6 +4,7 @@ import com.linecorp.intellij.plugins.armeria.explorer.model.PathType
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import com.linecorp.intellij.plugins.armeria.test.ArmeriaFixtureTestBase
 import com.linecorp.intellij.plugins.armeria.test.assertRoute
+import com.linecorp.intellij.plugins.armeria.test.singleRoute
 
 class ArmeriaExtendedRegistrationCollectorBasicTest : ArmeriaFixtureTestBase() {
     override fun registerArmeriaStubs() {
@@ -41,17 +42,17 @@ class ArmeriaExtendedRegistrationCollectorBasicTest : ArmeriaFixtureTestBase() {
 
     fun testCollectPathAnnotationAndPathType() {
         configureFixture("extendedRegistration/basic/pathAnnotation/HelloService.java")
-        collectRoutes().assertRoute(path = "/hello", pathType = PathType.PREFIX)
+        collectRoutes().also { it.singleRoute() }.assertRoute(path = "/hello", pathType = PathType.PREFIX)
     }
 
     fun testCollectRegexPathAnnotationTrimsWhitespace() {
         configureFixture("extendedRegistration/basic/regexPathAnnotation/HelloService.java")
-        collectRoutes().assertRoute(path = "/foo", pathType = PathType.REGEX)
+        collectRoutes().also { it.singleRoute() }.assertRoute(path = "/foo", pathType = PathType.REGEX)
     }
 
     fun testCollectGlobPathAnnotationNormalizesLeadingSlash() {
         configureFixture("extendedRegistration/basic/globPathAnnotation/HelloService.java")
-        collectRoutes().assertRoute(path = "/foo/**", pathType = PathType.GLOB)
+        collectRoutes().also { it.singleRoute() }.assertRoute(path = "/foo/**", pathType = PathType.GLOB)
     }
 
     fun testCollectFluentRoutePathPrefix() {

--- a/plugin-route-collectors/src/test/testData/extendedRegistration/basic/decoratorUnder/Main.java
+++ b/plugin-route-collectors/src/test/testData/extendedRegistration/basic/decoratorUnder/Main.java
@@ -1,0 +1,12 @@
+package example;
+
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.logging.LoggingService;
+
+public class Main {
+    public static void main(String[] args) {
+        Server.builder()
+            .decoratorUnder("/public", LoggingService.newDecorator())
+            .build();
+    }
+}

--- a/plugin-route-collectors/src/test/testData/extendedRegistration/basic/fileService/Main.java
+++ b/plugin-route-collectors/src/test/testData/extendedRegistration/basic/fileService/Main.java
@@ -1,0 +1,12 @@
+package example;
+
+import com.linecorp.armeria.server.Server;
+import java.io.File;
+
+public class Main {
+    public static void main(String[] args) {
+        Server.builder()
+            .fileService("/files/", new File("/tmp"))
+            .build();
+    }
+}

--- a/plugin-route-collectors/src/test/testData/extendedRegistration/basic/fileServiceWithConstant/Main.java
+++ b/plugin-route-collectors/src/test/testData/extendedRegistration/basic/fileServiceWithConstant/Main.java
@@ -1,0 +1,14 @@
+package example;
+
+import com.linecorp.armeria.server.Server;
+import java.io.File;
+
+public class Main {
+    private static final String FILES_PATH = "/files/";
+
+    public static void main(String[] args) {
+        Server.builder()
+            .fileService(FILES_PATH, new File("/tmp"))
+            .build();
+    }
+}

--- a/plugin-route-collectors/src/test/testData/extendedRegistration/basic/fluentRoute/Main.java
+++ b/plugin-route-collectors/src/test/testData/extendedRegistration/basic/fluentRoute/Main.java
@@ -1,0 +1,13 @@
+package example;
+
+import com.linecorp.armeria.server.Server;
+
+public class Main {
+    public static void main(String[] args) {
+        Server.builder()
+            .route()
+            .post("/api/items")
+            .build((ctx, req) -> null)
+            .build();
+    }
+}

--- a/plugin-route-collectors/src/test/testData/extendedRegistration/basic/fluentRoutePathPrefix/Main.java
+++ b/plugin-route-collectors/src/test/testData/extendedRegistration/basic/fluentRoutePathPrefix/Main.java
@@ -1,0 +1,14 @@
+package example;
+
+import com.linecorp.armeria.server.Server;
+
+public class Main {
+    public static void main(String[] args) {
+        Server.builder()
+            .route()
+            .pathPrefix("/api")
+            .get("/items")
+            .build((ctx, req) -> null)
+            .build();
+    }
+}

--- a/plugin-route-collectors/src/test/testData/extendedRegistration/basic/globPathAnnotation/HelloService.java
+++ b/plugin-route-collectors/src/test/testData/extendedRegistration/basic/globPathAnnotation/HelloService.java
@@ -1,0 +1,12 @@
+package example;
+
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Path;
+
+public class HelloService {
+    @Get
+    @Path("glob:foo/**")
+    public String hello() {
+        return "hello";
+    }
+}

--- a/plugin-route-collectors/src/test/testData/extendedRegistration/basic/healthCheck/Main.java
+++ b/plugin-route-collectors/src/test/testData/extendedRegistration/basic/healthCheck/Main.java
@@ -1,0 +1,11 @@
+package example;
+
+import com.linecorp.armeria.server.Server;
+
+public class Main {
+    public static void main(String[] args) {
+        Server.builder()
+            .healthCheckService()
+            .build();
+    }
+}

--- a/plugin-route-collectors/src/test/testData/extendedRegistration/basic/pathAnnotation/HelloService.java
+++ b/plugin-route-collectors/src/test/testData/extendedRegistration/basic/pathAnnotation/HelloService.java
@@ -1,0 +1,12 @@
+package example;
+
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Path;
+
+public class HelloService {
+    @Get
+    @Path("prefix:/hello")
+    public String hello() {
+        return "hello";
+    }
+}

--- a/plugin-route-collectors/src/test/testData/extendedRegistration/basic/regexPathAnnotation/HelloService.java
+++ b/plugin-route-collectors/src/test/testData/extendedRegistration/basic/regexPathAnnotation/HelloService.java
@@ -1,0 +1,12 @@
+package example;
+
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Path;
+
+public class HelloService {
+    @Get
+    @Path("regex: /foo")
+    public String hello() {
+        return "hello";
+    }
+}

--- a/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaFixtureTestBase.kt
+++ b/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaFixtureTestBase.kt
@@ -13,6 +13,10 @@ abstract class ArmeriaFixtureTestBase : ArmeriaLightJavaCodeInsightFixtureTestCa
         return myFixture.configureByFile(relativePath)
     }
 
+    /**
+     * Collects routes via [ArmeriaRouteCollector] (core annotated + service registration only).
+     * Tests needing Spring or protocol routes must call [ArmeriaRouteAnalysisCollector.collect] instead.
+     */
     protected fun collectRoutes(): List<ArmeriaRoute> = ArmeriaRouteCollector.collect(project)
 
     override fun setUp() {

--- a/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaFixtureTestBase.kt
+++ b/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaFixtureTestBase.kt
@@ -8,7 +8,10 @@ import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
  * Shared Armeria PSI stubs for [LightJavaCodeInsightFixtureTestCase] subclasses.
  */
 abstract class ArmeriaFixtureTestBase : ArmeriaLightJavaCodeInsightFixtureTestCase() {
-    protected fun configureFixture(relativePath: String): PsiFile = myFixture.configureByFile(relativePath)
+    protected fun configureFixture(relativePath: String): PsiFile {
+        myFixture.testDataPath = resolveModuleTestDataPath()
+        return myFixture.configureByFile(relativePath)
+    }
 
     protected fun collectRoutes(): List<ArmeriaRoute> = ArmeriaRouteCollector.collect(project)
 

--- a/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaFixtureTestBase.kt
+++ b/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaFixtureTestBase.kt
@@ -1,9 +1,17 @@
 package com.linecorp.intellij.plugins.armeria.test
 
+import com.intellij.psi.PsiFile
+import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteCollector
+import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
+
 /**
  * Shared Armeria PSI stubs for [LightJavaCodeInsightFixtureTestCase] subclasses.
  */
 abstract class ArmeriaFixtureTestBase : ArmeriaLightJavaCodeInsightFixtureTestCase() {
+    protected fun configureFixture(relativePath: String): PsiFile = myFixture.configureByFile(relativePath)
+
+    protected fun collectRoutes(): List<ArmeriaRoute> = ArmeriaRouteCollector.collect(project)
+
     override fun setUp() {
         super.setUp()
         registerArmeriaStubs()

--- a/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaFixtureTestBase.kt
+++ b/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaFixtureTestBase.kt
@@ -15,7 +15,8 @@ abstract class ArmeriaFixtureTestBase : ArmeriaLightJavaCodeInsightFixtureTestCa
 
     /**
      * Collects routes via [ArmeriaRouteCollector] (core annotated + service registration only).
-     * Tests needing Spring or protocol routes must call [ArmeriaRouteAnalysisCollector.collect] instead.
+     * Tests needing Spring or protocol routes must call `ArmeriaRouteAnalysisCollector.collect(project)`
+     * in the `plugin-route-analysis` module instead.
      */
     protected fun collectRoutes(): List<ArmeriaRoute> = ArmeriaRouteCollector.collect(project)
 

--- a/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaLightJavaCodeInsightFixtureTestCase.kt
+++ b/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaLightJavaCodeInsightFixtureTestCase.kt
@@ -15,7 +15,7 @@ abstract class ArmeriaLightJavaCodeInsightFixtureTestCase : LightJavaCodeInsight
      * platform default from [LightJavaCodeInsightFixtureTestCase].
      */
     protected fun resolveModuleTestDataPath(): String {
-        System.getProperty("armeria.moduleTestDataPath")?.let { return it.replace('\\', '/') }
+        System.getProperty("armeria.moduleTestDataPath")?.takeIf { it.isNotBlank() }?.let { return it.replace('\\', '/') }
         val fromWorkingDir = File("src/test/testData")
         require(fromWorkingDir.isDirectory) {
             "Expected testData directory at ${fromWorkingDir.absolutePath}; run tests from the owning module root " +

--- a/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaLightJavaCodeInsightFixtureTestCase.kt
+++ b/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaLightJavaCodeInsightFixtureTestCase.kt
@@ -9,21 +9,18 @@ import java.io.File
  * [LightJavaCodeInsightFixtureTestCase] with 2026.2+ test sandbox root access for plugin runtime libraries.
  */
 abstract class ArmeriaLightJavaCodeInsightFixtureTestCase : LightJavaCodeInsightFixtureTestCase() {
-    override fun getTestDataPath(): String = resolveModuleTestDataPath()
-
+    /**
+     * Resolves `src/test/testData` relative to the Gradle test task working directory (module root).
+     * Do not override [getTestDataPath] globally — consumer modules without `testData/` rely on the
+     * platform default from [LightJavaCodeInsightFixtureTestCase].
+     */
     protected fun resolveModuleTestDataPath(): String {
         val fromWorkingDir = File("src/test/testData")
-        if (fromWorkingDir.isDirectory) {
-            return toSystemIndependentPath(fromWorkingDir.absolutePath)
+        require(fromWorkingDir.isDirectory) {
+            "Expected testData directory at ${fromWorkingDir.absolutePath}; run tests from the owning module root"
         }
-
-        val codeSource = javaClass.protectionDomain.codeSource
-        val classesDir = File(codeSource.location.toURI())
-        val moduleRoot = classesDir.parentFile.parentFile.parentFile
-        return toSystemIndependentPath(File(moduleRoot, "src/test/testData").absolutePath)
+        return fromWorkingDir.absolutePath.replace('\\', '/')
     }
-
-    private fun toSystemIndependentPath(path: String): String = path.replace('\\', '/')
 
     override fun setUp() {
         super.setUp()

--- a/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaLightJavaCodeInsightFixtureTestCase.kt
+++ b/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaLightJavaCodeInsightFixtureTestCase.kt
@@ -15,9 +15,11 @@ abstract class ArmeriaLightJavaCodeInsightFixtureTestCase : LightJavaCodeInsight
      * platform default from [LightJavaCodeInsightFixtureTestCase].
      */
     protected fun resolveModuleTestDataPath(): String {
+        System.getProperty("armeria.moduleTestDataPath")?.let { return it.replace('\\', '/') }
         val fromWorkingDir = File("src/test/testData")
         require(fromWorkingDir.isDirectory) {
-            "Expected testData directory at ${fromWorkingDir.absolutePath}; run tests from the owning module root"
+            "Expected testData directory at ${fromWorkingDir.absolutePath}; run tests from the owning module root " +
+                "or set -Darmeria.moduleTestDataPath"
         }
         return fromWorkingDir.absolutePath.replace('\\', '/')
     }

--- a/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaLightJavaCodeInsightFixtureTestCase.kt
+++ b/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaLightJavaCodeInsightFixtureTestCase.kt
@@ -1,7 +1,6 @@
 package com.linecorp.intellij.plugins.armeria.test
 
 import com.intellij.openapi.application.PathManager
-import com.intellij.openapi.util.io.PathUtil
 import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
 import java.io.File
@@ -15,14 +14,16 @@ abstract class ArmeriaLightJavaCodeInsightFixtureTestCase : LightJavaCodeInsight
     protected fun resolveModuleTestDataPath(): String {
         val fromWorkingDir = File("src/test/testData")
         if (fromWorkingDir.isDirectory) {
-            return PathUtil.toSystemIndependentName(fromWorkingDir.absolutePath)
+            return toSystemIndependentPath(fromWorkingDir.absolutePath)
         }
 
         val codeSource = javaClass.protectionDomain.codeSource
         val classesDir = File(codeSource.location.toURI())
         val moduleRoot = classesDir.parentFile.parentFile.parentFile
-        return PathUtil.toSystemIndependentName(File(moduleRoot, "src/test/testData").absolutePath)
+        return toSystemIndependentPath(File(moduleRoot, "src/test/testData").absolutePath)
     }
+
+    private fun toSystemIndependentPath(path: String): String = path.replace('\\', '/')
 
     override fun setUp() {
         super.setUp()

--- a/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaLightJavaCodeInsightFixtureTestCase.kt
+++ b/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaLightJavaCodeInsightFixtureTestCase.kt
@@ -1,6 +1,7 @@
 package com.linecorp.intellij.plugins.armeria.test
 
 import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.util.io.PathUtil
 import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
 import java.io.File
@@ -9,6 +10,20 @@ import java.io.File
  * [LightJavaCodeInsightFixtureTestCase] with 2026.2+ test sandbox root access for plugin runtime libraries.
  */
 abstract class ArmeriaLightJavaCodeInsightFixtureTestCase : LightJavaCodeInsightFixtureTestCase() {
+    override fun getTestDataPath(): String = resolveModuleTestDataPath()
+
+    protected fun resolveModuleTestDataPath(): String {
+        val fromWorkingDir = File("src/test/testData")
+        if (fromWorkingDir.isDirectory) {
+            return PathUtil.toSystemIndependentName(fromWorkingDir.absolutePath)
+        }
+
+        val codeSource = javaClass.protectionDomain.codeSource
+        val classesDir = File(codeSource.location.toURI())
+        val moduleRoot = classesDir.parentFile.parentFile.parentFile
+        return PathUtil.toSystemIndependentName(File(moduleRoot, "src/test/testData").absolutePath)
+    }
+
     override fun setUp() {
         super.setUp()
         allowTestSandboxRoots()

--- a/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaRouteTestSupport.kt
+++ b/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaRouteTestSupport.kt
@@ -52,6 +52,8 @@ fun List<ArmeriaRoute>.assertRoute(
         "assertRoute requires at least one expected field; use singleRoute() for cardinality-only checks"
     }
     val route = route(match = match, path = path, httpMethod = httpMethod, pathType = pathType)
+    match?.let { assertEquals(it, route.routeMatch, message = "routeMatch") }
+    path?.let { assertEquals(it, route.path, message = "path") }
     httpMethod?.let { assertEquals(it, route.httpMethod, message = "httpMethod") }
     pathType?.let { assertEquals(it, route.pathType, message = "pathType") }
     return route

--- a/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaRouteTestSupport.kt
+++ b/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaRouteTestSupport.kt
@@ -3,6 +3,7 @@ package com.linecorp.intellij.plugins.armeria.test
 import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
 import com.linecorp.intellij.plugins.armeria.explorer.model.PathType
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
+import org.junit.Assert.assertEquals
 
 fun List<ArmeriaRoute>.route(
     match: RouteMatch? = null,
@@ -42,7 +43,7 @@ fun List<ArmeriaRoute>.assertRoute(
     pathType: PathType? = null,
 ): ArmeriaRoute {
     val route = route(match = match, path = path)
-    httpMethod?.let { check(route.httpMethod == it) { "Expected httpMethod '$it' but was '${route.httpMethod}'" } }
-    pathType?.let { check(route.pathType == it) { "Expected pathType '$it' but was '${route.pathType}'" } }
+    httpMethod?.let { assertEquals("httpMethod", it, route.httpMethod) }
+    pathType?.let { assertEquals("pathType", it, route.pathType) }
     return route
 }

--- a/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaRouteTestSupport.kt
+++ b/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaRouteTestSupport.kt
@@ -4,26 +4,32 @@ import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
 import com.linecorp.intellij.plugins.armeria.explorer.model.PathType
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
 import kotlin.test.assertEquals
+import kotlin.test.fail
 
 fun List<ArmeriaRoute>.route(
     match: RouteMatch? = null,
     path: String? = null,
+    httpMethod: String? = null,
+    pathType: PathType? = null,
 ): ArmeriaRoute {
     val filtered =
         filter { route ->
             (match == null || route.routeMatch == match) &&
-                (path == null || route.path == path)
+                (path == null || route.path == path) &&
+                (httpMethod == null || route.httpMethod == httpMethod) &&
+                (pathType == null || route.pathType == pathType)
         }
+    val criteria = routeCriteriaDescription(match, path, httpMethod, pathType)
     return when (filtered.size) {
         1 -> filtered.single()
         0 ->
-            error(
-                "No route matching match=$match path=$path in " +
+            fail(
+                "No route matching $criteria in " +
                     map { it.routeMatch to it.path },
             )
         else ->
-            error(
-                "Multiple routes matching match=$match path=$path: " +
+            fail(
+                "Multiple routes matching $criteria: " +
                     filtered.map { it.routeMatch to it.path },
             )
     }
@@ -31,7 +37,7 @@ fun List<ArmeriaRoute>.route(
 
 fun List<ArmeriaRoute>.singleRoute(): ArmeriaRoute {
     if (size != 1) {
-        error("Expected a single route but found $size: ${map { it.routeMatch to it.path }}")
+        fail("Expected a single route but found $size: ${map { it.routeMatch to it.path }}")
     }
     return single()
 }
@@ -45,8 +51,21 @@ fun List<ArmeriaRoute>.assertRoute(
     require(match != null || path != null || httpMethod != null || pathType != null) {
         "assertRoute requires at least one expected field; use singleRoute() for cardinality-only checks"
     }
-    val route = route(match = match, path = path)
+    val route = route(match = match, path = path, httpMethod = httpMethod, pathType = pathType)
     httpMethod?.let { assertEquals(it, route.httpMethod, message = "httpMethod") }
     pathType?.let { assertEquals(it, route.pathType, message = "pathType") }
     return route
 }
+
+private fun routeCriteriaDescription(
+    match: RouteMatch?,
+    path: String?,
+    httpMethod: String?,
+    pathType: PathType?,
+): String =
+    buildString {
+        append("match=").append(match)
+        append(" path=").append(path)
+        append(" httpMethod=").append(httpMethod)
+        append(" pathType=").append(pathType)
+    }

--- a/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaRouteTestSupport.kt
+++ b/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaRouteTestSupport.kt
@@ -1,0 +1,50 @@
+package com.linecorp.intellij.plugins.armeria.test
+
+import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
+import com.linecorp.intellij.plugins.armeria.explorer.model.PathType
+import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
+import kotlin.test.assertEquals
+
+fun List<ArmeriaRoute>.route(
+    match: RouteMatch? = null,
+    path: String? = null,
+): ArmeriaRoute {
+    val filtered =
+        filter { route ->
+            (match == null || route.routeMatch == match) &&
+                (path == null || route.path == path)
+        }
+    return when (filtered.size) {
+        1 -> filtered.single()
+        0 ->
+            error(
+                "No route matching match=$match path=$path in " +
+                    map { it.routeMatch to it.path },
+            )
+        else ->
+            error(
+                "Multiple routes matching match=$match path=$path: " +
+                    filtered.map { it.routeMatch to it.path },
+            )
+    }
+}
+
+fun List<ArmeriaRoute>.singleRoute(): ArmeriaRoute {
+    if (size != 1) {
+        error("Expected a single route but found $size: ${map { it.routeMatch to it.path }}")
+    }
+    return single()
+}
+
+fun List<ArmeriaRoute>.assertRoute(
+    match: RouteMatch? = null,
+    path: String? = null,
+    httpMethod: String? = null,
+    pathType: PathType? = null,
+): ArmeriaRoute {
+    val route = route(match = match, path = path)
+    path?.let { assertEquals(it, route.path) }
+    httpMethod?.let { assertEquals(it, route.httpMethod) }
+    pathType?.let { assertEquals(it, route.pathType) }
+    return route
+}

--- a/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaRouteTestSupport.kt
+++ b/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaRouteTestSupport.kt
@@ -42,7 +42,6 @@ fun List<ArmeriaRoute>.assertRoute(
     pathType: PathType? = null,
 ): ArmeriaRoute {
     val route = route(match = match, path = path)
-    path?.let { check(route.path == it) { "Expected path '$it' but was '${route.path}'" } }
     httpMethod?.let { check(route.httpMethod == it) { "Expected httpMethod '$it' but was '${route.httpMethod}'" } }
     pathType?.let { check(route.pathType == it) { "Expected pathType '$it' but was '${route.pathType}'" } }
     return route

--- a/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaRouteTestSupport.kt
+++ b/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaRouteTestSupport.kt
@@ -3,7 +3,7 @@ package com.linecorp.intellij.plugins.armeria.test
 import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
 import com.linecorp.intellij.plugins.armeria.explorer.model.PathType
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
-import org.junit.Assert.assertEquals
+import kotlin.test.assertEquals
 
 fun List<ArmeriaRoute>.route(
     match: RouteMatch? = null,
@@ -42,8 +42,11 @@ fun List<ArmeriaRoute>.assertRoute(
     httpMethod: String? = null,
     pathType: PathType? = null,
 ): ArmeriaRoute {
+    require(match != null || path != null || httpMethod != null || pathType != null) {
+        "assertRoute requires at least one expected field; use singleRoute() for cardinality-only checks"
+    }
     val route = route(match = match, path = path)
-    httpMethod?.let { assertEquals("httpMethod", it, route.httpMethod) }
-    pathType?.let { assertEquals("pathType", it, route.pathType) }
+    httpMethod?.let { assertEquals(it, route.httpMethod, message = "httpMethod") }
+    pathType?.let { assertEquals(it, route.pathType, message = "pathType") }
     return route
 }

--- a/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaRouteTestSupport.kt
+++ b/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaRouteTestSupport.kt
@@ -3,7 +3,6 @@ package com.linecorp.intellij.plugins.armeria.test
 import com.linecorp.intellij.plugins.armeria.explorer.model.ArmeriaRoute
 import com.linecorp.intellij.plugins.armeria.explorer.model.PathType
 import com.linecorp.intellij.plugins.armeria.explorer.model.RouteMatch
-import kotlin.test.assertEquals
 
 fun List<ArmeriaRoute>.route(
     match: RouteMatch? = null,
@@ -43,8 +42,8 @@ fun List<ArmeriaRoute>.assertRoute(
     pathType: PathType? = null,
 ): ArmeriaRoute {
     val route = route(match = match, path = path)
-    path?.let { assertEquals(it, route.path) }
-    httpMethod?.let { assertEquals(it, route.httpMethod) }
-    pathType?.let { assertEquals(it, route.pathType) }
+    path?.let { check(route.path == it) { "Expected path '$it' but was '${route.path}'" } }
+    httpMethod?.let { check(route.httpMethod == it) { "Expected httpMethod '$it' but was '${route.httpMethod}'" } }
+    pathType?.let { check(route.pathType == it) { "Expected pathType '$it' but was '${route.pathType}'" } }
     return route
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adopts the JetBrains `testData/` pattern for PSI fixture tests and introduces shared route assertion helpers in `plugin-route-collectors` testFixtures. This is the reference migration for issue #337; further test classes can follow the same pattern incrementally.

## Changes

- Add `configureFixture()` and `collectRoutes()` conveniences on `ArmeriaFixtureTestBase`; `configureFixture()` sets `myFixture.testDataPath` via `armeria.moduleTestDataPath` (Gradle) or module-root CWD before loading files (no global `getTestDataPath()` override)
- Add `resolveModuleTestDataPath()` on `ArmeriaLightJavaCodeInsightFixtureTestCase` for CWD-relative resolution under Gradle module roots
- Add `ArmeriaRouteTestSupport` with `route()` / `singleRoute()` / `assertRoute()` helpers; failures use `kotlin.test.fail()`; `route()` filters on `httpMethod` and `pathType` when provided; `assertRoute()` rejects all-null expected fields and asserts all provided fields via `assertEquals`
- Set `armeria.moduleTestDataPath` from the JVM test suite `test` target (`targets.all { testTask.configure { ... } }`) when `src/test/testData` exists — not applied to `fastTest`
- Expose `kotlin.test` via `testFixturesApi` so `assertRoute()` consumers get the dependency transitively
- Migrate `ArmeriaExtendedRegistrationCollectorBasicTest` end-to-end: nine Java fixtures moved to `src/test/testData/extendedRegistration/basic/`; all tests use `singleRoute()` before `assertRoute()` for cardinality checks
- Document the `testData/` + helper convention (including per-module JVM test suite wiring, `collectRoutes()` scope, migration patterns, and `configureFixture`/`configureByText` mixing footgun) in the route-psi-analysis skill

## Depends on

None.

## Test plan

- [x] `ktlintCheck`
- [x] `:plugin-route-collectors:test` (`ArmeriaExtendedRegistrationCollectorBasicTest` — 9/9)
- [x] `:plugin-route-analysis:test` (`ArmeriaAnnotatedMetadataSupportTest` — consumer module without `testData/`)
- [x] `:plugin-route-collectors:fastTest`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f939e-0e15-7bcd-a00e-8a972f903e5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f939e-0e15-7bcd-a00e-8a972f903e5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

