### PR TITLE
docs: prefer Cursor Cloud PR tools over gh CLI in agent docs

### DIFF
--- a/.cursor/rules/cloud-github.mdc
+++ b/.cursor/rules/cloud-github.mdc
@@ -7,16 +7,28 @@ alwaysApply: true
 
 In Cursor Cloud, do **not** assume `gh` is on PATH before `.cursor/install.sh` completes.
 
-## Pull requests
+## Pull requests (built-in tools)
 
-- Use the built-in **ManagePullRequest** tool for `create_pr` and `update_pr`.
+- Use **ManagePullRequest** for PR work:
+  - `create_pr` / `update_pr` — open or edit a PR
+  - `post_comment` — top-level comment, review-thread reply (`in_reply_to`), or line comment (`path` + `line`)
+  - `resolve_comment` — resolve a review thread (`comment_id`)
+  - `get_ci_status` — PR check / CI status (not `gh pr checks`)
+  - `set_pr_status` — open or close a PR
 - Use **EditPullRequestLabels** for label changes.
-- Do not run `gh pr create` / `gh pr edit` unless ManagePullRequest fails and `gh auth status` succeeds.
+- Do not run `gh pr create` / `gh pr edit` / `gh pr comment` / `gh pr checks` unless the matching built-in action fails and `gh auth status` succeeds.
 - PR bodies must follow `.cursor/rules/pr-description-format.mdc` (feature PR format; no review-response sections).
 
-## GitHub CLI fallback
+## GitHub CLI fallback (no built-in tool)
 
-When a skill requires `gh` (CI checks, PR comments, API calls):
+Use `gh` only when built-in tools do not cover the operation:
+
+| Operation | gh fallback |
+|-----------|---------------|
+| Fetch review threads / inline comment metadata | `gh api graphql` |
+| Create GitHub Release with assets | `gh release create` |
+
+Before calling `gh`:
 
 1. Resolve: `command -v gh` or `/exec-daemon/gh`
 2. Verify: `gh auth status`

--- a/.cursor/rules/cloud-github.mdc
+++ b/.cursor/rules/cloud-github.mdc
@@ -27,6 +27,7 @@ Use `gh` only when built-in tools do not cover the operation:
 |-----------|---------------|
 | Fetch review threads / inline comment metadata | `gh api graphql` |
 | Fetch PR branch metadata (no review threads) | `gh pr view --json headRefName,baseRefName,title` |
+| CI failure logs (run/job ID from check URLs) | `gh run view <run-id> --log-failed` or `gh run view --job <job-id> --log-failed` |
 | Create GitHub Release with assets | `gh release create` |
 
 Before calling `gh`:

--- a/.cursor/rules/cloud-github.mdc
+++ b/.cursor/rules/cloud-github.mdc
@@ -16,7 +16,7 @@ In Cursor Cloud, do **not** assume `gh` is on PATH before `.cursor/install.sh` c
   - `get_ci_status` — PR check / CI status (not `gh pr checks`)
   - `set_pr_status` — open or close a PR
 - Use **EditPullRequestLabels** for label changes.
-- Do not run `gh pr create` / `gh pr edit` / `gh pr comment` / `gh pr checks` unless the matching built-in action fails and `gh auth status` succeeds.
+- Do not run `gh pr create` / `gh pr edit` / `gh pr comment` / `gh pr checks` / `gh pr close` unless the matching built-in action fails and `gh auth status` succeeds.
 - PR bodies must follow `.cursor/rules/pr-description-format.mdc` (feature PR format; no review-response sections).
 
 ## GitHub CLI fallback (no built-in tool)
@@ -26,6 +26,7 @@ Use `gh` only when built-in tools do not cover the operation:
 | Operation | gh fallback |
 |-----------|---------------|
 | Fetch review threads / inline comment metadata | `gh api graphql` |
+| Fetch PR branch metadata (no review threads) | `gh pr view --json headRefName,baseRefName,title` |
 | Create GitHub Release with assets | `gh release create` |
 
 Before calling `gh`:

--- a/.cursor/skills/cloud-github/SKILL.md
+++ b/.cursor/skills/cloud-github/SKILL.md
@@ -2,7 +2,8 @@
 name: cloud-github
 description: >-
   GitHub and pull-request workflows for Cursor Cloud Agents in this repo.
-  Prefer built-in ManagePullRequest over gh CLI; use gh only after install.sh.
+  Prefer built-in ManagePullRequest and EditPullRequestLabels over gh CLI;
+  use gh only for operations with no built-in tool (review-thread fetch, releases).
 ---
 
 # Cloud GitHub operations
@@ -12,18 +13,29 @@ Cursor Cloud Agents in this repository must not fail because `gh` is missing fro
 `/usr/local/bin` is writable, into `/usr/local/bin/gh`. When `gh auth status` is unauthenticated,
 it logs in with `GH_TOKEN` or `GITHUB_TOKEN` if set.
 
-## PR create / update (preferred)
+## PR operations (preferred — built-in tools)
 
-Use the built-in **ManagePullRequest** tool. Do not run `gh pr create` or `gh pr edit`
-unless ManagePullRequest fails and `gh auth status` succeeds.
+Use the built-in **ManagePullRequest** and **EditPullRequestLabels** tools. Do **not** run
+`gh pr create`, `gh pr edit`, `gh pr comment`, `gh pr checks`, or `gh pr close` unless the
+built-in tool fails and `gh auth status` succeeds.
 
 | Task | Tool / action |
 |------|----------------|
 | Open a PR | `ManagePullRequest` with `action: create_pr` |
 | Update PR title/body | `ManagePullRequest` with `action: update_pr` |
-| Edit labels | `EditPullRequestLabels` |
+| Post a top-level PR comment | `ManagePullRequest` with `action: post_comment` |
+| Reply to a review comment | `ManagePullRequest` with `action: post_comment`, `in_reply_to: <databaseId>` |
+| Comment on a file/line in the diff | `ManagePullRequest` with `action: post_comment`, `path` + `line` (optional `start_line`, `side`) |
+| Resolve a review thread | `ManagePullRequest` with `action: resolve_comment`, `comment_id: <databaseId>` |
+| PR check / CI status | `ManagePullRequest` with `action: get_ci_status` |
+| Open or close a PR | `ManagePullRequest` with `action: set_pr_status`, `status: open` or `closed` |
+| Edit labels | `EditPullRequestLabels` with `add_labels` / `remove_labels` |
 
 Branch naming for agent work: `cursor/<descriptive-name>-<suffix>` (suffix is assigned per agent session).
+
+When a bundled skill (for example `loop-on-ci`, `fix-ci`, `new-branch-and-pr`, `review-and-ship`)
+instructs `gh pr create`, `gh pr checks`, or similar, use the matching built-in tool above instead
+in Cursor Cloud.
 
 ## PR description format
 
@@ -32,17 +44,23 @@ PR bodies must read like **feature pull requests**, not review-response document
 
 - Use **Summary**, **Changes**, optional **Depends on**, and **Test plan** only
 - Never add sections such as "Thermos review fixes", "Fixes in this update", or "Review feedback addressed"
-- After addressing review comments, fold edits into **Changes**; reply in PR comments, not as new body sections
+- After addressing review comments, fold edits into **Changes**; reply in PR comments via `post_comment`, not as new body sections
 
-## When `gh` is required
+## When `gh` is still required
 
-Some bundled skills (for example `loop-on-ci`, `fix-ci`) reference `gh pr checks`.
-Before calling `gh`:
+There is **no** built-in tool for these operations today:
+
+| Task | gh command |
+|------|------------|
+| Fetch review threads / inline comment metadata | `gh api graphql` (see `pr-review-response` skill) |
+| Create a GitHub Release with assets | `gh release create` (see `release` skill) |
+
+Before calling `gh` for the above:
 
 1. Confirm install finished: `.cursor/install.sh` runs on every Cloud Agent boot.
 2. Resolve the binary: `command -v gh` → prefer that path; fall back to `/exec-daemon/gh`.
 3. Confirm auth: `gh auth status` (or the resolved path above).
-4. If auth fails, stop retrying `gh` and either use ManagePullRequest for PR work or
+4. If auth fails, stop retrying `gh`. Use built-in PR tools for create/update/comment/resolve/CI;
    verify locally with Gradle MCP (`gradle_run_tasks` `["build"]` + background/poll).
 
 Do not install `gh` via apt, brew, or curl in agent sessions.
@@ -55,7 +73,8 @@ For agent-side verification, prefer:
 1. **Gradle MCP** — `gradle_connection_status`, then `gradle_run_tasks` / `gradle_run_tests` with `background: true` + poll (see `gradle-tapi-mcp` skill)
 2. Shell `./gradlew build` only when MCP is unresponsive, returns `BUILD_ALREADY_RUNNING` that cannot be cancelled, or for final CI parity after MCP passes
 
-Use `gh pr checks` only when you need GitHub-attached check status and `gh auth status` succeeds.
+For GitHub-attached check status on a PR, use **ManagePullRequest** `get_ci_status` (not `gh pr checks`).
+Fall back to `gh pr checks` only when `get_ci_status` fails and `gh auth status` succeeds.
 
 ## Authentication troubleshooting
 

--- a/.cursor/skills/cloud-github/SKILL.md
+++ b/.cursor/skills/cloud-github/SKILL.md
@@ -55,6 +55,7 @@ There is **no** built-in tool for these operations today:
 |------|------------|
 | Fetch review threads / inline comment metadata | `gh api graphql` (see `pr-review-response` skill) |
 | Fetch PR branch metadata (no review threads) | `gh pr view --json headRefName,baseRefName,title` |
+| CI failure logs (run/job ID from check URLs) | `gh run view <run-id> --log-failed` or `gh run view --job <job-id> --log-failed` |
 | Create a GitHub Release with assets | `gh release create` (see `release` skill) |
 
 Before calling `gh` for the above:
@@ -77,8 +78,10 @@ For agent-side verification, prefer:
 
 For GitHub-attached check status on a PR, use **ManagePullRequest** `get_ci_status` (not `gh pr checks`).
 Fall back to `gh pr checks` only when `get_ci_status` fails and `gh auth status` succeeds.
-When a check fails and you need log output to fix it, use `gh run view --log-failed` or follow the
-failing check's URL from `get_ci_status` (after `gh auth status` succeeds).
+When a check fails and you need log output to fix it, follow the failing check's URL from
+`get_ci_status` (or `gh pr checks` fallback) first. To fetch logs via CLI, use
+`gh run view <run-id> --log-failed` or `gh run view --job <job-id> --log-failed` with the run or
+job ID from those URLs (after `gh auth status` succeeds).
 
 ## Authentication troubleshooting
 

--- a/.cursor/skills/cloud-github/SKILL.md
+++ b/.cursor/skills/cloud-github/SKILL.md
@@ -3,7 +3,8 @@ name: cloud-github
 description: >-
   GitHub and pull-request workflows for Cursor Cloud Agents in this repo.
   Prefer built-in ManagePullRequest and EditPullRequestLabels over gh CLI;
-  use gh only for operations with no built-in tool (review-thread fetch, releases).
+  use gh only for operations with no built-in tool (review-thread fetch, PR metadata,
+  releases).
 ---
 
 # Cloud GitHub operations
@@ -33,9 +34,9 @@ built-in tool fails and `gh auth status` succeeds.
 
 Branch naming for agent work: `cursor/<descriptive-name>-<suffix>` (suffix is assigned per agent session).
 
-When a bundled skill (for example `loop-on-ci`, `fix-ci`, `new-branch-and-pr`, `review-and-ship`)
-instructs `gh pr create`, `gh pr checks`, or similar, use the matching built-in tool above instead
-in Cursor Cloud.
+When a bundled skill (for example `loop-on-ci`, `fix-ci`, `get-pr-comments`, `new-branch-and-pr`,
+`review-and-ship`, or any other skill that references `gh pr …`) instructs `gh pr create`,
+`gh pr checks`, or similar, use the matching built-in tool above instead in Cursor Cloud.
 
 ## PR description format
 
@@ -53,6 +54,7 @@ There is **no** built-in tool for these operations today:
 | Task | gh command |
 |------|------------|
 | Fetch review threads / inline comment metadata | `gh api graphql` (see `pr-review-response` skill) |
+| Fetch PR branch metadata (no review threads) | `gh pr view --json headRefName,baseRefName,title` |
 | Create a GitHub Release with assets | `gh release create` (see `release` skill) |
 
 Before calling `gh` for the above:
@@ -75,6 +77,8 @@ For agent-side verification, prefer:
 
 For GitHub-attached check status on a PR, use **ManagePullRequest** `get_ci_status` (not `gh pr checks`).
 Fall back to `gh pr checks` only when `get_ci_status` fails and `gh auth status` succeeds.
+When a check fails and you need log output to fix it, use `gh run view --log-failed` or follow the
+failing check's URL from `get_ci_status` (after `gh auth status` succeeds).
 
 ## Authentication troubleshooting
 

--- a/.cursor/skills/pr-review-response/SKILL.md
+++ b/.cursor/skills/pr-review-response/SKILL.md
@@ -25,8 +25,9 @@ do not read the full skill unless Gradle MCP fails.
 ## Phase 1 — Fetch comments (minimal payload)
 
 Read **`cloud-github`** for built-in PR tools. In Cursor Cloud, prefer those tools for
-create/update, replies, resolve, and CI status. **`gh` is required only to fetch review-thread
-metadata** (no built-in list/fetch tool today).
+create/update, replies, resolve, and CI status. **`gh` is still required** for review-thread
+metadata (GraphQL) and, when the branch is unknown, PR branch metadata via `gh pr view` — no
+built-in list/fetch tool for review threads today.
 
 Before any `gh` call:
 

--- a/.cursor/skills/pr-review-response/SKILL.md
+++ b/.cursor/skills/pr-review-response/SKILL.md
@@ -24,12 +24,16 @@ do not read the full skill unless Gradle MCP fails.
 
 ## Phase 1 — Fetch comments (minimal payload)
 
-Before any `gh` call in Cursor Cloud (see `.cursor/rules/cloud-github.mdc`):
+Read **`cloud-github`** for built-in PR tools. In Cursor Cloud, prefer those tools for
+create/update, replies, resolve, and CI status. **`gh` is required only to fetch review-thread
+metadata** (no built-in list/fetch tool today).
+
+Before any `gh` call:
 
 1. Resolve: `command -v gh` or `/exec-daemon/gh`
 2. Verify: `gh auth status`
 3. If either step fails, stop — do not install `gh` in agent sessions. Use
-   **ManagePullRequest** for PR create/update/resolve; retry GraphQL only after auth works.
+   **ManagePullRequest** for create/update/post/resolve/CI; retry GraphQL only after auth works.
 
 **Do not** call `gh api repos/.../pulls/{n}/comments` — the REST endpoint always
 includes `diff_hunk` per comment (~50 KB for a typical Copilot review) and there is
@@ -80,15 +84,16 @@ Extract:
 
 | Field | Use |
 |-------|-----|
-| `databaseId` | `ManagePullRequest` `resolve_comment` `comment_id` |
+| `databaseId` | `ManagePullRequest` `resolve_comment` `comment_id`; `post_comment` `in_reply_to` |
 | `isResolved` | Skip already resolved |
 | `body` + `path` + line fields | Triage and locate code — prefer `line`; when `line` is null (outdated thread), use `originalLine`; for multi-line comments use `startLine` / `originalStartLine` |
 | `headRefName` | Checkout branch |
 
-### Fallback: PR metadata only (not review threads)
+### Branch metadata without GraphQL
 
-When you need branch names before running GraphQL (or to recover from a GraphQL failure),
-fetch PR metadata separately — **`gh pr view` does not return review threads or comment bodies**:
+When the agent already has `branch_name` or `headRefName` from the task or a prior GraphQL
+call, skip `gh pr view`. Otherwise fetch PR metadata separately — **`gh pr view` does not
+return review threads or comment bodies**:
 
 ```bash
 gh pr view N --json headRefName,baseRefName,title
@@ -126,7 +131,8 @@ For each **unresolved** thread, record:
 | **P2** | Performance, test stability, redundant work, misleading API usage |
 | **P3** | Style, dead code, unused variables |
 
-Skip invalid comments with a brief PR reply; do not implement speculative fixes.
+Skip invalid comments with a brief PR reply via **ManagePullRequest** `post_comment`
+(`in_reply_to` the thread's `databaseId` when replying inline); do not implement speculative fixes.
 
 **Batch by file** — e.g. all `ArmeriaRouteNavigationSupport.kt` comments in one edit pass.
 
@@ -200,6 +206,8 @@ comment_id: <databaseId>
 
 Update PR body via `update_pr` only when behavior changed materially — fold fixes into **Changes**, not a "review fixes" section (see `.cursor/rules/pr-description-format.mdc`).
 
+For thread replies (e.g. explaining a skip), use `post_comment` with `in_reply_to: <databaseId>` instead of `gh pr comment`.
+
 ## Phase 7 — User summary
 
 Report in the user’s language:
@@ -211,7 +219,8 @@ Report in the user’s language:
 
 ## Token budget checklist
 
-- [ ] `gh` preflight (`command -v gh`, `gh auth status`) before GraphQL
+- [ ] Built-in tools used for create/update/post/resolve/CI (`cloud-github` table)
+- [ ] `gh` preflight (`command -v gh`, `gh auth status`) only before GraphQL (or `gh pr view` when branch unknown)
 - [ ] GraphQL used instead of REST review comments API
 - [ ] ≤ 1 branch checkout
 - [ ] Files read with offset/limit or Grep, not full-file unless refactoring

--- a/.cursor/skills/release/SKILL.md
+++ b/.cursor/skills/release/SKILL.md
@@ -142,7 +142,8 @@ Rebuild on `main` so the ZIP matches the tagged commit (prefer MCP `gradle_run_t
 cp plugin/build/distributions/plugin-<version>.zip /tmp/armeria-intellij-plugin-<version>.zip
 ```
 
-Create the release with `gh` (after `gh auth status` succeeds — see `cloud-github` skill):
+There is **no** built-in tool for GitHub Releases. Create the release with `gh` after
+`gh auth status` succeeds (see `cloud-github` skill):
 
 ```bash
 gh release create v<version> \
@@ -193,7 +194,9 @@ Ensure `## [Unreleased]` still has the six empty section templates.
 ## Cloud Agent notes
 
 - Use branch prefix `cursor/` and session suffix (e.g. `cursor/release-0.2.0-0716`).
-- Prefer **ManagePullRequest** for the version-bump PR; use `gh release create` only after `gh auth status` succeeds.
+- Prefer **ManagePullRequest** for the version-bump PR; use **ManagePullRequest** `get_ci_status`
+  to wait for CI green before merge (not `gh pr checks`).
+- Use `gh release create` only for publishing the release asset — no built-in release tool.
 - Do not commit `plugin/build/` artifacts; upload the ZIP only to GitHub Releases.
 - CI (`.github/workflows/main.yml`) runs `./gradlew build` on PRs — wait for green before merging the release PR.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ Do not rely on bare `gh` commands without checking availability. `.cursor/instal
 | Post or reply to PR comments | **ManagePullRequest** (`post_comment`; use `in_reply_to` for review-thread replies) |
 | Resolve review threads | **ManagePullRequest** (`resolve_comment`) |
 | PR check status | **ManagePullRequest** (`get_ci_status`); fallback `gh pr checks` per `cloud-github` |
-| CI failure logs | `gh run view --log-failed` or follow check URLs from `get_ci_status` (after `gh auth status` succeeds) |
+| CI failure logs | Follow failing check URLs from `get_ci_status` (or `gh pr checks` fallback); or `gh run view <run-id> --log-failed` / `gh run view --job <job-id> --log-failed` with IDs from those URLs (after `gh auth status` succeeds) |
 | Open or close a PR | **ManagePullRequest** (`set_pr_status`) |
 | Edit PR labels | **EditPullRequestLabels** |
 | Verify changes locally | **Gradle MCP** (`gradle_run_tasks` / `gradle_run_tests`); shell `./gradlew build` for CI parity fallback — see `gradle-tapi-mcp` skill |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,11 +39,12 @@ Do not rely on bare `gh` commands without checking availability. `.cursor/instal
 | Create or update a PR | Built-in **ManagePullRequest** (`create_pr` / `update_pr`); body format in `.cursor/rules/pr-description-format.mdc` |
 | Post or reply to PR comments | **ManagePullRequest** (`post_comment`; use `in_reply_to` for review-thread replies) |
 | Resolve review threads | **ManagePullRequest** (`resolve_comment`) |
-| PR check status / CI logs | **ManagePullRequest** (`get_ci_status`) |
+| PR check status | **ManagePullRequest** (`get_ci_status`); fallback `gh pr checks` per `cloud-github` |
+| CI failure logs | `gh run view --log-failed` or follow check URLs from `get_ci_status` (after `gh auth status` succeeds) |
 | Open or close a PR | **ManagePullRequest** (`set_pr_status`) |
 | Edit PR labels | **EditPullRequestLabels** |
 | Verify changes locally | **Gradle MCP** (`gradle_run_tasks` / `gradle_run_tests`); shell `./gradlew build` for CI parity fallback — see `gradle-tapi-mcp` skill |
-| Fetch review threads / create GitHub Release | `gh` only after `gh auth status` succeeds — no built-in tool (see `.cursor/skills/cloud-github/SKILL.md`) |
+| Fetch review threads / PR metadata / create GitHub Release | `gh` only after `gh auth status` succeeds — no built-in tool (see `.cursor/skills/cloud-github/SKILL.md`) |
 
 If `gh` is not found or auth fails, use ManagePullRequest and EditPullRequestLabels for PR work
 and Gradle MCP for build verification instead of retrying `gh`. Set `GH_TOKEN` in Cursor Cloud

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,20 +36,25 @@ Do not rely on bare `gh` commands without checking availability. `.cursor/instal
 
 | Goal | Preferred approach |
 |------|-------------------|
-| Create or update a PR | Built-in **ManagePullRequest** tool (`create_pr` / `update_pr`); body format in `.cursor/rules/pr-description-format.mdc` |
-| Edit PR labels | **EditPullRequestLabels** tool |
+| Create or update a PR | Built-in **ManagePullRequest** (`create_pr` / `update_pr`); body format in `.cursor/rules/pr-description-format.mdc` |
+| Post or reply to PR comments | **ManagePullRequest** (`post_comment`; use `in_reply_to` for review-thread replies) |
+| Resolve review threads | **ManagePullRequest** (`resolve_comment`) |
+| PR check status / CI logs | **ManagePullRequest** (`get_ci_status`) |
+| Open or close a PR | **ManagePullRequest** (`set_pr_status`) |
+| Edit PR labels | **EditPullRequestLabels** |
 | Verify changes locally | **Gradle MCP** (`gradle_run_tasks` / `gradle_run_tests`); shell `./gradlew build` for CI parity fallback — see `gradle-tapi-mcp` skill |
-| PR check status / CI logs | `gh` only after `gh auth status` succeeds (see `.cursor/skills/cloud-github/SKILL.md`) |
+| Fetch review threads / create GitHub Release | `gh` only after `gh auth status` succeeds — no built-in tool (see `.cursor/skills/cloud-github/SKILL.md`) |
 
-If `gh` is not found or auth fails, use ManagePullRequest for PR work and Gradle MCP for build
-verification instead of retrying `gh`. Set `GH_TOKEN` in Cursor Cloud Secrets when the GitHub App
-token lacks required scopes.
+If `gh` is not found or auth fails, use ManagePullRequest and EditPullRequestLabels for PR work
+and Gradle MCP for build verification instead of retrying `gh`. Set `GH_TOKEN` in Cursor Cloud
+Secrets when the GitHub App token lacks required scopes.
 
 ### Plugin releases
 
 GitHub Releases distribution is documented in `.cursor/skills/release/SKILL.md`. Version lives in
 `gradle.properties` (`pluginVersion`); changelog in `plugin/CHANGELOG.md`. There is no automated
-release workflow — tag and `gh release create` after merging a version-bump PR to `main`.
+release workflow — tag and publish with `gh release create` after merging a version-bump PR to
+`main` (no built-in release tool; see `release` skill).
 
 ### Build, test, lint
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cursor Cloud provides built-in PR tools (`ManagePullRequest`, `EditPullRequestLabels`) that replace most `gh` CLI usage in agent workflows. This updates agent instructions and skills to prefer those tools and reserve `gh` only for operations without a built-in alternative.

## Changes

- Expand `.cursor/skills/cloud-github/SKILL.md` and `.cursor/rules/cloud-github.mdc` with the full built-in tool mapping (`create_pr`, `update_pr`, `post_comment`, `resolve_comment`, `get_ci_status`, `set_pr_status`, `EditPullRequestLabels`)
- Note that bundled skills such as `loop-on-ci` / `fix-ci` should use `get_ci_status` instead of `gh pr checks` in Cursor Cloud
- Update `AGENTS.md` GitHub table with comment, resolve, CI status, CI log, and label actions; split PR check status from CI failure logs
- Document `gh pr view` and `gh run view` (with run/job ID) as `gh` fallbacks where no built-in tool exists
- Update `pr-review-response` to use `post_comment` / `resolve_comment` for replies and thread resolution; keep `gh api graphql` only for fetching review-thread metadata
- Update `release` skill to use `get_ci_status` for CI waits; document that `gh release create` remains required (no built-in release tool)

## Test plan

- [x] Docs-only change; no code or build impact
- [x] Thermo-nuclear review passed (SHIP) after two fix rounds
- [x] Verified `gh` references remain only for GraphQL review-thread fetch, `gh pr view`, `gh run view` (with IDs), and `gh release create`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f941e-9525-703a-8e8a-db5f4d31fa84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f941e-9525-703a-8e8a-db5f4d31fa84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

