### PR TITLE
docs: align setup-gh-cli.sh auth messages with Cloud PR tool guidance

### DIFF
--- a/.cursor/scripts/setup-gh-cli.sh
+++ b/.cursor/scripts/setup-gh-cli.sh
@@ -24,11 +24,11 @@ if ! "${gh_source}" auth status >/dev/null 2>&1; then
   if [[ -n "${token}" ]]; then
     if ! "${gh_source}" auth login --hostname github.com --git-protocol https --with-token <<<"${token}"; then
       echo "Warning: gh auth login failed; gh CLI may be unavailable for API calls." >&2
-      echo "Use ManagePullRequest for PRs, or set GH_TOKEN in Cursor Cloud Secrets." >&2
+      echo "Use ManagePullRequest and EditPullRequestLabels for PR work, or set GH_TOKEN in Cursor Cloud Secrets (see .cursor/skills/cloud-github/SKILL.md)." >&2
     fi
   else
     echo "Warning: gh is not authenticated and GH_TOKEN/GITHUB_TOKEN is unset." >&2
-    echo "Set GH_TOKEN in Cursor Cloud Secrets, or use the ManagePullRequest tool for PRs." >&2
+    echo "Set GH_TOKEN in Cursor Cloud Secrets, or use ManagePullRequest / EditPullRequestLabels for PR work (see .cursor/skills/cloud-github/SKILL.md)." >&2
   fi
 fi
 

--- a/.cursor/scripts/setup-gh-cli.sh
+++ b/.cursor/scripts/setup-gh-cli.sh
@@ -24,7 +24,7 @@ if ! "${gh_source}" auth status >/dev/null 2>&1; then
   if [[ -n "${token}" ]]; then
     if ! "${gh_source}" auth login --hostname github.com --git-protocol https --with-token <<<"${token}"; then
       echo "Warning: gh auth login failed; gh CLI may be unavailable for API calls." >&2
-      echo "Use ManagePullRequest and EditPullRequestLabels for PR work, or verify GH_TOKEN scopes in Cursor Cloud Secrets (see .cursor/skills/cloud-github/SKILL.md)." >&2
+      echo "Use ManagePullRequest and EditPullRequestLabels for PR work, or verify GH_TOKEN/GITHUB_TOKEN scopes in Cursor Cloud Secrets (see .cursor/skills/cloud-github/SKILL.md)." >&2
     fi
   else
     echo "Warning: gh is not authenticated and GH_TOKEN/GITHUB_TOKEN is unset." >&2

--- a/.cursor/scripts/setup-gh-cli.sh
+++ b/.cursor/scripts/setup-gh-cli.sh
@@ -24,11 +24,11 @@ if ! "${gh_source}" auth status >/dev/null 2>&1; then
   if [[ -n "${token}" ]]; then
     if ! "${gh_source}" auth login --hostname github.com --git-protocol https --with-token <<<"${token}"; then
       echo "Warning: gh auth login failed; gh CLI may be unavailable for API calls." >&2
-      echo "Use ManagePullRequest and EditPullRequestLabels for PR work, or set GH_TOKEN in Cursor Cloud Secrets (see .cursor/skills/cloud-github/SKILL.md)." >&2
+      echo "Use ManagePullRequest and EditPullRequestLabels for PR work, or verify GH_TOKEN scopes in Cursor Cloud Secrets (see .cursor/skills/cloud-github/SKILL.md)." >&2
     fi
   else
     echo "Warning: gh is not authenticated and GH_TOKEN/GITHUB_TOKEN is unset." >&2
-    echo "Set GH_TOKEN in Cursor Cloud Secrets, or use ManagePullRequest / EditPullRequestLabels for PR work (see .cursor/skills/cloud-github/SKILL.md)." >&2
+    echo "Set GH_TOKEN in Cursor Cloud Secrets, or use ManagePullRequest and EditPullRequestLabels for PR work (see .cursor/skills/cloud-github/SKILL.md)." >&2
   fi
 fi
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When `gh` authentication fails during Cloud Agent setup, agents see warnings from `.cursor/scripts/setup-gh-cli.sh`. Those messages only mentioned `ManagePullRequest`, while the repo now documents a broader set of built-in PR tools (`EditPullRequestLabels`, `post_comment`, `resolve_comment`, `get_ci_status`, `set_pr_status`).

This updates the auth-failure guidance so agents are pointed at both built-in tools and the canonical skill reference.

Fixes #354.

## Changes

- Auth-failure warnings now mention `ManagePullRequest` and `EditPullRequestLabels`, with a pointer to `.cursor/skills/cloud-github/SKILL.md`
- Token-login-failure path advises verifying `GH_TOKEN`/`GITHUB_TOKEN` scopes (not re-setting a token that is already present)
- Consistent wording between the token-present and no-token warning paths

## Test plan

- [x] Thermo-nuclear review on PR diff (no P0–P2 findings)
- [x] Manual review of warning strings against `cloud-github` skill and `AGENTS.md`
- [x] No functional or build impact (message-only change in setup script)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9439-1c45-7857-870f-bad6da1471d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9439-1c45-7857-870f-bad6da1471d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

