### PR TITLE
perf: reuse route collector cache in blocking client inspection

### DIFF
--- a/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientInspection.kt
+++ b/plugin/src/main/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientInspection.kt
@@ -10,9 +10,6 @@ import com.intellij.psi.PsiLiteralExpression
 import com.intellij.psi.PsiMethodCallExpression
 import com.intellij.psi.PsiReferenceExpression
 import com.intellij.psi.search.GlobalSearchScope
-import com.intellij.psi.util.CachedValueProvider
-import com.intellij.psi.util.CachedValuesManager
-import com.intellij.psi.util.PsiModificationTracker
 import com.intellij.psi.util.PsiTreeUtil
 import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteAnalysisCollector
 import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaRouteSupport
@@ -136,14 +133,10 @@ class ArmeriaBlockingClientInspection : LocalInspectionTool() {
 
 internal object ArmeriaBlockingClientInspectionPaths {
     fun blockingRoutePaths(project: Project): Set<String> =
-        CachedValuesManager.getManager(project).getCachedValue(project) {
-            val paths =
-                ArmeriaRouteAnalysisCollector
-                    .collect(project)
-                    .asSequence()
-                    .filter { ArmeriaTestMethodGenerator.isBlockingInspectableRoute(it) }
-                    .map { ArmeriaRouteSupport.normalizePath(it.path) }
-                    .toSet()
-            CachedValueProvider.Result.create(paths, PsiModificationTracker.MODIFICATION_COUNT)
-        }
+        ArmeriaRouteAnalysisCollector
+            .collect(project)
+            .asSequence()
+            .filter { ArmeriaTestMethodGenerator.isBlockingInspectableRoute(it) }
+            .map { ArmeriaRouteSupport.normalizePath(it.path) }
+            .toSet()
 }

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientInspectionTest.kt
@@ -8,6 +8,9 @@ import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiManager
 import com.intellij.testFramework.PsiTestUtil
+import com.linecorp.intellij.plugins.armeria.explorer.collector.ArmeriaRouteAnalysisCollector
+import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaRouteCollectionMetrics
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class ArmeriaBlockingClientInspectionTest : ArmeriaLightJavaCodeInsightFixtureTestCase() {
@@ -248,6 +251,32 @@ class ArmeriaBlockingClientInspectionTest : ArmeriaLightJavaCodeInsightFixtureTe
         )
 
         myFixture.testHighlighting(true, false, true)
+    }
+
+    fun testBlockingRoutePathsReusesRouteCollectorCache() {
+        myFixture.addClass(
+            """
+            package example;
+
+            import com.linecorp.armeria.server.annotation.Blocking;
+            import com.linecorp.armeria.server.annotation.Get;
+
+            public class SlowService {
+                @Blocking
+                @Get("/slow")
+                public String slow() {
+                    return "slow";
+                }
+            }
+            """.trimIndent(),
+        )
+
+        ArmeriaRouteAnalysisCollector.collect(project)
+        assertTrue(ArmeriaRouteCollectionMetrics.lastSnapshot!!.filesScanned > 0)
+
+        val blockingPaths = ArmeriaBlockingClientInspectionPaths.blockingRoutePaths(project)
+        assertTrue(blockingPaths.contains("/slow"))
+        assertEquals(0, ArmeriaRouteCollectionMetrics.lastSnapshot!!.filesScanned)
     }
 
     fun testNoInspectionSetupForMainSourceTestNamedFile() {

--- a/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientInspectionTest.kt
+++ b/plugin/src/test/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaBlockingClientInspectionTest.kt
@@ -272,11 +272,13 @@ class ArmeriaBlockingClientInspectionTest : ArmeriaLightJavaCodeInsightFixtureTe
         )
 
         ArmeriaRouteAnalysisCollector.collect(project)
-        assertTrue(ArmeriaRouteCollectionMetrics.lastSnapshot!!.filesScanned > 0)
+        val firstScan = ArmeriaRouteCollectionMetrics.lastSnapshot!!.filesScanned
+        assertTrue(firstScan > 0)
 
         val blockingPaths = ArmeriaBlockingClientInspectionPaths.blockingRoutePaths(project)
         assertTrue(blockingPaths.contains("/slow"))
-        assertEquals(0, ArmeriaRouteCollectionMetrics.lastSnapshot!!.filesScanned)
+        val secondScan = ArmeriaRouteCollectionMetrics.lastSnapshot!!.filesScanned
+        assertEquals(0, secondScan)
     }
 
     fun testNoInspectionSetupForMainSourceTestNamedFile() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Blocking Client inspection maintained its own `CachedValuesManager` cache around `ArmeriaRouteAnalysisCollector.collect()`, causing duplicate full-project route scans when the route collector cache was already warm.

This change derives blocking paths directly from the route collector's cached route list, matching how Route Explorer and other callers use `ArmeriaRouteAnalysisCollector`. The blocking-path helper now inherits the route collector's dual invalidation (`PsiModificationTracker` and `ProjectRootModificationTracker`) instead of the previous outer cache that only tracked PSI modification count.

Fixes #306

## Changes

- Remove the redundant `CachedValuesManager` wrapper from `ArmeriaBlockingClientInspectionPaths`
- Derive blocking paths by filtering the cached route list from `ArmeriaRouteAnalysisCollector.collect()`
- Add `testBlockingRoutePathsReusesRouteCollectorCache` to assert no duplicate scan when the route collector cache is warm
- Capture route scan metrics in locals in the cache regression test for clearer assertions

## Test plan

- [x] `ArmeriaBlockingClientInspectionTest` (all tests including cache regression)
- [x] `ktlintCheck`
- [x] CI green (14/14 checks)

## Deferred follow-ups

- #360 — harden blocking client cache reuse test assertions
- #361 — optional memoization of filtered blocking route paths
- #362 — memoize blocking client inspection path filter on large route sets

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9438-e976-7209-8c17-2c4ab7179e84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9438-e976-7209-8c17-2c4ab7179e84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

