### PR TITLE
docs: mention Gradle MCP in setup-gh-cli auth-failure warnings

### DIFF
--- a/.cursor/scripts/setup-gh-cli.sh
+++ b/.cursor/scripts/setup-gh-cli.sh
@@ -24,11 +24,11 @@ if ! "${gh_source}" auth status >/dev/null 2>&1; then
   if [[ -n "${token}" ]]; then
     if ! "${gh_source}" auth login --hostname github.com --git-protocol https --with-token <<<"${token}"; then
       echo "Warning: gh auth login failed; gh CLI may be unavailable for API calls." >&2
-      echo "Use ManagePullRequest and EditPullRequestLabels for PR work, or verify GH_TOKEN/GITHUB_TOKEN scopes in Cursor Cloud Secrets (see .cursor/skills/cloud-github/SKILL.md)." >&2
+      echo "Use ManagePullRequest and EditPullRequestLabels for PR work, or verify GH_TOKEN/GITHUB_TOKEN scopes in Cursor Cloud Secrets; use Gradle MCP for local build/test verification (see .cursor/skills/cloud-github/SKILL.md, .cursor/skills/gradle-tapi-mcp/SKILL.md)." >&2
     fi
   else
     echo "Warning: gh is not authenticated and GH_TOKEN/GITHUB_TOKEN is unset." >&2
-    echo "Set GH_TOKEN in Cursor Cloud Secrets, or use ManagePullRequest and EditPullRequestLabels for PR work (see .cursor/skills/cloud-github/SKILL.md)." >&2
+    echo "Set GH_TOKEN in Cursor Cloud Secrets, or use ManagePullRequest and EditPullRequestLabels for PR work; use Gradle MCP for local build/test verification (see .cursor/skills/cloud-github/SKILL.md, .cursor/skills/gradle-tapi-mcp/SKILL.md)." >&2
   fi
 fi
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When `gh` authentication fails during Cloud Agent install, the warnings in `.cursor/scripts/setup-gh-cli.sh` already point agents at built-in PR tools. This change extends those messages to also mention Gradle MCP for local build and test verification, aligning install-time guidance with `AGENTS.md` and `.cursor/rules/cloud-github.mdc`.

Fixes #357.

## Changes

- Extend both `gh` auth-failure warning lines in `.cursor/scripts/setup-gh-cli.sh` to reference Gradle MCP and the `gradle-tapi-mcp` skill alongside the existing `cloud-github` skill pointers

## Test plan

- [x] Verified warning text reads correctly in the updated script
- [x] No Kotlin or Gradle changes; install script only
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9491-07c9-7dd9-88ae-fa18955425dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9491-07c9-7dd9-88ae-fa18955425dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

