### PR TITLE
fix: clear ArmeriaRouteCollectionMetrics lastSnapshot in fixture teardown

### DIFF
--- a/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaRouteCollectionMetrics.kt
+++ b/plugin-route-collectors/src/main/kotlin/com/linecorp/intellij/plugins/armeria/explorer/support/ArmeriaRouteCollectionMetrics.kt
@@ -59,6 +59,11 @@ class ArmeriaRouteCollectionMetrics {
 
         fun current(): ArmeriaRouteCollectionMetrics? = active.get()
 
+        /** Clears the thread-local [lastSnapshot] after fixture tests to avoid leaking on pooled threads. */
+        fun clearLastSnapshotForTests() {
+            lastSnapshotHolder.remove()
+        }
+
         fun logIfEnabled(snapshot: Snapshot) {
             lastSnapshot = snapshot
             if (ApplicationManager.getApplication().isUnitTestMode) {

--- a/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaLightJavaCodeInsightFixtureTestCase.kt
+++ b/plugin-route-collectors/src/testFixtures/kotlin/com/linecorp/intellij/plugins/armeria/test/ArmeriaLightJavaCodeInsightFixtureTestCase.kt
@@ -3,6 +3,7 @@ package com.linecorp.intellij.plugins.armeria.test
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+import com.linecorp.intellij.plugins.armeria.explorer.support.ArmeriaRouteCollectionMetrics
 import java.io.File
 
 /**
@@ -27,6 +28,14 @@ abstract class ArmeriaLightJavaCodeInsightFixtureTestCase : LightJavaCodeInsight
     override fun setUp() {
         super.setUp()
         allowTestSandboxRoots()
+    }
+
+    override fun tearDown() {
+        try {
+            ArmeriaRouteCollectionMetrics.clearLastSnapshotForTests()
+        } finally {
+            super.tearDown()
+        }
     }
 
     private fun allowTestSandboxRoots() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`ArmeriaRouteCollectionMetrics.lastSnapshot` is stored in a `ThreadLocal` for parallel test stability. While `active` is cleared in `runWith`'s `finally` block, `lastSnapshotHolder` could persist on pooled executor threads after fixture tests finish.

This change adds test-only cleanup so fixture teardown clears the thread-local snapshot state consistently.

Fixes #331.

## Changes

- Add `ArmeriaRouteCollectionMetrics.clearLastSnapshotForTests()` to remove the thread-local `lastSnapshot` entry
- Call it from `ArmeriaLightJavaCodeInsightFixtureTestCase.tearDown()` so all fixture-based tests inherit the cleanup

## Test plan

- [x] `:plugin-route-collectors:compileKotlin` and `:plugin-route-collectors:compileTestFixturesKotlin`
- [x] `ArmeriaGrpcRouteCollectorTest` (uses `lastSnapshot` assertions)
- [x] `ArmeriaProtoRouteRegistryGateTest` (uses `lastSnapshot` assertions)
- [x] `ktlintCheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9493-13f0-74de-88d5-3d1643fe36e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9493-13f0-74de-88d5-3d1643fe36e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

