### PR TITLE
docs: token-efficient Cloud Agent workflow skills and rules

### DIFF
--- a/.cursor/rules/agent-workflow.mdc
+++ b/.cursor/rules/agent-workflow.mdc
@@ -1,0 +1,25 @@
+---
+description: Token-efficient Cloud Agent workflow — checkout first, no duplicate audits, Gradle test-suite convention
+alwaysApply: true
+---
+
+# Agent workflow (token-efficient)
+
+## Checkout before explore
+
+For PR work (`/thermos`, review fixes), **fetch and checkout the PR head branch first**. Do not grep or read production code on `main` when a PR branch exists.
+
+## No duplicate work
+
+- **Resume** an IDLE Cloud Agent for the same PR/issue when the user provides a session URL or `bc-…` id.
+- If `HEAD` is unchanged since the last SHIP and the user only asks to file deferred issues, create issues — **do not** re-run Thermo, full diff review, or tests.
+
+## Gradle test tasks
+
+Modules use the JVM Test Suite plugin (`testing { suites { … } }` in `build-logic`). Configure test tasks via `getByName<JvmTestSuite>("test") { targets.all { testTask.configure { … } } }`.
+
+**Do not** add bare `tasks.named<Test>("test") { … }` when the module already has `testing { suites }`. Pattern: `build-logic/src/main/kotlin/com.linecorp.intellij.platform-library.gradle.kts`.
+
+## Skill routing
+
+Read `workflow-router` first for `/thermos`, PR comment triage, or issue fixes — then only the matching on-demand skill (`thermo-nuclear-review`, `pr-review-response`, or `issue-to-pr`).

--- a/.cursor/skills/copilot-review-preflight/SKILL.md
+++ b/.cursor/skills/copilot-review-preflight/SKILL.md
@@ -24,7 +24,10 @@ final pass before requesting review.
 
 | Area | Skill |
 |------|-------|
+| **Route task first** | `workflow-router` |
+| **`/thermos` branch audit** | `thermo-nuclear-review` |
 | **Addressing PR review comments** | `pr-review-response` |
+| **Issue → PR** | `issue-to-pr` |
 | UI, run configs, tool windows, inspections, module placement | `intellij-armeria-plugin` |
 | Route/client PSI collectors, Spring YAML/properties, virtualHost | `armeria-route-psi-analysis` |
 | Gradle build/test via MCP | `gradle-tapi-mcp` |

--- a/.cursor/skills/issue-to-pr/SKILL.md
+++ b/.cursor/skills/issue-to-pr/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: issue-to-pr
+description: >-
+  Token-efficient workflow to pick one GitHub issue, implement a minimal fix,
+  verify with targeted Gradle MCP tests, and open a PR. Use for issue-driven tasks.
+---
+
+# Issue → PR (token-efficient)
+
+Read `workflow-router` only if you have not already routed here.
+
+## 1 — Pick one issue (one command)
+
+**Oldest open** (`gh issue list --sort` is not available):
+
+```bash
+gh issue list --state open --limit 100 --json number,title,createdAt \
+  | jq 'sort_by(.createdAt) | .[0]'
+```
+
+**Easy / small** — prefer labels or a tight limit; do not list and compare 30+ issues:
+
+```bash
+gh issue list --state open --label "good first issue" --limit 5 --json number,title
+# or: --search "is:open no:assignee" --limit 5
+```
+
+Then: `gh issue view N` once.
+
+## 2 — Branch
+
+```bash
+git checkout main && git pull origin main
+git checkout -b cursor/issue-<N>-<short-slug>-<suffix>
+```
+
+Use plan mode only for non-trivial perf/refactors; hygiene/docs fixes go straight to code.
+
+## 3 — Implement
+
+- Minimal diff scoped to the issue.
+- `Grep` + `Read` with `offset`/`limit` — not full-file reads unless refactoring.
+- New tests only when behavior or perf changes require them.
+
+## 4 — Verify (before commit)
+
+Wait for `gradle_connection_status` (`connectedAny: true`).
+
+| Step | MCP |
+|------|-----|
+| Compile affected module(s) | `gradle_run_tasks` e.g. `[":plugin:compileKotlin", ":plugin:compileTestKotlin"]` |
+| Tests | **One** `gradle_run_tests` batch — affected class(es) only (`Grep` for callers) |
+| Lint (when `*.kt` staged) | `gradle_run_tasks` `["ktlintCheck"]` — after tests, before commit |
+
+Do not run full `build` for small fixes. Poll without `includeOutput` until failure.
+
+## 5 — Commit + PR
+
+```bash
+git commit -m "<type>: <summary>
+
+Fixes #N"
+git push -u origin cursor/issue-<N>-...
+```
+
+- **ManagePullRequest** `create_pr` — **open** (not draft) when verification passed.
+- Body: Summary / Changes / Test plan (`pr-description-format.mdc`).
+- `gh issue comment N --body "PR: <url>"` or link in PR body.
+
+## Token budget
+
+- [ ] ≤2 `gh issue` calls (list pick + view)
+- [ ] ≤1 explore pass (Grep, not subagent) for simple issues
+- [ ] Gradle: compile + one test batch + ktlint
+- [ ] Did not read `pr-review-response` or full `gradle-tapi-mcp`

--- a/.cursor/skills/pr-review-response/SKILL.md
+++ b/.cursor/skills/pr-review-response/SKILL.md
@@ -12,6 +12,8 @@ description: >-
 Workflow for **triage → batch fix → verify once → resolve threads**, derived from
 agent sessions on this repository (e.g. PR #208, ~45 tool rounds without this skill).
 
+**Not for `/thermos` branch audits** — use `thermo-nuclear-review` instead (`workflow-router`).
+
 Read **`cloud-github`** for PR tools and **`copilot-review-preflight`** for recurring
 fix patterns. Read **`gradle-tapi-mcp`** only for the verification subsection below —
 do not read the full skill unless Gradle MCP fails.
@@ -21,6 +23,8 @@ do not read the full skill unless Gradle MCP fails.
 - User asks to address / fix / resolve comments on PR *N*
 - After Copilot or Thermos review on an open PR
 - Before marking review threads resolved
+
+**Not for `/thermos PR N` branch audits** — use `thermo-nuclear-review` (`workflow-router`).
 
 ## Phase 1 — Fetch comments (minimal payload)
 
@@ -245,6 +249,9 @@ Report in the user’s language:
 
 | Need | Skill |
 |------|-------|
+| `/thermos` branch audit (not inline comments) | `thermo-nuclear-review` |
+| Route task to correct skill | `workflow-router` |
+| Issue → PR | `issue-to-pr` |
 | PR create/update body | `cloud-github` + `pr-description-format.mdc` |
 | Copilot recurring patterns | `copilot-review-preflight` |
 | Plugin / PSI conventions | `intellij-armeria-plugin` |

--- a/.cursor/skills/thermo-nuclear-review/SKILL.md
+++ b/.cursor/skills/thermo-nuclear-review/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: thermo-nuclear-review
+description: >-
+  Token-efficient Thermo-nuclear branch audit for /thermos PR N prompts.
+  Fix P0–P2 on branch, file issues for deferred P3, SHIP when clean.
+  Use for branch audits — not for GitHub inline review-thread triage.
+---
+
+# Thermo-nuclear review (`/thermos PR N`)
+
+For **GitHub review comment threads**, use `pr-review-response` instead.
+
+Read `workflow-router` only if you have not already routed here.
+
+## Phase 0 — Branch first (no exploration on main)
+
+```bash
+gh pr view N --json headRefName,baseRefName,title,files
+git fetch origin <headRefName>
+git checkout -B <headRefName> origin/<headRefName>
+git diff origin/<baseRefName>...HEAD   # single diff; do not gh pr diff
+```
+
+Optional: **ManagePullRequest** `get_ci_status` once if merge-readiness matters.
+
+## Phase 1 — Tier (controls subagent use)
+
+| Tier | When | Thermo subagent |
+|------|------|-----------------|
+| **A** | Docs / scripts / ≤2 files and ≤30 net lines | **No** — use checklist below |
+| **B** | Typical code PR | **Max 1** before fixes |
+| **C** | Large diff or first pass found P0/P1 | **Max 2** (initial + after fixes only) |
+
+Never run a subagent and a long manual P0–P3 audit on the same pass.
+
+### Tier A checklist (inline, no subagent)
+
+- [ ] User-visible strings via `message()` / bundle
+- [ ] No hard-coded paths; tests reuse fixtures / `setUp()`
+- [ ] Module placement matches `intellij-armeria-plugin` / `armeria-route-psi-analysis`
+- [ ] Agent docs: built-in PR tools over `gh` where applicable
+- [ ] Gradle: `testing { suites { … } }` — no bare `tasks.named<Test>("test")` (see `agent-workflow` rule)
+
+## Phase 2 — Triage
+
+| Priority | Action on branch |
+|----------|------------------|
+| P0–P1 | Must fix before SHIP |
+| P2 | Fix in PR or block SHIP |
+| P3 | Fix now **or** file one issue each — **decide before SHIP** |
+
+Do not SHIP with “will file issues later” — create issues in the same session.
+
+## Phase 3 — Implement + verify
+
+1. Batch all fixes per file; one commit when possible.
+2. Verify (code PRs only) — `gradle-tapi-mcp` table: **one** compile batch + **one** `gradle_run_tests` for affected classes; `ktlintCheck` before commit when `*.kt` staged.
+3. Tier B/C: optional second subagent **only after** push-worthy fixes are in the tree.
+4. **Do not** re-audit if `HEAD` unchanged and user only asked to file P3 issues.
+
+## Phase 4 — Ship
+
+```bash
+git push -u origin <headRefName>
+```
+
+- **ManagePullRequest** `update_pr` when behavior changed (fold into Summary/Changes per `pr-description-format.mdc`).
+- `gh issue create` for deferred P3; link issues in a PR comment (**ManagePullRequest** `post_comment`).
+
+Report: priority table, fixed vs deferred, test command, PR link.
+
+## Token budget
+
+- [ ] ≤1 `gh pr view` / built-in PR metadata fetch
+- [ ] ≤1 diff (`git diff`, not `gh pr diff` twice)
+- [ ] Subagent count within tier cap
+- [ ] No `pr-review-response` full read
+- [ ] Gradle: ≤1 compile + ≤1 test batch + ktlint at commit

--- a/.cursor/skills/workflow-router/SKILL.md
+++ b/.cursor/skills/workflow-router/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: workflow-router
+description: >-
+  Route Cloud Agent tasks to the correct on-demand skill. Read this first when the
+  user prompt matches /thermos, PR review comments, issue fixes, or docs-only edits.
+  Prevents loading the wrong skill and wasting tokens.
+---
+
+# Workflow router (read first)
+
+Pick **one** path below. Do **not** read unrelated skills in full.
+
+| User intent | Read only | Do not read |
+|-------------|-----------|-------------|
+| `/thermos PR N`, Thermo branch audit | `thermo-nuclear-review` | `pr-review-response` |
+| Address PR review comments / resolve threads | `pr-review-response` | `thermo-nuclear-review` |
+| Fix an issue → open PR | `issue-to-pr` | `pr-review-response` |
+| Docs / `.cursor/` / `AGENTS.md` only | `cloud-github` + target files via Grep | `gradle-tapi-mcp` (full) |
+| Plugin / route code (implementation) | Area skill from table below | Full `AGENTS.md` |
+
+## Area skills (implementation only)
+
+| Area | Skill |
+|------|-------|
+| Plugin UI, run configs, inspections | `intellij-armeria-plugin` |
+| Route collectors, PSI, Spring config | `armeria-route-psi-analysis` |
+| Gradle verify (after you know the task) | `gradle-tapi-mcp` — verification table only |
+| Pre-PR Copilot patterns | `copilot-review-preflight` — checklist for changed area only |
+
+## Session reuse (token save)
+
+- Same PR or issue: **resume an IDLE Cloud Agent** (user may pass `bc-…` URL) instead of starting a new session.
+- If `HEAD` is unchanged since last SHIP and the user only asks to file P3 issues, create issues — **do not** re-run Thermo or tests.
+
+## Fetch once
+
+| Need | One call |
+|------|----------|
+| PR branch + files | `gh pr view N --json headRefName,baseRefName,title,files` or **ManagePullRequest** |
+| Diff after checkout | `git diff origin/<base>...HEAD` — not `gh pr diff` |
+| Review threads | GraphQL once (`pr-review-response`); if empty, do not re-fetch |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Past Cloud Agent sessions spent tokens on wrong skill loading (`pr-review-response` for `/thermos`), repeated Thermo subagent runs, session restarts, and redundant `gh` fetches. This PR adds short on-demand skills and a compact always-applied rule to route tasks and cap expensive work.

## Changes

- **`workflow-router`** — pick one path (`/thermos`, PR comments, issue → PR, docs); session reuse and fetch-once table
- **`thermo-nuclear-review`** — tiered Thermo audits (A: no subagent, B: max 1, C: max 2); P3 issue filing before SHIP; Gradle verify budget
- **`issue-to-pr`** — one-command issue selection, targeted Gradle MCP verify, OPEN PR policy
- **`agent-workflow.mdc`** (always applied) — checkout before explore, no duplicate audits on unchanged `HEAD`, JVM Test Suite Gradle convention
- Cross-links in `pr-review-response` and `copilot-review-preflight` so `/thermos` does not load the PR comment triage skill

## Test plan

- [x] Markdown/mdc only — no build required
- [ ] Confirm agents load `workflow-router` then `thermo-nuclear-review` on `/thermos PR N`
- [ ] Confirm `pr-review-response` is skipped for `/thermos` prompts

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9690-4557-7dfe-9f31-e255d3dff504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9690-4557-7dfe-9f31-e255d3dff504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

